### PR TITLE
Add Marvis quant selection to TTS Web UI

### DIFF
--- a/mlx_audio/ui/app/text-to-speech/page.tsx
+++ b/mlx_audio/ui/app/text-to-speech/page.tsx
@@ -327,6 +327,12 @@ export default function SpeechSynthesis() {
                 </div>
               )}
 
+              <div className="mb-6">
+                <div className="text-xs text-gray-500 dark:text-gray-400">
+                  <span className="font-medium">Selected Model:</span> <span className="font-mono">{model}</span>
+                </div>
+              </div>
+
 
 
               <div className="mb-6">


### PR DESCRIPTION
## Context
In the web UI quantization of models are not clear

## Description
Add a quantization selector in Settings and display for name of the selected model

## Changes in the codebase
Only modifying the web UI settings

## Changes outside the codebase
None

## Additional information
Coding assisted with Claude

## Additional information
<img width="336" height="345" alt="Screenshot 2025-11-09 at 23 46 34" src="https://github.com/user-attachments/assets/bd9218df-348c-4de1-aa03-fff7501cc40e" />
