### PR TITLE
Fix: Add missing librosa dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sounddevice>=0.5.1
 soundfile>=0.13.1
 fastapi>=0.95.0
 uvicorn>=0.22.0
+librosa>=0.10.2.post1


### PR DESCRIPTION
I tried following the instructions in README.md but ran into an issue while executing the hello world sample. It seemed to indicate librosa module wasn't found, so this adds it to requirements.txt.


# Details

I ran

```
bash
# Install the package
pip install mlx-audio

# For web interface and API dependencies
pip install -r requirements.txt
```
Then

```bash
mlx_audio.tts.generate --text "Hello, world"
```

However I got the following error


```
config.json: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.35k/2.35k [00:00<00:00, 31.0MB/s]
kokoro-v1_0.safetensors: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 327M/327M [00:08<00:00, 37.2MB/s]
Fetching 2 files: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:08<00:00,  4.45s/it]
ERROR:root:Model type kokoro not supported.
Error loading model: Model type kokoro not supported.
Traceback (most recent call last):
  File "/Users/mdigiovanni/dev/ai/mlx-audio/.venv/lib/python3.11/site-packages/mlx_audio/tts/utils.py", line 30, in get_model_and_args
    arch = importlib.import_module(f"mlx_audio.tts.models.{model_type}")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/mdigiovanni/dev/ai/mlx-audio/.venv/lib/python3.11/site-packages/mlx_audio/tts/models/kokoro/__init__.py", line 1, in <module>
    from .kokoro import Model
  File "/Users/mdigiovanni/dev/ai/mlx-audio/.venv/lib/python3.11/site-packages/mlx_audio/tts/models/kokoro/kokoro.py", line 15, in <module>
    from .istftnet import Decoder
  File "/Users/mdigiovanni/dev/ai/mlx-audio/.venv/lib/python3.11/site-packages/mlx_audio/tts/models/kokoro/istftnet.py", line 4, in <module>
    import librosa
ModuleNotFoundError: No module named 'librosa'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mdigiovanni/dev/ai/mlx-audio/.venv/lib/python3.11/site-packages/mlx_audio/tts/generate.py", line 39, in main
    model = load_model(model_path=args.model)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdigiovanni/dev/ai/mlx-audio/.venv/lib/python3.11/site-packages/mlx_audio/tts/utils.py", line 140, in load_model
    model_class, model_type = get_model_and_args(model_type=model_type)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdigiovanni/dev/ai/mlx-audio/.venv/lib/python3.11/site-packages/mlx_audio/tts/utils.py", line 34, in get_model_and_args
    raise ValueError(msg)
ValueError: Model type kokoro not supported.
```

Seemed to indicate that the librosa module was not installed. So I ran 
```
pip install librosa
```

Then checked pip freeze for the version and added it to requirements.txt.
