### PR TITLE
Use batched vocoding to reduce peak memory usage with Sesame arch models

### DIFF
--- a/mlx_audio/tts/models/sesame/attention.py
+++ b/mlx_audio/tts/models/sesame/attention.py
@@ -172,21 +172,6 @@ class Attention(nn.Module):
         if cache:
             k, v = cache.update_and_fetch(k, v)
 
-        if self.n_heads != self.n_kv_heads:
-            q_per_kv = self.n_heads // self.n_kv_heads
-
-            k = mx.expand_dims(k, axis=2)
-            v = mx.expand_dims(v, axis=2)
-
-            k_expand_shape = (b, self.n_kv_heads, q_per_kv) + k.shape[3:]
-            v_expand_shape = (b, self.n_kv_heads, q_per_kv) + v.shape[3:]
-
-            k = mx.broadcast_to(k, k_expand_shape)
-            v = mx.broadcast_to(v, v_expand_shape)
-
-            k = k.reshape(b, self.n_kv_heads * q_per_kv, *k.shape[3:])
-            v = v.reshape(b, self.n_kv_heads * q_per_kv, *v.shape[3:])
-
         output = scaled_dot_product_attention(
             q, k, v, cache=cache, scale=self.scale, mask=mask
         )


### PR DESCRIPTION
`python -m mlx_audio.tts.generate --model Marvis-AI/marvis-tts-250M-v0.1-MLX-4bit --play --text "Home cooking, natural wine, majestic vistas and rustic guesthouses: A road trip through this small Central European country yielded a rich array of surprises for a first-time visitor." --verbose`

Before:

```
Duration:              00:00:10.320
Samples/sec:           66985.4
Prompt:                129 tokens, 34.9 tokens-per-sec
Audio:                 247680 samples, 66985.4 samples-per-sec
Real-time factor:      0.36x
Processing time:       3.70s
Peak memory usage:     4.09GB
```

After:
```
Duration:              00:00:10.080
Samples/sec:           63249.7
Prompt:                126 tokens, 32.9 tokens-per-sec
Audio:                 241920 samples, 63249.7 samples-per-sec
Real-time factor:      0.38x
Processing time:       3.82s
Peak memory usage:     2.26GB
```

I also tried using the QuantizedKVCache from mlx-lm, but it's slower and doesn't help overall memory usage.