### PR TITLE
Add voice matching support for Dia

### DIFF
--- a/mlx_audio/codec/tests/test_descript.py
+++ b/mlx_audio/codec/tests/test_descript.py
@@ -38,7 +38,7 @@ class TestDescript(unittest.TestCase):
         self.assertEqual(latents.shape, (1, 96, 250))
 
         y = model.decode(z).squeeze(-1)
-        self.assertEqual(y.shape, (1, 79_992))
+        self.assertEqual(y.shape, (1, 80_043))
 
     def test_descript_24khz(self):
         audio = mx.zeros((1, 1, 120_000))
@@ -70,7 +70,7 @@ class TestDescript(unittest.TestCase):
         self.assertEqual(latents.shape, (1, 256, 375))
 
         y = model.decode(z).squeeze(-1)
-        self.assertEqual(y.shape, (1, 119_992))
+        self.assertEqual(y.shape, (1, 120_043))
 
     def test_descript_44khz(self):
         audio = mx.zeros((1, 1, 220_000))
@@ -102,7 +102,7 @@ class TestDescript(unittest.TestCase):
         self.assertEqual(latents.shape, (1, 72, 430))
 
         y = model.decode(z).squeeze(-1)
-        self.assertEqual(y.shape, (1, 220_160))
+        self.assertEqual(y.shape, (1, 220_235))
 
 
 if __name__ == "__main__":

--- a/mlx_audio/codec/tests/test_snac.py
+++ b/mlx_audio/codec/tests/test_snac.py
@@ -33,7 +33,7 @@ class TestSNAC(unittest.TestCase):
         self.assertEqual(codes[2].shape, (1, 236))
 
         reconstructed = model.decode(codes).squeeze(-1)
-        self.assertEqual(reconstructed.shape, (1, 120_832))
+        self.assertEqual(reconstructed.shape, (1, 120_907))
 
 
 if __name__ == "__main__":

--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -74,7 +74,7 @@ def generate_audio(
         if ref_audio:
             if not os.path.exists(ref_audio):
                 raise FileNotFoundError(f"Reference audio file not found: {ref_audio}")
-            ref_audio = load_audio(ref_audio)
+            ref_audio = load_audio(ref_audio, sample_rate=sample_rate)
             if not ref_text:
                 print("Ref_text not found. Transcribing ref_audio...")
                 # mlx_whisper seems takes long time to import. Import only necessary.


### PR DESCRIPTION
This allows for consistent voices for each generation. Using the example prompt from their repo:

`python -m mlx_audio.tts.generate --model mlx-community/Dia-1.6B --text "[S1] Testing, 1, 2 3. Is this thing on? [S2] Yeah, it's working. (laughs) [S1] OK, phew. (laughs)" --ref_audio example_prompt.mp3 --ref_text "[S1] Dia is an open weights text to dialogue model. [S2] You get full control over scripts and voices. " --sample_rate 44100 --play`