### PR TITLE
Improvements to streaming playback

### DIFF
--- a/mlx_audio/codec/models/mimi/__init__.py
+++ b/mlx_audio/codec/models/mimi/__init__.py
@@ -1,1 +1,1 @@
-from .mimi import Mimi
+from .mimi import Mimi, MimiStreamingDecoder

--- a/mlx_audio/codec/models/mimi/mimi.py
+++ b/mlx_audio/codec/models/mimi/mimi.py
@@ -239,3 +239,48 @@ class Mimi(nn.Module):
         model_file = hf_hub_download(repo_id, filename)
         model.load_pytorch_weights(model_file, strict=True)
         return model
+
+
+class MimiStreamingDecoder:
+    """Incremental decoder wrapper for the Mimi codec.
+
+    This helper keeps the internal state of the Mimi model across calls and
+    decodes audio tokens frame by frame using ``decode_step``.
+    """
+
+    def __init__(self, mimi: "Mimi") -> None:  # noqa: F821 - Mimi defined below
+        self._mimi = mimi
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset the underlying codec state."""
+        self._mimi.decoder.reset_state()
+        self._mimi.upsample.reset_state()
+        for c in self._mimi.decoder_cache:
+            c.reset()
+
+    def decode_frames(self, tokens: mx.array) -> mx.array:
+        """Decode a sequence of audio tokens incrementally.
+
+        Parameters
+        ----------
+        tokens:
+            Array of shape ``(B, C, T)`` or ``(C, T)`` containing the audio
+            tokens to decode. ``B`` is the batch dimension, ``C`` is the number
+            of codebooks and ``T`` the number of frames.
+
+        Returns
+        -------
+        mx.array
+            The decoded waveform for the provided frames.
+        """
+
+        if tokens.ndim == 2:
+            tokens = mx.expand_dims(tokens, 0)
+
+        pcm = []
+        for t in range(tokens.shape[-1]):
+            step_tokens = tokens[:, :, t : t + 1]
+            pcm.append(self._mimi.decode_step(step_tokens))
+
+        return mx.concat(pcm, axis=-1)

--- a/mlx_audio/tts/audio_player.py
+++ b/mlx_audio/tts/audio_player.py
@@ -15,21 +15,22 @@ class AudioPlayer:
         self.drain_event = Event()
 
     def callback(self, outdata, frames, time, status):
+        outdata.fill(0) # initialize the frame with silence
+        filled = 0
+
         with self.buffer_lock:
-            if len(self.audio_buffer) > 0:
-                available = min(frames, len(self.audio_buffer[0]))
-                chunk = self.audio_buffer[0][:available].copy()
-                self.audio_buffer[0] = self.audio_buffer[0][available:]
+            while filled < frames and self.audio_buffer:
+                buf = self.audio_buffer[0]
+                to_copy = min(frames - filled, len(buf))
+                outdata[filled:filled + to_copy, 0] = buf[:to_copy]
+                filled += to_copy
 
-                if len(self.audio_buffer[0]) == 0:
+                if to_copy == len(buf):
                     self.audio_buffer.popleft()
-                    if len(self.audio_buffer) == 0:
-                        self.drain_event.set()
+                else:
+                    self.audio_buffer[0] = buf[to_copy:]
 
-                outdata[:, 0] = np.zeros(frames)
-                outdata[:available, 0] = chunk
-            else:
-                outdata[:, 0] = np.zeros(frames)
+            if not self.audio_buffer and filled < frames:
                 self.drain_event.set()
 
     def play(self):

--- a/mlx_audio/tts/audio_player.py
+++ b/mlx_audio/tts/audio_player.py
@@ -15,14 +15,14 @@ class AudioPlayer:
         self.drain_event = Event()
 
     def callback(self, outdata, frames, time, status):
-        outdata.fill(0) # initialize the frame with silence
+        outdata.fill(0)  # initialize the frame with silence
         filled = 0
 
         with self.buffer_lock:
             while filled < frames and self.audio_buffer:
                 buf = self.audio_buffer[0]
                 to_copy = min(frames - filled, len(buf))
-                outdata[filled:filled + to_copy, 0] = buf[:to_copy]
+                outdata[filled : filled + to_copy, 0] = buf[:to_copy]
                 filled += to_copy
 
                 if to_copy == len(buf):


### PR DESCRIPTION
A couple of fixes that improve the quality of streaming audio:
- Make sure we always provide a full output buffer in the audio player callback to avoid discontinuities
- Keep the internal state of the Mimi decoder consistent for streamed frames, instead of resetting it per chunk