### PR TITLE
Update swift-transformers dependency to 1.1.0 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,13 +7,13 @@ let package = Package(
     products: [
         .library(
             name: "mlx-swift-audio",
-            targets: ["Swift-TTS","ESpeakNG"]),
-
+            targets: ["Swift-TTS", "ESpeakNG"]
+        ),
     ],
     dependencies: [
-         .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.25.2"),
-         .package(url: "https://github.com/ml-explore/mlx-swift-examples.git", branch: "main"),
-         .package(url: "https://github.com/huggingface/swift-transformers", .upToNextMinor(from: "0.1.22")),
+        .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.25.2"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-examples.git", branch: "main"),
+        .package(url: "https://github.com/huggingface/swift-transformers", .upToNextMinor(from: "1.1.0")),
     ],
     targets: [
         .binaryTarget(
@@ -23,18 +23,18 @@ let package = Package(
         .target(
             name: "Swift-TTS",
             dependencies: [
-      .product(name: "MLX", package: "mlx-swift"),
-                    .product(name: "MLXNN", package: "mlx-swift"),
-                    .product(name: "MLXRandom", package: "mlx-swift"),
-                    .product(name: "MLXLMCommon", package: "mlx-swift-examples"),
-                    .product(name: "MLXLLM", package: "mlx-swift-examples"),
-                    .product(name: "Transformers", package: "swift-transformers"),
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXNN", package: "mlx-swift"),
+                .product(name: "MLXRandom", package: "mlx-swift"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-examples"),
+                .product(name: "MLXLLM", package: "mlx-swift-examples"),
+                .product(name: "Transformers", package: "swift-transformers"),
                 "ESpeakNG"
             ],
             path: "mlx_audio_swift/tts/Swift-TTS",
             exclude: ["Preview Content", "Assets.xcassets", "Swift_TTSApp.swift", "Swift_TTS.entitlements"],
             resources: [
-                .process("Kokoro/Resources"),                  // Kokoro voices
+                .process("Kokoro/Resources") // Kokoro voices
             ]
         ),
         .testTarget(
@@ -42,6 +42,5 @@ let package = Package(
             dependencies: ["Swift-TTS"],
             path: "mlx_audio_swift/tts/Tests"
         ),
-
     ]
 )


### PR DESCRIPTION
**Description:**  
This PR updates the `swift-transformers` dependency in `Package.swift` to version `1.1.0` (`.upToNextMinor(from: "1.1.0")`).  

**Reason for change:**  
- The previous version (`0.1.22`) conflicts with `mlx-swift-examples`, which requires `swift-transformers 1.1.0..<1.2.0`.  
- Updating the version resolves the dependency conflict and allows the package graph to build successfully.  

**Impact:**  
- No changes to functionality; only the dependency version is updated.  
- Compatible with all existing targets and examples.