### PR TITLE
Allow receiving text input from stdin or an entry prompt

### DIFF
--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -18,7 +18,10 @@ def parse_args():
         help="Path or repo id of the model",
     )
     parser.add_argument(
-        "--text", type=str, default="The sky above the port", help="Text to generate"
+        "--text",
+        type=str,
+        default=None,
+        help="Text to generate (leave blank to input via stdin)",
     )
     parser.add_argument("--voice", type=str, default="af_heart", help="Voice name")
     parser.add_argument("--speed", type=float, default=1.0, help="Speed of the audio")
@@ -30,7 +33,16 @@ def parse_args():
     parser.add_argument(
         "--join_audio", action="store_true", help="Join all audio files into one"
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if args.text is None:
+        if not sys.stdin.isatty():
+            args.text = sys.stdin.read().strip()
+        else:
+            print("Please enter the text to generate:")
+            args.text = input("> ").strip()
+
+    return args
 
 
 def main():


### PR DESCRIPTION
This allows chaining commands like:

```
mlx_lm.generate --model mlx-community/Llama-3.2-1B-Instruct-4bit --verbose false \
 --temp 0 --max-tokens 512 --prompt "Write a concise paragraph on short time fourier transforms." \
| python -m mlx_audio.tts.generate --play
```

which enables a simple workflow for voice-based LLM output.