### PR TITLE
Align Orpheus sampling parameters with the reference implementation

### DIFF
--- a/mlx_audio/tts/models/llama/llama.py
+++ b/mlx_audio/tts/models/llama/llama.py
@@ -289,8 +289,8 @@ class Model(nn.Module):
         self,
         text,
         voice: str,
-        temperature: float = 1.0,
-        top_p: float = 0.95,
+        temperature: float = 0.6,
+        top_p: float = 0.8,
         split_pattern: str = "\n",
         max_tokens: int = 1200,
         verbose: bool = False,
@@ -320,10 +320,10 @@ class Model(nn.Module):
 
         input_ids = mx.concatenate(all_modified_input_ids, axis=0)
 
-        sampler = make_sampler(temperature, top_p, top_k=kwargs.get("top_k", 1))
+        sampler = make_sampler(temperature, top_p, top_k=kwargs.get("top_k", -1))
         logits_processors = make_logits_processors(
             kwargs.get("logit_bias", None),
-            kwargs.get("repetition_penalty", 1.1),
+            kwargs.get("repetition_penalty", 1.3),
             kwargs.get("repetition_context_size", 20),
         )
 


### PR DESCRIPTION
I noticed the sampling parameters were a little bit odd -- top-k is set to 1 which is effectively greedy/argmax sampling, and the reference implementation uses different values for top-p, temperature, and the repetition penalty: https://github.com/canopyai/Orpheus-Speech-PyPi/blob/a57e9d6a59d955291d32b0202c6f256cab238ef6/orpheus_tts/engine_class.py#L162

This fixes all the examples in https://github.com/Blaizzy/mlx-audio/issues/60 that previously generated silence when using the bf16 model on my machine.