### PR TITLE
Improve Parakeet token merging

### DIFF
--- a/mlx_audio/stt/models/parakeet/alignment.py
+++ b/mlx_audio/stt/models/parakeet/alignment.py
@@ -74,8 +74,92 @@ def sentences_to_result(sentences: list[AlignedSentence]) -> AlignedResult:
     return AlignedResult("".join(sentence.text for sentence in sentences), sentences)
 
 
+def merge_longest_contiguous(
+    a: list[AlignedToken],
+    b: list[AlignedToken],
+    *,
+    overlap_duration: float,
+):
+    if not a or not b:
+        return b if not a else a
+
+    a_end_time = a[-1].end
+    b_start_time = b[0].start
+
+    if a_end_time <= b_start_time:
+        return a + b
+
+    overlap_a = [token for token in a if token.end > b_start_time - overlap_duration]
+    overlap_b = [token for token in b if token.start < a_end_time + overlap_duration]
+
+    enough_pairs = len(overlap_a) // 2
+
+    if len(overlap_a) < 2 or len(overlap_b) < 2:
+        cutoff_time = (a_end_time + b_start_time) / 2
+        return [t for t in a if t.end <= cutoff_time] + [
+            t for t in b if t.start >= cutoff_time
+        ]
+
+    best_contiguous = []
+    for i in range(len(overlap_a)):
+        for j in range(len(overlap_b)):
+            if (
+                overlap_a[i].id == overlap_b[j].id
+                and abs(overlap_a[i].start - overlap_b[j].start) < overlap_duration / 2
+            ):
+                current = []
+                k, l_ = i, j
+                while (
+                    k < len(overlap_a)
+                    and l_ < len(overlap_b)
+                    and overlap_a[k].id == overlap_b[l_].id
+                    and abs(overlap_a[k].start - overlap_b[l_].start)
+                    < overlap_duration / 2
+                ):
+                    current.append((k, l_))
+                    k += 1
+                    l_ += 1
+
+                if len(current) > len(best_contiguous):
+                    best_contiguous = current
+
+    if len(best_contiguous) >= enough_pairs:
+        a_start_idx = len(a) - len(overlap_a)
+        lcs_indices_a = [a_start_idx + pair[0] for pair in best_contiguous]
+        lcs_indices_b = [pair[1] for pair in best_contiguous]
+
+        result = []
+        result.extend(a[: lcs_indices_a[0]])
+
+        for i in range(len(best_contiguous)):
+            idx_a = lcs_indices_a[i]
+            idx_b = lcs_indices_b[i]
+
+            result.append(a[idx_a])
+
+            if i < len(best_contiguous) - 1:
+                next_idx_a = lcs_indices_a[i + 1]
+                next_idx_b = lcs_indices_b[i + 1]
+
+                gap_tokens_a = a[idx_a + 1 : next_idx_a]
+                gap_tokens_b = b[idx_b + 1 : next_idx_b]
+
+                if len(gap_tokens_b) > len(gap_tokens_a):
+                    result.extend(gap_tokens_b)
+                else:
+                    result.extend(gap_tokens_a)
+
+        result.extend(b[lcs_indices_b[-1] + 1 :])
+        return result
+    else:
+        raise RuntimeError(f"No pairs exceeding {enough_pairs}")
+
+
 def merge_longest_common_subsequence(
-    a: list[AlignedToken], b: list[AlignedToken], *, overlap_duration: float
+    a: list[AlignedToken],
+    b: list[AlignedToken],
+    *,
+    overlap_duration: float,
 ):
     if not a or not b:
         return b if not a else a
@@ -143,12 +227,21 @@ def merge_longest_common_subsequence(
 
     for i in range(len(lcs_pairs)):
         idx_a = lcs_indices_a[i]
+        idx_b = lcs_indices_b[i]
 
-        result.append(a[idx_a])  # a is preferred since it contains previous context
+        result.append(a[idx_a])
 
         if i < len(lcs_pairs) - 1:
             next_idx_a = lcs_indices_a[i + 1]
-            result.extend(a[idx_a + 1 : next_idx_a])
+            next_idx_b = lcs_indices_b[i + 1]
+
+            gap_tokens_a = a[idx_a + 1 : next_idx_a]
+            gap_tokens_b = b[idx_b + 1 : next_idx_b]
+
+            if len(gap_tokens_b) > len(gap_tokens_a):
+                result.extend(gap_tokens_b)
+            else:
+                result.extend(gap_tokens_a)
 
     result.extend(b[lcs_indices_b[-1] + 1 :])
 

--- a/mlx_audio/stt/models/parakeet/parakeet.py
+++ b/mlx_audio/stt/models/parakeet/parakeet.py
@@ -14,6 +14,7 @@ from mlx_audio.stt.models.parakeet.alignment import (
     AlignedResult,
     AlignedToken,
     merge_longest_common_subsequence,
+    merge_longest_contiguous,
     sentences_to_result,
     tokens_to_sentences,
 )
@@ -183,9 +184,14 @@ class Model(nn.Module):
                 chunk_tokens.extend(sentence.tokens)
 
             if all_tokens:
-                all_tokens = merge_longest_common_subsequence(
-                    all_tokens, chunk_tokens, overlap_duration=overlap_duration
-                )
+                try:
+                    all_tokens = merge_longest_contiguous(
+                        all_tokens, chunk_tokens, overlap_duration=overlap_duration
+                    )
+                except RuntimeError:
+                    all_tokens = merge_longest_common_subsequence(
+                        all_tokens, chunk_tokens, overlap_duration=overlap_duration
+                    )
             else:
                 all_tokens = chunk_tokens
 
@@ -254,7 +260,6 @@ class Model(nn.Module):
 
 
 class ParakeetTDT(Model):
-
     def __init__(self, args: ParakeetTDTArgs):
         super().__init__(args.preprocessor)
 
@@ -362,7 +367,6 @@ class ParakeetTDT(Model):
 
 
 class ParakeetRNNT(Model):
-
     def __init__(self, args: ParakeetRNNTArgs):
         super().__init__(args.preprocessor)
 
@@ -460,7 +464,6 @@ class ParakeetRNNT(Model):
 
 
 class ParakeetCTC(Model):
-
     def __init__(self, args: ParakeetCTCArgs):
         super().__init__(args.preprocessor)
 


### PR DESCRIPTION
### Issue
The current LCS merging only favors `a` (the first input of merging), causing it to miss some sentences during merging.
### Changes
- Find continuous overlapping tokens first. If the length is smaller than len(overlap_a) / 2, then use existing LCS merging.
- In LCS merging, instead of simply favoring a, favor the input which has longer tokens between gaps.