### PR TITLE
Update Swift Package paths

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,3 +22,5 @@ jobs:
         run: cd mlx_audio_swift/tts && xcodebuild clean -scheme Swift-TTS # <-- Add this clean step
       - name: Build and Run tests
         run: cd mlx_audio_swift/tts && xcodebuild test -scheme Swift-TTS -destination 'platform=macOS' MACOSX_DEPLOYMENT_TARGET=14.0 CODE_SIGNING_ALLOWED=NO
+      - name: Build Swift Package
+        run: swift build

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "d3f89b1f520ea9e52fd9de68c1dca708f040406a",
+        "version" : "0.25.3"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -15,22 +15,24 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "ESpeakNG",
-            path: "Swift-TTS/Kokoro/Frameworks/ESpeakNG.xcframework"
+            path: "mlx_audio_swift/tts/Swift-TTS/Kokoro/Frameworks/ESpeakNG.xcframework"
         ),
         .target(
             name: "Swift-TTS",
-            dependencies: [.product(name: "MLX", package: "mlx-swift"),
-            .product(name: "MLXFFT", package: "mlx-swift"),
-            .product(name: "MLXNN", package: "mlx-swift"),
-             "ESpeakNG"
-           ],
-            path: "Swift-TTS",
-            exclude: ["Preview Content","Assets.xcassets","Swift_TTSApp.swift","Swift_TTS.entitlements"]),
-            resources: [.process("Kokoro/Resources")]),
+            dependencies: [
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXFFT", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                "ESpeakNG"
+            ],
+            path: "mlx_audio_swift/tts/Swift-TTS",
+            exclude: ["Preview Content", "Assets.xcassets", "Swift_TTSApp.swift", "Swift_TTS.entitlements"],
+            resources: [.process("Kokoro/Resources")]
+        ),
         .testTarget(
             name: "Swift-TTS-Tests",
             dependencies: ["Swift-TTS"],
-            path: "Tests"
+            path: "mlx_audio_swift/tts/Tests"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     platforms: [.macOS(.v14), .iOS(.v16)],
     products: [
         .library(
-            name: "Swift-TTS",
+            name: "mlx-swift-audio",
             targets: ["Swift-TTS","ESpeakNG"]),
     ],
     dependencies: [
@@ -26,6 +26,7 @@ let package = Package(
            ],
             path: "Swift-TTS",
             exclude: ["Preview Content","Assets.xcassets","Swift_TTSApp.swift","Swift_TTS.entitlements"]),
+            resources: [.process("Kokoro/Resources")]),
         .testTarget(
             name: "Swift-TTS-Tests",
             dependencies: ["Swift-TTS"],

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
             ],
             path: "mlx_audio_swift/tts/Swift-TTS",
             exclude: ["Preview Content", "Assets.xcassets", "Swift_TTSApp.swift", "Swift_TTS.entitlements"],
-            resources: [.process("Kokoro/Resources")]
+            resources: [.process("Kokoro/Resources")] // Access the voices from Kokoro
         ),
         .testTarget(
             name: "Swift-TTS-Tests",


### PR DESCRIPTION
## Context
This PR addresses several build issues in the Swift package configuration. Fixes #134 

## Description
- Fixed the path to `ESpeakNG.xcframework `to point to the correct location
- Updated the main target's path to reflect the actual project structure
- Corrected the test target's path to point to the right test directory
- Added resources in the Package.swift file

And finally, move the `Package.swift` to the root for everyone to use it! 🎉