### PR TITLE
Add auto sampling rate

### DIFF
--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -211,7 +211,6 @@ def generate_audio(
     stt_model: str = "mlx-community/whisper-large-v3-turbo",
     file_prefix: str = "audio",
     audio_format: str = "wav",
-    sample_rate: int = 24000,
     join_audio: bool = False,
     play: bool = False,
     verbose: bool = True,
@@ -235,7 +234,6 @@ def generate_audio(
     - stt_model (str): A mlx whisper model to use to transcribe.
     - file_prefix (str): The output file path without extension.
     - audio_format (str): Output audio format (e.g., "wav", "flac").
-    - sample_rate (int): Sampling rate in Hz.
     - join_audio (bool): Whether to join multiple audio files into one.
     - play (bool): Whether to play the generated audio.
     - verbose (bool): Whether to print status messages.
@@ -258,7 +256,7 @@ def generate_audio(
                 normalize = True
 
             ref_audio = load_audio(
-                ref_audio, sample_rate=sample_rate, volume_normalize=normalize
+                ref_audio, sample_rate=model.sample_rate, volume_normalize=normalize
             )
             if not ref_text:
                 print("Ref_text not found. Transcribing ref_audio...")
@@ -269,7 +267,7 @@ def generate_audio(
                 print("Ref_text", ref_text)
 
         # Load AudioPlayer
-        player = AudioPlayer(sample_rate=sample_rate) if play else None
+        player = AudioPlayer(sample_rate=model.sample_rate) if play else None
 
         print(
             f"\n\033[94mModel:\033[0m {model_path}\n"
@@ -378,9 +376,6 @@ def parse_args():
     parser.add_argument("--play", action="store_true", help="Play the output audio")
     parser.add_argument(
         "--audio_format", type=str, default="wav", help="Output audio format"
-    )
-    parser.add_argument(
-        "--sample_rate", type=int, default=24000, help="Audio sample rate in Hz"
     )
     parser.add_argument(
         "--ref_audio", type=str, default=None, help="Path to reference audio"

--- a/mlx_audio/tts/models/bark/bark.py
+++ b/mlx_audio/tts/models/bark/bark.py
@@ -115,6 +115,7 @@ class ModelConfig(BaseModelArgs):
     model_type: str = "bark"
     initializer_range: float = 0.02
     codec_path: str = "mlx-community/encodec-24khz-float32"
+    sample_rate: int = 24000
 
 
 class LayerNorm(nn.Module):
@@ -450,6 +451,10 @@ class Model(nn.Module):
 
         return sanitized_weights
 
+    @property
+    def sample_rate(self):
+        return self.config.sample_rate
+
     def generate(self, text: str, voice: str = None, **kwargs):
         pipeline = Pipeline(
             model=self,
@@ -473,7 +478,7 @@ class Model(nn.Module):
             token_count = len(tokens) if tokens is not None else 0
 
             # Calculate audio duration in seconds
-            sample_rate = 24000  # Assuming 24kHz sample rate, adjust if different
+            sample_rate = self.config.sample_rate
             audio_duration_seconds = samples / sample_rate * audio.shape[1]
 
             # Calculate milliseconds per sample

--- a/mlx_audio/tts/models/dia/config.py
+++ b/mlx_audio/tts/models/dia/config.py
@@ -143,6 +143,7 @@ class ModelConfig:
     weight_dtype: str = "float32"
     rope_min_timescale: int = 1
     rope_max_timescale: int = 10_000
+    sample_rate: int = 44100
 
 
 @dataclass(frozen=True)
@@ -204,6 +205,7 @@ class DiaConfig:
                 "weight_dtype": self.model.weight_dtype,
                 "rope_min_timescale": self.model.rope_min_timescale,
                 "rope_max_timescale": self.model.rope_max_timescale,
+                "sample_rate": self.model.sample_rate,
             },
             "training": vars(self.training),
             "data": vars(self.data),

--- a/mlx_audio/tts/models/dia/dia.py
+++ b/mlx_audio/tts/models/dia/dia.py
@@ -114,6 +114,10 @@ class Model(nn.Module):
     def eval(self):
         self.model.eval()
 
+    @property
+    def sample_rate(self):
+        return self.config.model.sample_rate
+
     def _create_attn_mask(
         self,
         q_padding_mask_1d: mx.array,
@@ -261,7 +265,7 @@ class Model(nn.Module):
             samples = audio.shape[0] if audio is not None else 0
             assert samples > 0, "No audio generated"
 
-            sample_rate = 44100
+            sample_rate = self.config.model.sample_rate
             audio_duration_seconds = samples / sample_rate
 
             elapsed_time = time_end - time_start

--- a/mlx_audio/tts/models/kokoro/kokoro.py
+++ b/mlx_audio/tts/models/kokoro/kokoro.py
@@ -60,6 +60,7 @@ class ModelConfig(BaseModelArgs):
     text_encoder_kernel_size: int
     plbert: dict
     vocab: Dict[str, int]
+    sample_rate: int = 24000
 
 
 class Model(nn.Module):
@@ -249,6 +250,10 @@ class Model(nn.Module):
                 sanitized_weights[key] = self.decoder.sanitize(key, state_dict)
         return sanitized_weights
 
+    @property
+    def sample_rate(self):
+        return self.config.sample_rate
+
     def generate(
         self,
         text: str,
@@ -283,9 +288,8 @@ class Model(nn.Module):
             token_count = len(phonemes) if phonemes is not None else 0
 
             # Calculate audio duration in seconds
-            sample_rate = kwargs.get(
-                "sample_rate", 24000
-            )  # Assuming 24kHz sample rate, adjust if different
+            sample_rate = self.config.sample_rate
+
             audio_duration_seconds = samples / sample_rate * audio.shape[1]
 
             # Calculate real-time factor (RTF)

--- a/mlx_audio/tts/models/llama/llama.py
+++ b/mlx_audio/tts/models/llama/llama.py
@@ -36,6 +36,7 @@ class ModelConfig(BaseModelArgs):
     rope_scaling: Optional[Dict[str, Union[float, str]]] = None
     tie_word_embeddings: bool = True
     tokenizer_name: str = "mlx-community/orpheus-3b-0.1-ft-bf16"
+    sample_rate: int = 24000
 
     def __post_init__(self):
         if self.num_key_value_heads is None:
@@ -228,14 +229,14 @@ class LlamaModel(nn.Module):
 
 
 class Model(nn.Module):
-    def __init__(self, args: ModelConfig, **kwargs):
+    def __init__(self, config: ModelConfig, **kwargs):
         super().__init__()
-        self.args = args
-        self.model_type = args.model_type
-        self.tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name)
-        self.model = LlamaModel(args)
-        if not args.tie_word_embeddings:
-            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        self.args = config
+        self.model_type = config.model_type
+        self.tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_name)
+        self.model = LlamaModel(config)
+        if not config.tie_word_embeddings:
+            self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
 
     def __call__(
         self,
@@ -244,7 +245,7 @@ class Model(nn.Module):
         cache=None,
     ):
         out = self.model(inputs, mask, cache)
-        if self.args.tie_word_embeddings:
+        if self.config.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(out)
         else:
             out = self.lm_head(out)
@@ -255,13 +256,17 @@ class Model(nn.Module):
         weights = {
             k: v for k, v in weights.items() if "self_attn.rotary_emb.inv_freq" not in k
         }
-        if self.args.tie_word_embeddings:
+        if self.config.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
         return weights
 
     @property
     def layers(self):
         return self.model.layers
+
+    @property
+    def sample_rate(self):
+        return self.config.sample_rate
 
     def parse_output(self, input_ids):
         token_to_find = 128257
@@ -455,7 +460,7 @@ class Model(nn.Module):
                 token_count = input_ids.shape[1] if input_ids is not None else 0
 
                 # Calculate audio duration in seconds
-                sample_rate = 24000  # Assuming 24kHz sample rate, adjust if different
+                sample_rate = self.config.sample_rate
                 audio_duration_seconds = samples / sample_rate
 
                 # Calculate real-time factor (RTF)

--- a/mlx_audio/tts/models/outetts/outetts.py
+++ b/mlx_audio/tts/models/outetts/outetts.py
@@ -22,12 +22,20 @@ class ModelConfig(LlamaModelConfig):
 
 
 class Model(LlamaModel):
+    def __init__(self, config: ModelConfig, **kwargs):
+        super().__init__(config, **kwargs)
+        self.config = config
+
     def sanitize(self, weights):
         return weights
 
     @property
     def layers(self):
         return self.model.layers
+
+    @property
+    def sample_rate(self):
+        return self.config.sample_rate
 
     def generate(
         self,
@@ -109,7 +117,11 @@ class Model(LlamaModel):
 
             token_count = input_ids.shape[1] if input_ids is not None else 0
 
-            sample_rate = 24000
+            sample_rate = (
+                self.config.sample_rate
+                if kwargs.get("sample_rate") is None
+                else kwargs.get("sample_rate")
+            )
             audio_duration_seconds = samples / sample_rate
 
             elapsed_time = time_end - time_start

--- a/mlx_audio/tts/models/sesame/sesame.py
+++ b/mlx_audio/tts/models/sesame/sesame.py
@@ -321,6 +321,10 @@ class Model(nn.Module):
         """Return the backbone layers of the model."""
         return self.model.backbone.layers
 
+    @property
+    def sample_rate(self):
+        return self._sample_rate
+
     def _tokenize_text_segment(
         self, text: str, speaker: int
     ) -> Tuple[mx.array, mx.array]:

--- a/mlx_audio/tts/models/spark/spark.py
+++ b/mlx_audio/tts/models/spark/spark.py
@@ -89,6 +89,10 @@ class Model(nn.Module):
         return self.model.sanitize(weights)
 
     @property
+    def sample_rate(self):
+        return self.config.sample_rate
+
+    @property
     def layers(self):
         return self.model.layers
 


### PR DESCRIPTION
Most models now have custom sampling rate so we are deprecating the sampling-rate args for hard-coded ones provided by the creators.

You can access the sampling rate of any model by using the sample_rate property or importing the config.

```python
from mlx_audio.tts.models.llama import Model, ModelConfig
config = ModelConfig()
model = Model(config)

print(model.sample_rate)
```

Note: You can still customize this by resampling the audio afterwards.

Closes #144 