### PR TITLE
Handle transformers-style config for Sesame CSM models

### DIFF
--- a/mlx_audio/tts/utils.py
+++ b/mlx_audio/tts/utils.py
@@ -15,7 +15,7 @@ from mlx_lm.convert import mixed_quant_predicate_builder
 from mlx_lm.utils import dequantize_model, quantize_model, save_config, save_model
 from transformers import AutoConfig
 
-MODEL_REMAPPING = {"outetts": "outetts", "spark": "spark", "sam": "sesame"}
+MODEL_REMAPPING = {"outetts": "outetts", "spark": "spark", "csm": "sesame"}
 MAX_FILE_SIZE_GB = 5
 MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
 


### PR DESCRIPTION
This updates the Sesame CSM TTS model to handle the transformers-style config, which was added to the model repo post-launch. This makes it easier to vary the model definitions without introducing new hardcoded flavors.

I verified `mlx-community/csm-1b` still generates speech as before:

```
% echo -n "The quick brown fox jumps over the lazy dog." | python -m mlx_audio.tts.generate --model mlx-community/csm-1b-fp16 --play --verbose

Model: mlx-community/csm-1b-fp16
Text: The quick brown fox jumps over the lazy dog.
Voice: None
Speed: 1.0x
Language: a
  3%|███▉                                                            | 39/1125 [00:02<01:02, 17.25it/s]
Starting audio stream...
✅ Audio successfully generated and saving as: audio_000.wav
==========
Duration:              00:00:03.120
Samples/sec:           32476.7
Prompt:                39 tokens, 16.9 tokens-per-sec
Audio:                 74880 samples, 32476.7 samples-per-sec
Real-time factor:      0.74x
Processing time:       2.31s
Peak memory usage:     5.67GB
```