### PR TITLE
Add support for DAC speech finetuned models

### DIFF
--- a/mlx_audio/codec/models/descript/dac.py
+++ b/mlx_audio/codec/models/descript/dac.py
@@ -140,6 +140,7 @@ class DAC(nn.Module, CodecMixin):
         codebook_size: int = 1024,
         codebook_dim: Union[int, list] = 8,
         sample_rate: int = 44100,
+        **kwargs,
     ):
         super().__init__()
 
@@ -248,18 +249,10 @@ class DAC(nn.Module, CodecMixin):
 
     @classmethod
     def from_pretrained(
-        cls, model: Literal["16khz", "24khz", "44khz"] = "24khz"
+        cls,
+        repo_id: str,
     ) -> "DAC":
-        if model == "16khz":
-            model_name = "mlx-community/descript-audio-codec-16khz"
-        elif model == "24khz":
-            model_name = "mlx-community/descript-audio-codec-24khz"
-        elif model == "44khz":
-            model_name = "mlx-community/descript-audio-codec-44khz"
-        else:
-            raise ValueError(f"Model is not supported: {model}")
-
-        path = fetch_from_hub(model_name)
+        path = fetch_from_hub(repo_id)
         if path is None:
             raise ValueError(f"Could not find model {path}")
 


### PR DESCRIPTION
Minor tweaks to allow loading the fine-tuned variants of DAC from [IBM Research](https://huggingface.co/ibm-research/DAC.speech.v1.0), which are used by the latest version of [OuteTTS](https://github.com/edwko/OuteTTS/blob/380664174e09d92cb798e5bbf0873119041fb615/outetts/dac/interface.py#L68).

I also uploaded MLX-converted models for the [3kbps](https://huggingface.co/mlx-community/dac-speech-24khz-3kbps) and [1.5kbps](https://huggingface.co/mlx-community/dac-speech-24khz-1.5kbps) versions to the HF hub.