### PR TITLE
Handle strict argument in load_weights for better model compatibility

### DIFF
--- a/mlx_audio/tts/models/sesame/model.py
+++ b/mlx_audio/tts/models/sesame/model.py
@@ -344,8 +344,8 @@ class Model(nn.Module):
 
         return sanitized_weights
 
-    def load_weights(self, weights):
-        self.model.load_weights(weights)
+    def load_weights(self, weights, strict: bool = True):
+        self.model.load_weights(weights, strict=strict)
 
     def generate(
         self,

--- a/mlx_audio/tts/utils.py
+++ b/mlx_audio/tts/utils.py
@@ -1,5 +1,6 @@
 import glob
 import importlib
+import inspect
 import logging
 import shutil
 from pathlib import Path
@@ -191,7 +192,13 @@ python -m mlx_vlm.convert --hf-path <local_dir> --mlx-path <mlx_dir>
             class_predicate=get_class_predicate,
         )
 
-    model.load_weights(list(weights.items()), strict=strict)
+    load_weights_sig = inspect.signature(model.load_weights)
+
+    kwargs = {"weights": list(weights.items())}
+    if "strict" in load_weights_sig.parameters:
+        kwargs["strict"] = strict
+
+    model.load_weights(**kwargs)
 
     if not lazy:
         mx.eval(model.parameters())


### PR DESCRIPTION
Some models within the MLX ecosystem, especially custom or older forks define `load_weights(weights)` without a `strict` keyword argument. With recent updates, `utils.load_model()` passes `strict=True` unconditionally which causes runtime errors when loading such models.

This PR inspects the `load_weights` signature at runtime using pythons inspect module and passes the strict parameter only if it’s explicitly supported.

This allows:
- full compatibility with legacy/custom models,
- smooth usage of updated utils across projects,
- forward compatibility with future models that may redefine the method.

No functionality is altered for models that already support strict - this simply makes the system more robust when loading models from various sources.