### PR TITLE
Fix Spark mel spec

### DIFF
--- a/mlx_audio/codec/models/vocos/mel.py
+++ b/mlx_audio/codec/models/vocos/mel.py
@@ -90,7 +90,7 @@ def hanning(size):
     )
 
 
-def stft(x, window, nperseg=256, noverlap=None, nfft=None, pad_mode="constant"):
+def stft(x, window, nperseg=256, noverlap=None, nfft=None, pad_mode="reflect"):
     if nfft is None:
         nfft = nperseg
     if noverlap is None:
@@ -107,9 +107,11 @@ def stft(x, window, nperseg=256, noverlap=None, nfft=None, pad_mode="constant"):
             raise ValueError(f"Invalid pad_mode {pad_mode}")
 
     if window.shape[0] < nfft:
-        window = mx.pad(window, (0, nfft - window.shape[0]))
+        pad_left = (nfft - window.shape[0]) // 2
+        pad_right = nfft - window.shape[0] - pad_left
+        window = mx.pad(window, (pad_left, pad_right))
 
-    padding = nperseg // 2
+    padding = nfft // 2
     x = _pad(x, padding, pad_mode)
 
     strides = [noverlap, 1]

--- a/mlx_audio/tts/models/spark/bicodec.py
+++ b/mlx_audio/tts/models/spark/bicodec.py
@@ -34,8 +34,9 @@ def log_mel_spectrogram(
         audio = mx.array(audio)
     if padding > 0:
         audio = mx.pad(audio, (0, padding))
-    freqs = stft(audio, hanning(win_length), nperseg=n_fft, noverlap=hop_length)
-    magnitudes = freqs[:-1, :].abs()
+    window = hanning(win_length + 1)[:-1]
+    freqs = stft(audio, window, nperseg=win_length, noverlap=hop_length, nfft=n_fft)
+    magnitudes = freqs.abs()
     filters = mel_filters(
         sample_rate=sample_rate,
         n_fft=n_fft,


### PR DESCRIPTION
This fixes a bug with the number of FFT filters, aligns the STFT window padding and padding mode with torch, and uses the exact window function that torch uses.