### PR TITLE
Fix Kokoro audio generation

### DIFF
--- a/mlx_audio/tts/models/kokoro/__init__.py
+++ b/mlx_audio/tts/models/kokoro/__init__.py
@@ -1,4 +1,4 @@
-from .kokoro import Model
+from .kokoro import Model, ModelConfig
 from .pipeline import KokoroPipeline
 
-__all__ = ["KokoroPipeline", "Model"]
+__all__ = ["KokoroPipeline", "Model", "ModelConfig"]

--- a/mlx_audio/tts/models/kokoro/kokoro.py
+++ b/mlx_audio/tts/models/kokoro/kokoro.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import time
 from dataclasses import dataclass

--- a/mlx_audio/tts/models/kokoro/kokoro.py
+++ b/mlx_audio/tts/models/kokoro/kokoro.py
@@ -10,12 +10,7 @@ from loguru import logger
 
 from ..base import BaseModelArgs, GenerationResult, check_array_shape
 from .istftnet import Decoder
-from .modules import (
-    AlbertModelArgs,
-    CustomAlbert,
-    ProsodyPredictor,
-    TextEncoder,
-)
+from .modules import AlbertModelArgs, CustomAlbert, ProsodyPredictor, TextEncoder
 from .pipeline import KokoroPipeline
 
 # Force reset logger configuration at the top of your file
@@ -47,6 +42,7 @@ def sanitize_lstm_weights(key: str, state_dict: mx.array) -> dict:
 
     return {key: state_dict}
 
+
 @dataclass
 class ModelConfig(BaseModelArgs):
     istftnet: dict
@@ -63,6 +59,7 @@ class ModelConfig(BaseModelArgs):
     text_encoder_kernel_size: int
     plbert: dict
     vocab: Dict[str, int]
+
 
 class Model(nn.Module):
     """
@@ -90,9 +87,7 @@ class Model(nn.Module):
             AlbertModelArgs(vocab_size=config.n_token, **config.plbert)
         )
 
-        self.bert_encoder = nn.Linear(
-            self.bert.config.hidden_size, config.hidden_dim
-        )
+        self.bert_encoder = nn.Linear(self.bert.config.hidden_size, config.hidden_dim)
         self.context_length = self.bert.config.max_position_embeddings
         self.predictor = ProsodyPredictor(
             style_dim=config.style_dim,

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -86,7 +86,7 @@ class TestKokoroModel(unittest.TestCase):
     def test_init(self, mock_load_weights, mock_mx_load, mock_open, mock_json_load):
         """Test KokoroModel initialization."""
         # Import inside the test method
-        from mlx_audio.tts.models.kokoro.kokoro import Model
+        from mlx_audio.tts.models.kokoro.kokoro import Model, ModelConfig
 
         # Mock the config loading
         config = {
@@ -129,7 +129,7 @@ class TestKokoroModel(unittest.TestCase):
         mock_load_weights.return_value = None
 
         # Initialize the model with the config parameter
-        model = Model(config)
+        model = Model(ModelConfig.from_dict(config))
 
         # Check that the model was initialized correctly
         self.assertIsInstance(model, nn.Module)


### PR DESCRIPTION
The original Kokoro didn't have a ModelConfig defined, which is now required with the latest changes. This allows the base generation function work again:

`python -m mlx_audio.tts.generate --text "Hello world." --play`