### PR TITLE
Fix join audio sample rate

### DIFF
--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -325,7 +325,11 @@ def generate_audio(
             if verbose:
                 print(f"Joining {len(audio_list)} audio files")
             audio = mx.concatenate(audio_list, axis=0)
-            sf.write(f"{file_prefix}.{audio_format}", audio, 24000)
+            sf.write(
+                f"{file_prefix}.{audio_format}",
+                audio,
+                model.sample_rate,
+            )
             if verbose:
                 print(f"✅ Audio successfully generated and saving as: {file_name}")
 


### PR DESCRIPTION
## Summary
- save joined audio files using the model's sample rate

## Testing
- `pytest -q` *(fails: command not found)*