### PR TITLE
Eval intermediate segment results to avoid OOM errors

### DIFF
--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -75,7 +75,7 @@ def main():
         audio_list = []
         for i, result in enumerate(results):
             mx.eval(result.audio)
-        
+
             if args.play:
                 player.queue_audio(result.audio)
             if args.join_audio:

--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -74,6 +74,8 @@ def main():
 
         audio_list = []
         for i, result in enumerate(results):
+            mx.eval(result.audio)
+        
             if args.play:
                 player.queue_audio(result.audio)
             if args.join_audio:


### PR DESCRIPTION
This allows resources to free up between iteration steps, which otherwise continue to accumulate due to lazy evaluation.

Fixes https://github.com/Blaizzy/mlx-audio/issues/31