### PR TITLE
More fixes for the Spark BiCodec module

### DIFF
--- a/mlx_audio/tts/models/spark/audio_tokenizer.py
+++ b/mlx_audio/tts/models/spark/audio_tokenizer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, Union
 
 import mlx.core as mx
 import numpy as np
@@ -52,13 +52,20 @@ class BiCodecTokenizer:
 
         return wav[:ref_segment_length]
 
-    def process_audio(self, wav_path: Path) -> Tuple[np.ndarray, mx.array]:
+    def process_audio(
+        self, wav_path: Union[Path, mx.array]
+    ) -> Tuple[np.ndarray, mx.array]:
         """load auido and get reference audio from wav path"""
-        wav = load_audio(
-            wav_path,
-            sampling_rate=self.config["sample_rate"],
-            volume_normalize=self.config["volume_normalize"],
-        )
+        if isinstance(wav_path, Path) or isinstance(wav_path, str):
+            wav = load_audio(
+                wav_path,
+                sampling_rate=self.config["sample_rate"],
+                volume_normalize=self.config["volume_normalize"],
+            )
+        elif isinstance(wav_path, mx.array):
+            wav = wav_path
+        else:
+            raise ValueError(f"Invalid input type: {type(wav_path)}")
 
         wav_ref = self.get_ref_clip(wav)
 

--- a/mlx_audio/tts/models/spark/bicodec.py
+++ b/mlx_audio/tts/models/spark/bicodec.py
@@ -145,9 +145,8 @@ class BiCodec(nn.Module):
         Returns:
             dict: A dictionary containing the reconstruction, features, and other metrics.
         """
-        feat = mx.array(batch["feat"])
-        # Use MLX mel transformer directly
-        ref_wav = mx.array(batch["ref_wav"])
+        feat = batch["feat"]
+        ref_wav = batch["ref_wav"]
         mel = self.get_mel_spectrogram(ref_wav)
         z = self.encoder(feat.transpose(0, 2, 1))
         vq_outputs = self.quantizer(z)
@@ -191,7 +190,7 @@ class BiCodec(nn.Module):
         Returns:
             tuple: Semantic tokens and global tokens.
         """
-        feat = mx.array(batch["feat"])
+        feat = batch["feat"]
         ref_wav = mx.array(batch["ref_wav"])
         mel = self.get_mel_spectrogram(ref_wav)
         z = self.encoder(feat.transpose(0, 2, 1))
@@ -211,8 +210,6 @@ class BiCodec(nn.Module):
         Returns:
             tensor: Reconstructed waveform.
         """
-        semantic_tokens = mx.array(semantic_tokens)
-        global_tokens = mx.array(global_tokens)
 
         z_q = self.quantizer.detokenize(semantic_tokens.transpose(0, 1)).transpose(
             0, 2, 1

--- a/mlx_audio/tts/models/spark/modules/residual.py
+++ b/mlx_audio/tts/models/spark/modules/residual.py
@@ -131,7 +131,7 @@ class FactorizedVectorQuantize(nn.Module):
         # Check if indices are empty
         if indices.shape[0] == 0 or indices.shape[1] == 0:
             # Return an appropriate empty or placeholder tensor
-            return mx.zeros((1, self.input_dim, 1))  # Adjust dimensions as needed
+            return mx.zeros((1, self.input_dim, 1))
 
         z_q = self.decode_code(indices).transpose(0, 2, 1)
         z_q = self.out_project(z_q)

--- a/mlx_audio/tts/models/spark/modules/residual.py
+++ b/mlx_audio/tts/models/spark/modules/residual.py
@@ -2,8 +2,8 @@ from typing import Any, Dict, List
 
 import mlx.core as mx
 import mlx.nn as nn
-
 from einops.array_api import rearrange
+
 from mlx_audio.codec.models.descript.nn.layers import WNConv1d
 
 
@@ -148,7 +148,7 @@ class FactorizedVectorQuantize(nn.Module):
         """Normalize input tensor along dimension 1."""
         norm = mx.sqrt(mx.sum(mx.power(x, 2), axis=1, keepdims=True))
         return x / mx.maximum(norm, 1e-12)
-    
+
     def decode_latents(self, latents):
         encodings = rearrange(latents, "b d t -> (b t) d")
         codebook = self.codebook.weight

--- a/mlx_audio/tts/models/spark/modules/residual.py
+++ b/mlx_audio/tts/models/spark/modules/residual.py
@@ -128,9 +128,12 @@ class FactorizedVectorQuantize(nn.Module):
 
     def detokenize(self, indices):
         """detokenize the input indices"""
+        # Check if indices are empty
+        if indices.shape[0] == 0 or indices.shape[1] == 0:
+            # Return an appropriate empty or placeholder tensor
+            return mx.zeros((1, self.input_dim, 1))  # Adjust dimensions as needed
 
         z_q = self.decode_code(indices).transpose(0, 2, 1)
-
         z_q = self.out_project(z_q)
         return z_q
 

--- a/mlx_audio/tts/models/spark/spark.py
+++ b/mlx_audio/tts/models/spark/spark.py
@@ -10,7 +10,6 @@ from mlx_lm.generate import stream_generate
 from mlx_lm.models.qwen2 import Model as Qwen2Model
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
 from mlx_lm.tokenizer_utils import load_tokenizer
-from mlx_lm.utils import load
 from tqdm import tqdm
 
 from mlx_audio.tts.models.base import BaseModelArgs, GenerationResult

--- a/mlx_audio/tts/models/spark/spark.py
+++ b/mlx_audio/tts/models/spark/spark.py
@@ -234,6 +234,9 @@ class Model(nn.Module):
         speed_factor = SPEED_MAP[speed]
         pitch_factor = PITCH_MAP[pitch]
 
+        if ref_audio is not None:  # voice cloning
+            gender = None
+
         text_splits = text.split(split_pattern)
 
         for text_split in text_splits:

--- a/mlx_audio/tts/models/spark/spark.py
+++ b/mlx_audio/tts/models/spark/spark.py
@@ -327,6 +327,9 @@ class Model(nn.Module):
                 pred_semantic_ids.astype(mx.int32),
             )
 
+            # Clear cache
+            mx.clear_cache()
+
             audio_samples = len(audio)
             audio_duration_seconds = audio_samples / self.config.sample_rate
 

--- a/mlx_audio/tts/models/spark/spark.py
+++ b/mlx_audio/tts/models/spark/spark.py
@@ -82,6 +82,9 @@ class Model(nn.Module):
     def parameters(self):
         return self.model.parameters()
 
+    def model_type(self):
+        return "spark"
+
     def sanitize(self, weights):
         return self.model.sanitize(weights)
 


### PR DESCRIPTION
There were a few issues across the various modules that didn't allow tokenization and reconstruction to work:

1) They use a mel spec directly, not log scaled.
2) Fixes in the ECAPA_TDNN encoder, Perceiver resamples, and factorized vector quantizer for residuals / norms.

With this I can get matching semantic & global tokenization and detokenization with the torch version.