### PR TITLE
Add Chatterbox

### DIFF
--- a/mlx_audio/codec/models/s3/__init__.py
+++ b/mlx_audio/codec/models/s3/__init__.py
@@ -1,1 +1,30 @@
-from .model_v2 import S3TokenizerV2
+from .model_v2 import ModelConfig, S3TokenizerV2
+from .utils import (
+    log_mel_spectrogram,
+    make_non_pad_mask,
+    mask_to_bias,
+    merge_tokenized_segments,
+    padding,
+)
+
+# S3Tokenizer constants
+S3_SR = 16_000  # Sample rate for S3Tokenizer
+S3_HOP = 160  # 100 frames/sec
+S3_TOKEN_HOP = 640  # 25 tokens/sec
+S3_TOKEN_RATE = 25
+SPEECH_VOCAB_SIZE = 6561  # 3^8
+
+__all__ = [
+    "S3TokenizerV2",
+    "ModelConfig",
+    "log_mel_spectrogram",
+    "make_non_pad_mask",
+    "mask_to_bias",
+    "padding",
+    "merge_tokenized_segments",
+    "S3_SR",
+    "S3_HOP",
+    "S3_TOKEN_HOP",
+    "S3_TOKEN_RATE",
+    "SPEECH_VOCAB_SIZE",
+]

--- a/mlx_audio/codec/models/s3/model_v2.py
+++ b/mlx_audio/codec/models/s3/model_v2.py
@@ -1,14 +1,16 @@
+import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
 from einops.array_api import rearrange
 from huggingface_hub import snapshot_download
+from mlx.utils import tree_flatten
 
 from .model import MultiHeadAttention
-from .utils import make_non_pad_mask, mask_to_bias
+from .utils import make_non_pad_mask, mask_to_bias, merge_tokenized_segments
 
 
 @dataclass
@@ -347,14 +349,246 @@ class S3TokenizerV2(nn.Module):
         return self.quantize(mel, mel_len)
 
     def quantize(self, mel: mx.array, mel_len: mx.array) -> Tuple[mx.array, mx.array]:
+        """
+        Quantize mel spectrogram to tokens, with automatic long audio handling.
+
+        Args:
+            mel: Mel spectrogram tensor (B, n_mels, T)
+            mel_len: Mel length tensor (B,)
+
+        Returns:
+            code: Quantized tokens (B, T')
+            code_len: Token length (B,)
+        """
+        # Check if any audio exceeds 30 seconds
+        # At 16kHz with hop_length=160: 30s = 3000 frames
+        max_frames = 3000
+        long_audio_mask = mel_len > max_frames
+
+        if mx.any(long_audio_mask):
+            # Has long audio - need special processing
+            return self._quantize_mixed_batch(mel, mel_len, long_audio_mask, max_frames)
+        else:
+            # All short audio - use simple path
+            hidden, code_len = self.encoder(mel, mel_len)
+            code = self.quantizer.encode(hidden)
+            return code, code_len
+
+    def _quantize_mixed_batch(
+        self,
+        mel: mx.array,
+        mel_len: mx.array,
+        long_audio_mask: mx.array,
+        max_frames: int,
+    ) -> Tuple[mx.array, mx.array]:
+        """
+        Handle mixed batch with both short and long audio.
+
+        For long audio, uses sliding window approach with 30s windows
+        and 4s overlap.
+        """
+        batch_size = mel.shape[0]
+
+        # Sliding window parameters
+        sample_rate = 16000
+        hop_length = 160
+        window_size = 30  # seconds
+        overlap = 4  # seconds
+
+        frames_per_window = window_size * sample_rate // hop_length  # 3000
+        frames_per_overlap = overlap * sample_rate // hop_length  # 400
+        frames_per_stride = frames_per_window - frames_per_overlap  # 2600
+
+        # Collect all segments
+        all_segments = []
+        all_segments_len = []
+        segment_info = []
+
+        for batch_idx in range(batch_size):
+            audio_mel = mel[batch_idx]
+            audio_mel_len = int(mel_len[batch_idx].item())
+            is_long_audio = bool(long_audio_mask[batch_idx].item())
+
+            if not is_long_audio:
+                # Short audio: process as single segment
+                segment = audio_mel[:, :audio_mel_len]
+                seg_len = audio_mel_len
+
+                if seg_len < frames_per_window:
+                    pad_size = frames_per_window - seg_len
+                    segment = mx.pad(segment, [(0, 0), (0, pad_size)])
+
+                all_segments.append(segment)
+                all_segments_len.append(seg_len)
+                segment_info.append(
+                    {
+                        "batch_idx": batch_idx,
+                        "is_long_audio": False,
+                        "segment_idx": 0,
+                        "total_segments": 1,
+                    }
+                )
+            else:
+                # Long audio: split into segments
+                start = 0
+                segment_idx = 0
+                while start < audio_mel_len:
+                    end = min(start + frames_per_window, audio_mel_len)
+                    segment = audio_mel[:, start:end]
+                    seg_len = segment.shape[1]
+
+                    if seg_len < frames_per_window:
+                        pad_size = frames_per_window - seg_len
+                        segment = mx.pad(segment, [(0, 0), (0, pad_size)])
+
+                    all_segments.append(segment)
+                    all_segments_len.append(seg_len)
+                    segment_info.append(
+                        {
+                            "batch_idx": batch_idx,
+                            "is_long_audio": True,
+                            "segment_idx": segment_idx,
+                            "total_segments": None,
+                        }
+                    )
+
+                    segment_idx += 1
+                    start += frames_per_stride
+
+                # Update total_segments
+                total_segments = segment_idx
+                for info in segment_info:
+                    if info["batch_idx"] == batch_idx and info["is_long_audio"]:
+                        info["total_segments"] = total_segments
+
+        if not all_segments:
+            return (
+                mx.zeros((batch_size, 0), dtype=mx.int32),
+                mx.zeros((batch_size,), dtype=mx.int32),
+            )
+
+        # Process all segments
+        unified_batch_mel = mx.stack(all_segments)
+        unified_batch_lens = mx.array(all_segments_len, dtype=mx.int32)
+
+        hidden, code_len = self.encoder(unified_batch_mel, unified_batch_lens)
+        codes = self.quantizer.encode(hidden)
+
+        # Reorganize results
+        results = {}
+
+        for seg_idx, info in enumerate(segment_info):
+            batch_idx = info["batch_idx"]
+            is_long_audio = info["is_long_audio"]
+
+            seg_code_len = int(code_len[seg_idx].item())
+            segment_code = codes[seg_idx, :seg_code_len].tolist()
+
+            if not is_long_audio:
+                results[batch_idx] = (
+                    mx.array(segment_code, dtype=mx.int32),
+                    len(segment_code),
+                )
+            else:
+                if batch_idx not in results:
+                    results[batch_idx] = []
+                results[batch_idx].append(segment_code)
+
+        # Merge long audio segments
+        for batch_idx in range(batch_size):
+            if bool(long_audio_mask[batch_idx].item()):
+                audio_codes = results[batch_idx]
+                token_rate = 25  # V2 uses 25Hz
+                merged_codes = merge_tokenized_segments(
+                    audio_codes, overlap=overlap, token_rate=token_rate
+                )
+                results[batch_idx] = (
+                    mx.array(merged_codes, dtype=mx.int32),
+                    len(merged_codes),
+                )
+
+        # Build output
+        max_code_len = max(info[1] for info in results.values())
+
+        # Rebuild using list comprehension
+        output_list = []
+        len_list = []
+        for batch_idx in range(batch_size):
+            code_tensor, code_len_val = results[batch_idx]
+            if code_tensor.shape[0] < max_code_len:
+                code_tensor = mx.pad(
+                    code_tensor, [(0, max_code_len - code_tensor.shape[0])]
+                )
+            output_list.append(code_tensor)
+            len_list.append(code_len_val)
+
+        output_codes = mx.stack(output_list)
+        output_codes_len = mx.array(len_list, dtype=mx.int32)
+
+        return output_codes, output_codes_len
+
+    def quantize_simple(
+        self, mel: mx.array, mel_len: mx.array
+    ) -> Tuple[mx.array, mx.array]:
+        """
+        Simple quantization without long audio handling.
+
+        Use this for audio clips under 30 seconds.
+        """
         hidden, code_len = self.encoder(mel, mel_len)
         code = self.quantizer.encode(hidden)
         return code, code_len
 
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        new_weights = {}
+
+        # Get expected shapes from model for idempotent transposition
+        curr_weights = dict(tree_flatten(self.parameters()))
+
+        for key, value in weights.items():
+            new_key = key
+
+            # Skip computed buffers and dynamic embeddings
+            if "freqs_cis" in key or "_mel_filters" in key:
+                continue
+
+            # Skip ONNX intermediate nodes (raw ONNX weight names)
+            if key.startswith("onnx::"):
+                continue
+
+            # Quantizer key mappings:
+            # - quantizer._codebook -> quantizer.fsq_codebook (PyTorch private attr)
+            # - quantizer.codebook -> quantizer.fsq_codebook (alternative naming)
+            new_key = new_key.replace("quantizer._codebook.", "quantizer.fsq_codebook.")
+            new_key = new_key.replace("quantizer.codebook.", "quantizer.fsq_codebook.")
+
+            # PyTorch Sequential uses mlp.0, mlp.2; MLX uses mlp.layers.0, mlp.layers.2
+            new_key = re.sub(r"\.mlp\.(\d+)\.", r".mlp.layers.\1.", new_key)
+
+            # Conv1d weights need transposition (idempotent)
+            # Only transpose if shape doesn't match expected MLX format
+            if (
+                ".conv1." in new_key
+                or ".conv2." in new_key
+                or ".fsmn_block." in new_key
+            ):
+                if "weight" in new_key and value.ndim == 3:
+                    # PyTorch Conv1d: (out_channels, in_channels, kernel_size)
+                    # MLX Conv1d: (out_channels, kernel_size, in_channels)
+                    if (
+                        new_key in curr_weights
+                        and value.shape != curr_weights[new_key].shape
+                    ):
+                        value = value.swapaxes(1, 2)
+
+            new_weights[new_key] = value
+
+        return new_weights
+
     @classmethod
     def from_pretrained(
         cls,
-        name: str = "speech_tokenizer_v2_25hz",
+        name: str,
         repo_id: str = "mlx-community/CosyVoice2-0.5B-S3Tokenizer",
     ) -> "S3TokenizerV2":
         path = fetch_from_hub(repo_id)

--- a/mlx_audio/codec/models/s3/utils.py
+++ b/mlx_audio/codec/models/s3/utils.py
@@ -120,3 +120,28 @@ def padding(data: List[mx.array]) -> tuple[mx.array, mx.array]:
         padded_feats[i, :, :seq_len] = feat
 
     return padded_feats, feats_lengths
+
+
+def merge_tokenized_segments(
+    tokenized_segments: List[List[int]], overlap: int, token_rate: int
+) -> List[int]:
+    """
+    Merges tokenized outputs by keeping the middle and dropping half of the overlapped tokens.
+
+    Args:
+        tokenized_segments: List of tokenized sequences.
+        overlap: Overlapping duration in seconds.
+        token_rate: Number of tokens per second.
+
+    Returns:
+        A single merged token sequence.
+    """
+    merged_tokens = []
+    overlap_tokens = (overlap // 2) * token_rate
+
+    for i, tokens in enumerate(tokenized_segments):
+        left = 0 if i == 0 else overlap_tokens
+        right = -overlap_tokens if i != len(tokenized_segments) - 1 else len(tokens)
+        merged_tokens.extend(tokens[left:right])
+
+    return merged_tokens

--- a/mlx_audio/tts/models/chatterbox/__init__.py
+++ b/mlx_audio/tts/models/chatterbox/__init__.py
@@ -1,0 +1,2 @@
+from .chatterbox import Model
+from .config import ModelConfig

--- a/mlx_audio/tts/models/chatterbox/chatterbox.py
+++ b/mlx_audio/tts/models/chatterbox/chatterbox.py
@@ -1,0 +1,792 @@
+import math
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Generator, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+from scipy import signal
+
+from ..base import GenerationResult
+from .config import ModelConfig
+from .s3gen import S3Token2Wav
+from .s3tokenizer import S3_SR as S3_TOKENIZER_SR
+from .s3tokenizer import S3TokenizerV2, log_mel_spectrogram
+from .t3 import T3
+from .t3.cond_enc import T3Cond
+from .voice_encoder import VoiceEncConfig, VoiceEncoder
+
+# Constants
+S3_SR = 16000  # Sample rate for speech tokenizer
+S3GEN_SR = 24000  # Sample rate for vocoder
+SPEECH_VOCAB_SIZE = 6561  # Size of speech token vocabulary
+
+# Special tokens
+SOT = "[START]"
+EOT = "[STOP]"
+SPACE = "[SPACE]"
+
+
+def resample_audio(audio: mx.array, orig_sr: int, target_sr: int) -> mx.array:
+    """
+    Resample audio to a target sample rate using scipy.
+
+    Args:
+        audio: Audio waveform as MLX array (samples,) or (channels, samples)
+        orig_sr: Original sample rate
+        target_sr: Target sample rate
+
+    Returns:
+        Resampled audio as MLX array
+    """
+    if orig_sr == target_sr:
+        return audio
+
+    # Convert to numpy for scipy
+    import numpy as np
+
+    audio_np = np.array(audio)
+
+    # Calculate resampling factors
+    gcd = math.gcd(orig_sr, target_sr)
+    up = target_sr // gcd
+    down = orig_sr // gcd
+
+    # Resample
+    resampled = signal.resample_poly(audio_np, up, down, padtype="edge")
+
+    return mx.array(resampled)
+
+
+def punc_norm(text: str) -> str:
+    """
+    Quick cleanup func for punctuation from LLMs or
+    containing chars not seen often in the dataset.
+    """
+    if len(text) == 0:
+        return "You need to add some text for me to talk."
+
+    # Capitalise first letter
+    if text[0].islower():
+        text = text[0].upper() + text[1:]
+
+    # Remove multiple space chars
+    text = " ".join(text.split())
+
+    # Replace uncommon/llm punc
+    punc_to_replace = [
+        ("...", ", "),
+        ("…", ", "),
+        (":", ","),
+        (" - ", ", "),
+        (";", ", "),
+        ("—", "-"),
+        ("–", "-"),
+        (" ,", ","),
+        (
+            """, "\""),
+        (""",
+            '"',
+        ),
+        ("'", "'"),
+        ("'", "'"),
+    ]
+    for old_char_sequence, new_char in punc_to_replace:
+        text = text.replace(old_char_sequence, new_char)
+
+    # Add full stop if no ending punc
+    text = text.rstrip(" ")
+    sentence_enders = {".", "!", "?", "-", ","}
+    if not any(text.endswith(p) for p in sentence_enders):
+        text += "."
+
+    return text
+
+
+def drop_invalid_tokens(x: mx.array) -> mx.array:
+    """
+    Drop SOS and EOS tokens, extracting only the speech content between them.
+
+    This matches the original PyTorch implementation which slices between
+    the start-of-speech (SOS=6561) and end-of-speech (EOS=6562) markers.
+    """
+    SOS = SPEECH_VOCAB_SIZE  # 6561
+    EOS = SPEECH_VOCAB_SIZE + 1  # 6562
+
+    assert len(x.shape) == 1 or (
+        len(x.shape) == 2 and x.shape[0] == 1
+    ), "only batch size of one allowed for now"
+
+    x_flat = x.flatten()
+
+    # Find SOS position using argmax (returns first True index)
+    sos_mask = x_flat == SOS
+    s = 0
+    if mx.any(sos_mask):
+        s = int(mx.argmax(sos_mask)) + 1  # Start after SOS
+
+    # Find EOS position using argmax
+    eos_mask = x_flat == EOS
+    e = x_flat.shape[0]
+    if mx.any(eos_mask):
+        e = int(mx.argmax(eos_mask))  # End before EOS
+
+    return x_flat[s:e]
+
+
+@dataclass
+class Conditionals:
+    """
+    Conditionals for T3 and S3Gen.
+
+    T3 conditionals:
+        - speaker_emb
+        - cond_prompt_speech_tokens
+        - emotion_adv
+
+    S3Gen conditionals:
+        - prompt_token
+        - prompt_token_len
+        - prompt_feat
+        - prompt_feat_len
+        - embedding
+    """
+
+    t3: T3Cond
+    gen: dict
+
+
+class Model(nn.Module):
+    """
+    Chatterbox Text-to-Speech model.
+
+    This integrates:
+    - T3: LLaMA-based text-to-speech-token generator
+    - S3Gen: Flow matching decoder with HiFi-GAN vocoder
+    - VoiceEncoder: Speaker embedding extractor
+    - S3Tokenizer: Speech tokenizer for reference audio
+    - Text Tokenizer: Text to token ID conversion
+
+    Usage:
+        model = Model.from_pretrained("path/to/weights")
+        audio = model.generate("Hello world!", audio_prompt_path="reference.wav")
+    """
+
+    ENC_COND_LEN = 6 * S3_SR  # 6 seconds at 16kHz for encoder
+    DEC_COND_LEN = 10 * S3GEN_SR  # 10 seconds at 24kHz for decoder
+
+    def __init__(
+        self,
+        config_or_t3: Union[ModelConfig, T3] = None,
+        s3gen: Optional[S3Token2Wav] = None,
+        ve: Optional[VoiceEncoder] = None,
+        conds: Optional[Conditionals] = None,
+    ):
+        super().__init__()
+        self.sr = S3GEN_SR  # sample rate of synthesized audio
+
+        # Check if first argument is a config
+        if config_or_t3 is None or isinstance(config_or_t3, ModelConfig):
+            # Initialize from config
+            config = config_or_t3 or ModelConfig()
+            self.config = config
+            self.t3 = T3(config.t3_config)
+            self.s3gen = S3Token2Wav()
+            self.ve = VoiceEncoder()
+            self.conds = None
+        else:
+            # Initialize with individual components
+            self.config = None
+            self.t3 = config_or_t3
+            self.s3gen = s3gen
+            self.ve = ve
+            self.conds = conds
+
+        # S3 tokenizer for speech token extraction (initialized lazily or during load_weights)
+        self.s3_tokenizer = S3TokenizerV2("speech_tokenizer_v2_25hz")
+        # Text tokenizer (initialized during load_weights if model_path is available)
+        self.tokenizer = None
+
+        # Initialize tokenizers from model_path if available in config
+        if self.config is not None and self.config.model_path is not None:
+            self._init_tokenizers(Path(self.config.model_path))
+
+    def _init_tokenizers(self, model_path: Path) -> None:
+        """Initialize text tokenizer from model path."""
+        tokenizer_path = model_path / "tokenizer.json"
+        if tokenizer_path.exists():
+            try:
+                from .tokenizer import EnTokenizer
+
+                self.tokenizer = EnTokenizer(tokenizer_path)
+            except ImportError:
+                print("Warning: tokenizers library not available")
+                self.tokenizer = None
+        else:
+            print(f"Warning: tokenizer.json not found at {tokenizer_path}")
+            self.tokenizer = None
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """
+        Sanitize PyTorch weights for MLX.
+
+        This routes weights to the appropriate component's sanitize method
+        based on the weight key prefix. Handles two cases:
+
+        1. Pre-prefixed weights (from MLX converted models):
+           - ve.* -> VoiceEncoder weights
+           - t3.* -> T3 model weights
+           - s3gen.* -> S3Gen (S3Token2Wav) weights
+           - s3_tokenizer.* -> S3TokenizerV2 weights
+
+        2. Original PyTorch weights (without prefix):
+           - Infers component from key names
+
+        Each component's sanitize method handles:
+        - Conv1d/Conv2d weight transposition
+        - LSTM weight renaming (for VoiceEncoder)
+        - Perceiver attention weight renaming (for T3)
+        - ConvTranspose weight transposition (for S3Gen)
+        """
+        new_weights = {}
+
+        # Separate weights by component
+        ve_weights = {}
+        t3_weights = {}
+        s3gen_weights = {}
+        s3tok_weights = {}
+        other_weights = {}
+
+        for key, value in weights.items():
+            if key.startswith("ve."):
+                # Remove prefix for component sanitize
+                ve_weights[key[3:]] = value
+            elif key.startswith("t3."):
+                t3_weights[key[3:]] = value
+            elif key.startswith("s3gen."):
+                s3gen_weights[key[6:]] = value
+            elif key.startswith("s3_tokenizer."):
+                s3tok_weights[key[13:]] = value
+            elif key.startswith("tokenizer."):
+                # S3Tokenizer bundled in s3gen.safetensors (PyTorch format)
+                s3tok_weights[key[10:]] = value
+            else:
+                # If no prefix, infer from key names
+                # VoiceEncoder keys: lstm.*, similarity_*, proj.*
+                if (
+                    key.startswith("lstm.")
+                    or key.startswith("similarity")
+                    or key == "proj.weight"
+                    or key == "proj.bias"
+                ):
+                    ve_weights[key] = value
+                # T3 keys: tfmr.*, text_emb.*, speech_emb.*, text_head.*, speech_head.*,
+                #          perceiver.*, cond_emb.*, prompt_pos_emb.*, cond_enc.*, text_pos_emb.*, speech_pos_emb.*
+                elif (
+                    key.startswith("tfmr.")
+                    or key.startswith("text_emb.")
+                    or key.startswith("speech_emb.")
+                    or key.startswith("text_head.")
+                    or key.startswith("speech_head.")
+                    or key.startswith("perceiver.")
+                    or key.startswith("cond_emb.")
+                    or key.startswith("prompt_pos_emb.")
+                    or key.startswith("cond_enc.")
+                    or key.startswith("text_pos_emb.")
+                    or key.startswith("speech_pos_emb.")
+                ):
+                    t3_weights[key] = value
+                # S3Gen keys: flow.*, mel2wav.*, speaker_encoder.*, f0_predictor.*
+                elif (
+                    key.startswith("flow.")
+                    or key.startswith("mel2wav.")
+                    or key.startswith("speaker_encoder.")
+                    or key.startswith("f0_predictor.")
+                ):
+                    s3gen_weights[key] = value
+                else:
+                    other_weights[key] = value
+
+        # Sanitize each component's weights
+        if ve_weights:
+            ve_sanitized = self.ve.sanitize(ve_weights)
+            for k, v in ve_sanitized.items():
+                new_weights[f"ve.{k}"] = v
+
+        if t3_weights:
+            t3_sanitized = self.t3.sanitize(t3_weights)
+            for k, v in t3_sanitized.items():
+                new_weights[f"t3.{k}"] = v
+
+        if s3gen_weights:
+            s3gen_sanitized = self.s3gen.sanitize(s3gen_weights)
+            for k, v in s3gen_sanitized.items():
+                new_weights[f"s3gen.{k}"] = v
+
+        if s3tok_weights:
+            s3tok_sanitized = self.s3_tokenizer.sanitize(s3tok_weights)
+            for k, v in s3tok_sanitized.items():
+                new_weights[f"s3_tokenizer.{k}"] = v
+
+        # Add other weights as-is
+        new_weights.update(other_weights)
+
+        return new_weights
+
+    def load_weights(self, weights, strict: bool = True):
+        """
+        Load weights into the model.
+
+        Uses strict=False by default for components because Chatterbox has
+        several non-checkpoint parameters (rand_noise, pos_enc.pe, stft_window,
+        trim_fade) that are generated during initialization.
+
+        Args:
+            weights: List of (key, value) tuples or dict
+            strict: If False, ignore missing/extra keys. Default True for
+                    compatibility with utils.load_model().
+        """
+        if isinstance(weights, dict):
+            weights = list(weights.items())
+
+        # Split weights by component prefix
+        ve_weights = []
+        t3_weights = []
+        s3gen_weights = []
+        s3tok_weights = []
+        other_weights = []
+
+        for k, v in weights:
+            if k.startswith("ve."):
+                ve_weights.append((k[3:], v))
+            elif k.startswith("t3."):
+                t3_weights.append((k[3:], v))
+            elif k.startswith("s3gen."):
+                s3gen_weights.append((k[6:], v))
+            elif k.startswith("s3_tokenizer."):
+                s3tok_weights.append((k[13:], v))
+            else:
+                other_weights.append((k, v))
+
+        # Load each component with strict=False to handle non-checkpoint params
+        if ve_weights:
+            self.ve.load_weights(ve_weights, strict=False)
+        if t3_weights:
+            self.t3.load_weights(t3_weights, strict=False)
+        if s3gen_weights:
+            self.s3gen.load_weights(s3gen_weights, strict=False)
+        if s3tok_weights:
+            if self.s3_tokenizer is None:
+                self.s3_tokenizer = S3TokenizerV2("speech_tokenizer_v2_25hz")
+            self.s3_tokenizer.load_weights(s3tok_weights, strict=False)
+
+        # Handle any remaining weights at the top level
+        if other_weights and strict:
+            raise ValueError(
+                f"Unrecognized weight keys: {[k for k, v in other_weights]}"
+            )
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        ckpt_dir: Union[str, Path],
+    ) -> "Model":
+        """
+        Load a pretrained Chatterbox model from a checkpoint directory.
+
+        Expects the standard mlx-audio format: a single model.safetensors file
+        with component prefixes (ve.*, t3.*, s3gen.*, s3_tokenizer.*).
+
+        Automatically handles quantized weights if config.json contains quantization info.
+
+        Use scripts/convert_chatterbox.py to convert from original PyTorch weights.
+
+        Args:
+            ckpt_dir: Path to checkpoint directory containing model.safetensors
+                and tokenizer.json.
+
+        Returns:
+            Initialized ChatterboxTTS model
+        """
+        import json
+
+        ckpt_dir = Path(ckpt_dir)
+
+        # Initialize models with default config
+        model = cls()
+
+        print("Loading MLX weights...")
+
+        combined_path = ckpt_dir / "model.safetensors"
+        if not combined_path.exists():
+            raise FileNotFoundError(
+                f"model.safetensors not found in {ckpt_dir}. "
+                "Use scripts/convert_chatterbox.py to convert from PyTorch weights."
+            )
+
+        # Load config to check for quantization
+        config_path = ckpt_dir / "config.json"
+        config = {}
+        if config_path.exists():
+            with open(config_path) as f:
+                config = json.load(f)
+
+        all_weights = mx.load(str(combined_path))
+
+        # Split weights by prefix
+        ve_weights = {k[3:]: v for k, v in all_weights.items() if k.startswith("ve.")}
+        t3_weights = {k[3:]: v for k, v in all_weights.items() if k.startswith("t3.")}
+        s3gen_weights = {
+            k[6:]: v for k, v in all_weights.items() if k.startswith("s3gen.")
+        }
+        s3tok_weights = {
+            k[13:]: v for k, v in all_weights.items() if k.startswith("s3_tokenizer.")
+        }
+
+        # Handle quantization if present in config
+        if quantization := config.get("quantization"):
+            print(f"Detected {quantization['bits']}-bit quantization...")
+
+            # Quantize the model before loading weights
+            # This converts Linear layers to QuantizedLinear so they can accept packed weights
+            def should_quantize(path, module):
+                """Check if this module should be quantized based on weights."""
+                if not hasattr(module, "to_quantized"):
+                    return False
+                # Check if we have quantized weights (scales) for this path
+                # Need to check in the appropriate weight dict based on prefix
+                if path.startswith("t3."):
+                    weight_path = path[3:]  # Remove "t3." prefix
+                    return f"{weight_path}.scales" in t3_weights
+                return False
+
+            nn.quantize(
+                model,
+                group_size=quantization["group_size"],
+                bits=quantization["bits"],
+                class_predicate=should_quantize,
+            )
+
+        def load_component_weights(component, weights, strict: bool = True):
+            """Load weights dict into component."""
+            if hasattr(component, "sanitize"):
+                weights = component.sanitize(weights)
+            component.load_weights(list(weights.items()), strict=strict)
+
+        if ve_weights:
+            load_component_weights(model.ve, ve_weights, strict=True)
+        if t3_weights:
+            load_component_weights(model.t3, t3_weights, strict=False)
+        if s3gen_weights:
+            load_component_weights(model.s3gen, s3gen_weights, strict=False)
+        if s3tok_weights:
+            model.s3_tokenizer = S3TokenizerV2("speech_tokenizer_v2_25hz")
+            load_component_weights(model.s3_tokenizer, s3tok_weights, strict=False)
+        else:
+            print("Warning: s3_tokenizer weights not found in model.safetensors")
+            model.s3_tokenizer = None
+
+        # Initialize text tokenizer
+        tokenizer_path = ckpt_dir / "tokenizer.json"
+        if tokenizer_path.exists():
+            try:
+                from .tokenizer import EnTokenizer
+
+                model.tokenizer = EnTokenizer(tokenizer_path)
+            except ImportError:
+                print("Warning: tokenizers library not available")
+                model.tokenizer = None
+        else:
+            print("Warning: tokenizer.json not found")
+            model.tokenizer = None
+
+        # Set to eval mode for inference (important for BatchNorm)
+        model.eval()
+        print("Model loaded successfully!")
+        return model
+
+    def prepare_conditionals(
+        self, ref_wav: mx.array, ref_sr: int, exaggeration: float = 0.5
+    ) -> Conditionals:
+        """
+        Prepare conditioning from a reference audio clip.
+
+        Args:
+            ref_wav: Reference waveform (samples,) or (1, samples)
+            ref_sr: Reference sample rate
+            exaggeration: Emotion exaggeration factor (0-1)
+
+        Returns:
+            Conditionals object with T3 and S3Gen conditioning
+
+        Note:
+            Following the original PyTorch implementation:
+            - S3Gen uses up to 10s of audio (DEC_COND_LEN at 24kHz)
+            - T3 encoder uses up to 6s of audio (ENC_COND_LEN at 16kHz)
+            - S3Gen tokens are computed from 24kHz audio resampled to 16kHz
+            - T3 tokens are computed from 16kHz audio (resampled from original)
+        """
+        # Ensure 1D waveform
+        if ref_wav.ndim == 2:
+            ref_wav = ref_wav.squeeze(0)
+
+        # Resample to 24kHz for S3Gen (mel extraction and base for speaker embedding)
+        if ref_sr != S3GEN_SR:
+            ref_wav_24k = resample_audio(ref_wav, ref_sr, S3GEN_SR)
+        else:
+            ref_wav_24k = ref_wav
+        # Truncate to decoder conditioning length (10s)
+        ref_wav_24k = ref_wav_24k[: self.DEC_COND_LEN]
+
+        # Resample 24kHz to 16kHz for S3Gen tokenization and speaker embedding
+        # This matches the original which resamples from 24kHz
+        ref_wav_16k_from_24k = resample_audio(ref_wav_24k, S3GEN_SR, S3_SR)
+
+        # Resample original to 16kHz for T3 encoder conditioning and VE embedding
+        if ref_sr != S3_SR:
+            ref_wav_16k_full = resample_audio(ref_wav, ref_sr, S3_SR)
+        else:
+            ref_wav_16k_full = ref_wav
+        # Truncate to encoder conditioning length (6s) for T3 tokens only
+        ref_wav_16k = ref_wav_16k_full[: self.ENC_COND_LEN]
+
+        # Get S3Gen reference embeddings
+        s3gen_ref_dict = {}
+        t3_cond_prompt_tokens = None
+
+        if self.s3_tokenizer is not None:
+            # --- S3Gen tokens (from 10s audio, resampled 24k->16k) ---
+            s3gen_mel = log_mel_spectrogram(ref_wav_16k_from_24k)
+            s3gen_mel = mx.expand_dims(s3gen_mel, 0)  # Add batch dim
+            s3gen_mel_len = mx.array([s3gen_mel.shape[2]])
+            s3gen_tokens, s3gen_token_lens = self.s3_tokenizer(s3gen_mel, s3gen_mel_len)
+
+            # Get S3Gen embeddings (tokens may be truncated by embed_ref to match mel)
+            s3gen_ref_dict = self.s3gen.embed_ref(
+                ref_wav=mx.expand_dims(ref_wav_24k, 0),
+                ref_sr=S3GEN_SR,
+                ref_speech_tokens=s3gen_tokens,
+                ref_speech_token_lens=s3gen_token_lens,
+            )
+
+            # --- T3 conditioning tokens (from 6s audio, limited to plen) ---
+            t3_mel = log_mel_spectrogram(ref_wav_16k)
+            t3_mel = mx.expand_dims(t3_mel, 0)
+            t3_mel_len = mx.array([t3_mel.shape[2]])
+            t3_tokens, t3_token_lens = self.s3_tokenizer(t3_mel, t3_mel_len)
+
+            # Limit T3 tokens to prompt length
+            plen = self.t3.hp.speech_cond_prompt_len if hasattr(self.t3, "hp") else 150
+            t3_cond_prompt_tokens = t3_tokens[:, :plen]
+
+        # Voice encoder speaker embedding (from full 16kHz audio, not truncated)
+        ve_embed = self.ve.embeds_from_wavs([ref_wav_16k_full], sample_rate=S3_SR)
+        ve_embed = mx.mean(ve_embed, axis=0, keepdims=True)
+
+        t3_cond = T3Cond(
+            speaker_emb=ve_embed,
+            cond_prompt_speech_tokens=t3_cond_prompt_tokens,
+            emotion_adv=mx.ones((1, 1, 1)) * exaggeration,
+        )
+
+        return Conditionals(t3_cond, s3gen_ref_dict)
+
+    @property
+    def sample_rate(self) -> int:
+        """Output sample rate."""
+        return S3GEN_SR
+
+    def generate(
+        self,
+        text: str,
+        audio_prompt: Optional[mx.array] = None,
+        audio_prompt_sr: Optional[int] = None,
+        conds: Optional[Conditionals] = None,
+        exaggeration: float = 0.1,
+        cfg_weight: float = 0.5,
+        temperature: float = 0.8,
+        repetition_penalty: float = 1.2,
+        min_p: float = 0.05,
+        top_p: float = 1.0,
+        max_new_tokens: int = 1000,
+        # Standard mlx_audio.tts.generate parameters (mapped to Chatterbox params)
+        ref_audio: Optional[mx.array] = None,
+        voice: Optional[str] = None,
+        speed: float = 1.0,
+        lang_code: str = "a",
+        ref_text: Optional[str] = None,
+        max_tokens: int = None,
+        verbose: bool = True,
+        stream: bool = False,
+        streaming_interval: float = 2.0,
+        **kwargs,
+    ) -> Generator[GenerationResult, None, None]:
+        """
+        Generate speech from text.
+
+        Args:
+            text: Input text to synthesize
+            audio_prompt: Reference audio for voice cloning (optional)
+            audio_prompt_sr: Sample rate of audio prompt
+            conds: Pre-computed conditionals (optional)
+            exaggeration: Emotion exaggeration factor (0-1)
+            cfg_weight: Classifier-free guidance weight
+            temperature: Sampling temperature
+            repetition_penalty: Penalty for repeated tokens
+            min_p: Minimum probability threshold
+            top_p: Top-p (nucleus) sampling threshold
+            max_new_tokens: Maximum number of tokens to generate
+            ref_audio: Alias for audio_prompt (for mlx_audio.tts.generate compatibility)
+            voice: Ignored (Chatterbox uses reference audio for voice cloning)
+            speed: Ignored (Chatterbox doesn't support speed adjustment)
+            lang_code: Ignored (Chatterbox is English-only)
+            ref_text: Ignored (Chatterbox doesn't use reference text)
+            max_tokens: Alias for max_new_tokens
+            verbose: Whether to print verbose output
+            stream: Ignored (Chatterbox doesn't support streaming)
+            streaming_interval: Ignored
+
+        Yields:
+            GenerationResult with generated audio waveform
+        """
+        start_time = time.time()
+
+        # Handle parameter aliases for mlx_audio.tts.generate compatibility
+        if ref_audio is not None and audio_prompt is None:
+            audio_prompt = ref_audio
+            audio_prompt_sr = (
+                self.sample_rate
+            )  # Assume ref_audio is already at correct sample rate
+        if max_tokens is not None and max_new_tokens == 1000:
+            max_new_tokens = max_tokens
+
+        # Prepare conditionals if needed
+        if conds is None:
+            if audio_prompt is not None and audio_prompt_sr is not None:
+                conds = self.prepare_conditionals(
+                    audio_prompt, audio_prompt_sr, exaggeration
+                )
+            elif self.conds is not None:
+                conds = self.conds
+            else:
+                raise ValueError(
+                    "Reference audio is required for voice cloning. "
+                    "Please provide audio_prompt and audio_prompt_sr parameters."
+                )
+
+        # Update exaggeration if needed
+        if exaggeration != float(conds.t3.emotion_adv[0, 0, 0]):
+            conds.t3.emotion_adv = mx.ones((1, 1, 1)) * exaggeration
+
+        # Normalize and tokenize text
+        text = punc_norm(text)
+
+        if self.tokenizer is not None:
+            text_tokens = self.tokenizer.text_to_tokens(text)
+        else:
+            raise ValueError(
+                "Text tokenizer not initialized. "
+                "Load model with from_pretrained() or set model.tokenizer manually."
+            )
+
+        token_count = text_tokens.shape[1]
+
+        if cfg_weight > 0.0:
+            text_tokens = mx.concatenate([text_tokens, text_tokens], axis=0)
+
+        # Add start/end tokens
+        sot = self.t3.hp.start_text_token
+        eot = self.t3.hp.stop_text_token
+
+        # Pad with start token
+        sot_tokens = mx.full((text_tokens.shape[0], 1), sot, dtype=mx.int32)
+        eot_tokens = mx.full((text_tokens.shape[0], 1), eot, dtype=mx.int32)
+        text_tokens = mx.concatenate([sot_tokens, text_tokens, eot_tokens], axis=1)
+
+        # Generate speech tokens with T3
+        speech_tokens = self.t3.inference(
+            t3_cond=conds.t3,
+            text_tokens=text_tokens,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            cfg_weight=cfg_weight,
+            repetition_penalty=repetition_penalty,
+            min_p=min_p,
+            top_p=top_p,
+        )
+
+        # Extract conditional batch (first in CFG pair)
+        speech_tokens = speech_tokens[0:1]
+
+        # Drop invalid tokens
+        speech_tokens = drop_invalid_tokens(speech_tokens)
+        # Filter out tokens >= SPEECH_VOCAB_SIZE
+        mask = speech_tokens < SPEECH_VOCAB_SIZE
+        # Use argsort to get indices of valid tokens (preserves order via stable sort)
+        valid_count = int(mx.sum(mask.astype(mx.int32)))
+        sorted_indices = mx.argsort(-mask.astype(mx.int32))
+        valid_indices = sorted_indices[:valid_count]
+        speech_tokens = mx.take(speech_tokens, valid_indices)
+
+        # Reshape for S3Gen
+        speech_tokens = mx.expand_dims(speech_tokens, 0)
+
+        # Generate waveform with S3Gen
+        wav = self.s3gen(
+            speech_tokens=speech_tokens,
+            ref_dict=conds.gen,
+            finalize=True,
+        )
+
+        # Flatten to 1D if needed
+        if wav.ndim == 2:
+            wav = wav.squeeze(0)
+
+        # Calculate timing and metrics
+        processing_time = time.time() - start_time
+        samples = wav.shape[0]
+        audio_duration_seconds = samples / self.sample_rate
+
+        # Format duration as HH:MM:SS.mmm
+        duration_hours = int(audio_duration_seconds // 3600)
+        duration_mins = int((audio_duration_seconds % 3600) // 60)
+        duration_secs = int(audio_duration_seconds % 60)
+        duration_ms = int((audio_duration_seconds % 1) * 1000)
+        duration_str = f"{duration_hours:02d}:{duration_mins:02d}:{duration_secs:02d}.{duration_ms:03d}"
+
+        # Calculate real-time factor
+        rtf = (
+            processing_time / audio_duration_seconds
+            if audio_duration_seconds > 0
+            else 0
+        )
+
+        yield GenerationResult(
+            audio=wav,
+            samples=samples,
+            sample_rate=self.sample_rate,
+            segment_idx=0,
+            token_count=token_count,
+            audio_duration=duration_str,
+            real_time_factor=round(rtf, 2),
+            prompt={
+                "tokens": token_count,
+                "tokens-per-sec": (
+                    round(token_count / processing_time, 2)
+                    if processing_time > 0
+                    else 0
+                ),
+            },
+            audio_samples={
+                "samples": samples,
+                "samples-per-sec": (
+                    round(samples / processing_time, 2) if processing_time > 0 else 0
+                ),
+            },
+            processing_time_seconds=processing_time,
+            peak_memory_usage=mx.get_peak_memory() / 1e9,
+        )
+
+        # Clear cache after generation
+        mx.clear_cache()

--- a/mlx_audio/tts/models/chatterbox/config.json
+++ b/mlx_audio/tts/models/chatterbox/config.json
@@ -1,0 +1,24 @@
+{
+  "model_type": "chatterbox",
+  "t3_config": {
+    "text_tokens_dict_size": 704,
+    "start_text_token": 255,
+    "stop_text_token": 0,
+    "max_text_tokens": 2048,
+    "speech_tokens_dict_size": 8194,
+    "start_speech_token": 6561,
+    "stop_speech_token": 6562,
+    "max_speech_tokens": 4096,
+    "llama_config_name": "Llama_520M",
+    "input_pos_emb": "learned",
+    "speech_cond_prompt_len": 150,
+    "encoder_type": "voice_encoder",
+    "speaker_embed_size": 256,
+    "use_perceiver_resampler": true,
+    "emotion_adv": true
+  },
+  "s3_sr": 16000,
+  "s3gen_sr": 24000,
+  "enc_cond_len": 96000,
+  "dec_cond_len": 240000
+}

--- a/mlx_audio/tts/models/chatterbox/config.py
+++ b/mlx_audio/tts/models/chatterbox/config.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from ..base import BaseModelArgs
+
+LLAMA_520M_CONFIG = {
+    "model_type": "llama",
+    "vocab_size": 8,  # Unused due to custom input layers
+    "hidden_size": 1024,
+    "num_hidden_layers": 30,
+    "intermediate_size": 4096,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 16,
+    "head_dim": 64,
+    "max_position_embeddings": 131072,
+    "rms_norm_eps": 1e-05,
+    "rope_theta": 500000.0,
+    "rope_scaling": {
+        "factor": 8.0,
+        "high_freq_factor": 4.0,
+        "low_freq_factor": 1.0,
+        "original_max_position_embeddings": 8192,
+        "rope_type": "llama3",
+    },
+    "attention_bias": False,
+    "mlp_bias": False,
+    "tie_word_embeddings": False,
+}
+
+LLAMA_CONFIGS = {
+    "Llama_520M": LLAMA_520M_CONFIG,
+}
+
+
+@dataclass
+class T3Config:
+    """Configuration for T3 (Token-to-Token) model."""
+
+    # Text token configuration
+    text_tokens_dict_size: int = 704  # English: 704, Multilingual: 2454
+    start_text_token: int = 255
+    stop_text_token: int = 0
+    max_text_tokens: int = 2048
+
+    # Speech token configuration
+    speech_tokens_dict_size: int = 8194
+    start_speech_token: int = 6561
+    stop_speech_token: int = 6562
+    max_speech_tokens: int = 4096
+
+    # Model architecture
+    llama_config_name: str = "Llama_520M"
+    input_pos_emb: str = "learned"  # "learned" or "rope"
+    speech_cond_prompt_len: int = 150
+
+    # Conditioning
+    encoder_type: str = "voice_encoder"
+    speaker_embed_size: int = 256
+    use_perceiver_resampler: bool = True
+    emotion_adv: bool = True
+
+    @property
+    def n_channels(self) -> int:
+        """Get hidden size from LLaMA config."""
+        return LLAMA_CONFIGS[self.llama_config_name]["hidden_size"]
+
+    @property
+    def is_multilingual(self) -> bool:
+        """Check if model is multilingual."""
+        return self.text_tokens_dict_size == 2454
+
+    @classmethod
+    def english_only(cls) -> "T3Config":
+        """Create configuration for English-only TTS model."""
+        return cls(text_tokens_dict_size=704)
+
+    @classmethod
+    def multilingual(cls) -> "T3Config":
+        """Create configuration for multilingual TTS model."""
+        return cls(text_tokens_dict_size=2454)
+
+
+@dataclass
+class ModelConfig(BaseModelArgs):
+    """Main configuration for Chatterbox TTS model."""
+
+    # Model type for auto-detection
+    model_type: str = "chatterbox"
+
+    # Model components
+    t3_config: T3Config = None
+
+    # Sample rates
+    s3_sr: int = 16000  # S3 tokenizer sample rate
+    s3gen_sr: int = 24000  # S3Gen output sample rate
+    sample_rate: int = 24000  # Output sample rate (alias for s3gen_sr)
+
+    # Conditioning lengths
+    enc_cond_len: int = 6 * 16000  # 6 seconds at 16kHz
+    dec_cond_len: int = 10 * 24000  # 10 seconds at 24kHz
+
+    # Model path (set by load_model for tokenizer initialization)
+    model_path: str = None
+
+    def __post_init__(self):
+        if self.t3_config is None:
+            self.t3_config = T3Config.english_only()
+
+    @classmethod
+    def from_dict(cls, config: Dict[str, Any]) -> "ModelConfig":
+        """Create config from dictionary."""
+        t3_config = None
+        if "t3_config" in config:
+            t3_config = T3Config(**config["t3_config"])
+
+        return cls(
+            model_type=config.get("model_type", "chatterbox"),
+            t3_config=t3_config,
+            s3_sr=config.get("s3_sr", 16000),
+            s3gen_sr=config.get("s3gen_sr", 24000),
+            sample_rate=config.get("sample_rate", config.get("s3gen_sr", 24000)),
+            enc_cond_len=config.get("enc_cond_len", 6 * 16000),
+            dec_cond_len=config.get("dec_cond_len", 10 * 24000),
+            model_path=config.get("model_path"),
+        )

--- a/mlx_audio/tts/models/chatterbox/s3gen/__init__.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/__init__.py
@@ -1,0 +1,21 @@
+from .decoder import ConditionalDecoder
+from .f0_predictor import ConvRNNF0Predictor
+from .flow import CausalMaskedDiffWithXvec
+from .flow_matching import CausalConditionalCFM
+from .hifigan import HiFTGenerator, Snake
+from .mel import mel_spectrogram
+from .s3gen import S3Token2Mel, S3Token2Wav
+from .xvector import CAMPPlus
+
+__all__ = [
+    "HiFTGenerator",
+    "Snake",
+    "ConvRNNF0Predictor",
+    "CAMPPlus",
+    "ConditionalDecoder",
+    "CausalConditionalCFM",
+    "CausalMaskedDiffWithXvec",
+    "S3Token2Mel",
+    "S3Token2Wav",
+    "mel_spectrogram",
+]

--- a/mlx_audio/tts/models/chatterbox/s3gen/decoder.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/decoder.py
@@ -1,0 +1,359 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from .matcha.decoder import (
+    Block1D,
+    Downsample1D,
+    ResnetBlock1D,
+    SinusoidalPosEmb,
+    TimestepEmbedding,
+    Upsample1D,
+)
+from .matcha.transformer import BasicTransformerBlock
+
+
+class CausalConv1d(nn.Module):
+    """Causal 1D convolution with left padding."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+        bias: bool = True,
+    ):
+        super().__init__()
+        assert stride == 1, "CausalConv1d only supports stride=1"
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=0,
+            dilation=dilation,
+            bias=bias,
+        )
+        self.causal_padding = kernel_size - 1
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+        # Pad on the left for causal convolution (time axis is now 1)
+        x = mx.pad(x, [(0, 0), (self.causal_padding, 0), (0, 0)])
+        x = self.conv(x)
+        x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+        return x
+
+
+class CausalBlock1D(nn.Module):
+    """
+    Causal 1D block with LayerNorm (matches original).
+
+    Unlike Block1D which uses GroupNorm, CausalBlock1D uses LayerNorm
+    as per the original Chatterbox implementation.
+    """
+
+    def __init__(self, dim: int, dim_out: int):
+        super().__init__()
+        self.conv = CausalConv1d(dim, dim_out, 3)
+        self.norm = nn.LayerNorm(dim_out)
+
+    def __call__(self, x: mx.array, mask: mx.array) -> mx.array:
+        output = self.conv(x * mask)
+        # Transpose to (B, T, C), apply LayerNorm, transpose back
+        output = mx.swapaxes(output, 1, 2)  # (B, C, T) -> (B, T, C)
+        output = self.norm(output)
+        output = mx.swapaxes(output, 1, 2)  # (B, T, C) -> (B, C, T)
+        output = nn.mish(output)
+        return output * mask
+
+
+class CausalResnetBlock1D(ResnetBlock1D):
+    """Causal ResNet block."""
+
+    def __init__(self, dim: int, dim_out: int, time_emb_dim: int, groups: int = 8):
+        super().__init__(dim, dim_out, time_emb_dim, groups)
+        self.block1 = CausalBlock1D(dim, dim_out)
+        self.block2 = CausalBlock1D(dim_out, dim_out)
+
+
+class DownBlock(nn.Module):
+    """Container for down block components."""
+
+    def __init__(self, resnet, transformer_blocks, downsample):
+        super().__init__()
+        self.resnet = resnet
+        # Store transformer blocks with indexed names for proper weight loading
+        for i, block in enumerate(transformer_blocks):
+            setattr(self, f"transformer_{i}", block)
+        self.n_transformer = len(transformer_blocks)
+        self.downsample = downsample
+
+    @property
+    def transformer_blocks(self):
+        return [getattr(self, f"transformer_{i}") for i in range(self.n_transformer)]
+
+
+class MidBlock(nn.Module):
+    """Container for mid block components."""
+
+    def __init__(self, resnet, transformer_blocks):
+        super().__init__()
+        self.resnet = resnet
+        for i, block in enumerate(transformer_blocks):
+            setattr(self, f"transformer_{i}", block)
+        self.n_transformer = len(transformer_blocks)
+
+    @property
+    def transformer_blocks(self):
+        return [getattr(self, f"transformer_{i}") for i in range(self.n_transformer)]
+
+
+class UpBlock(nn.Module):
+    """Container for up block components."""
+
+    def __init__(self, resnet, transformer_blocks, upsample):
+        super().__init__()
+        self.resnet = resnet
+        for i, block in enumerate(transformer_blocks):
+            setattr(self, f"transformer_{i}", block)
+        self.n_transformer = len(transformer_blocks)
+        self.upsample = upsample
+
+    @property
+    def transformer_blocks(self):
+        return [getattr(self, f"transformer_{i}") for i in range(self.n_transformer)]
+
+
+class ConditionalDecoder(nn.Module):
+    """
+    Conditional U-Net decoder for flow matching.
+
+    This is the Chatterbox-specific decoder that uses causal blocks
+    for streaming TTS generation.
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 320,
+        out_channels: int = 80,
+        causal: bool = True,
+        channels: list = [256],
+        dropout: float = 0.0,
+        attention_head_dim: int = 64,
+        n_blocks: int = 4,
+        num_mid_blocks: int = 12,
+        num_heads: int = 8,
+        act_fn: str = "gelu",
+    ):
+        super().__init__()
+        channels = tuple(channels)
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.causal = causal
+
+        # Time embeddings
+        self.time_embeddings = SinusoidalPosEmb(in_channels)
+        time_embed_dim = channels[0] * 4
+        self.time_mlp = TimestepEmbedding(
+            in_channels=in_channels,
+            time_embed_dim=time_embed_dim,
+            act_fn="silu",
+        )
+
+        # Down blocks - use indexed attributes for proper weight loading
+        output_channel = in_channels
+        for i, ch in enumerate(channels):
+            input_channel = output_channel
+            output_channel = ch
+            is_last = i == len(channels) - 1
+
+            ResBlock = CausalResnetBlock1D if causal else ResnetBlock1D
+            resnet = ResBlock(input_channel, output_channel, time_embed_dim)
+
+            transformer_blocks = [
+                BasicTransformerBlock(
+                    output_channel,
+                    num_heads,
+                    attention_head_dim,
+                    dropout,
+                    act_fn,
+                )
+                for _ in range(n_blocks)
+            ]
+
+            if not is_last:
+                downsample = Downsample1D(output_channel)
+            else:
+                downsample = (
+                    CausalConv1d(output_channel, output_channel, 3)
+                    if causal
+                    else nn.Conv1d(output_channel, output_channel, 3, padding=1)
+                )
+
+            setattr(
+                self,
+                f"down_blocks_{i}",
+                DownBlock(resnet, transformer_blocks, downsample),
+            )
+        self.n_down_blocks = len(channels)
+
+        # Mid blocks
+        for i in range(num_mid_blocks):
+            ResBlock = CausalResnetBlock1D if causal else ResnetBlock1D
+            resnet = ResBlock(channels[-1], channels[-1], time_embed_dim)
+            transformer_blocks = [
+                BasicTransformerBlock(
+                    channels[-1],
+                    num_heads,
+                    attention_head_dim,
+                    dropout,
+                    act_fn,
+                )
+                for _ in range(n_blocks)
+            ]
+            setattr(self, f"mid_blocks_{i}", MidBlock(resnet, transformer_blocks))
+        self.n_mid_blocks = num_mid_blocks
+
+        # Up blocks
+        channels_reversed = list(reversed(channels)) + [channels[0]]
+        for i in range(len(channels_reversed) - 1):
+            input_channel = channels_reversed[i] * 2
+            output_channel = channels_reversed[i + 1]
+            is_last = i == len(channels_reversed) - 2
+
+            ResBlock = CausalResnetBlock1D if causal else ResnetBlock1D
+            resnet = ResBlock(input_channel, output_channel, time_embed_dim)
+
+            transformer_blocks = [
+                BasicTransformerBlock(
+                    output_channel,
+                    num_heads,
+                    attention_head_dim,
+                    dropout,
+                    act_fn,
+                )
+                for _ in range(n_blocks)
+            ]
+
+            if not is_last:
+                upsample = Upsample1D(output_channel, use_conv_transpose=True)
+            else:
+                upsample = (
+                    CausalConv1d(output_channel, output_channel, 3)
+                    if causal
+                    else nn.Conv1d(output_channel, output_channel, 3, padding=1)
+                )
+
+            setattr(
+                self, f"up_blocks_{i}", UpBlock(resnet, transformer_blocks, upsample)
+            )
+        self.n_up_blocks = len(channels_reversed) - 1
+
+        # Final layers
+        FinalBlock = CausalBlock1D if causal else Block1D
+        self.final_block = FinalBlock(channels_reversed[-1], channels_reversed[-1])
+        self.final_proj = nn.Conv1d(channels_reversed[-1], out_channels, 1)
+
+    @property
+    def down_blocks(self):
+        return [getattr(self, f"down_blocks_{i}") for i in range(self.n_down_blocks)]
+
+    @property
+    def mid_blocks(self):
+        return [getattr(self, f"mid_blocks_{i}") for i in range(self.n_mid_blocks)]
+
+    @property
+    def up_blocks(self):
+        return [getattr(self, f"up_blocks_{i}") for i in range(self.n_up_blocks)]
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: mx.array,
+        mu: mx.array,
+        t: mx.array,
+        spks: mx.array = None,
+        cond: mx.array = None,
+    ) -> mx.array:
+        """
+        Forward pass.
+
+        Args:
+            x: Noisy input (B, in_channels, T)
+            mask: Mask (B, 1, T)
+            mu: Condition (B, channels, T)
+            t: Timestep (B,)
+            spks: Speaker embeddings (B, spk_dim)
+            cond: Additional conditioning
+
+        Returns:
+            Predicted noise (B, out_channels, T)
+        """
+        # Time embedding
+        t = self.time_embeddings(t)
+        t = self.time_mlp(t)
+
+        # Concatenate conditioning
+        x = mx.concatenate([x, mu], axis=1)
+        if spks is not None:
+            spks_expanded = mx.broadcast_to(
+                mx.expand_dims(spks, -1), (spks.shape[0], spks.shape[1], x.shape[2])
+            )
+            x = mx.concatenate([x, spks_expanded], axis=1)
+        if cond is not None:
+            x = mx.concatenate([x, cond], axis=1)
+
+        # Down blocks
+        hiddens = []
+        masks = [mask]
+        for down_block in self.down_blocks:
+            mask_down = masks[-1]
+            x = down_block.resnet(x, mask_down, t)
+
+            # Transformer blocks
+            x_t = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+            for transformer_block in down_block.transformer_blocks:
+                x_t = transformer_block(x_t, attention_mask=None, timestep=t)
+            x = mx.swapaxes(x_t, 1, 2)  # (B, T, C) -> (B, C, T)
+
+            hiddens.append(x)
+            x = down_block.downsample(x * mask_down)
+            # Downsample mask
+            masks.append(mask_down[:, :, ::2])
+
+        masks = masks[:-1]
+        mask_mid = masks[-1]
+
+        # Mid blocks
+        for mid_block in self.mid_blocks:
+            x = mid_block.resnet(x, mask_mid, t)
+
+            x_t = mx.swapaxes(x, 1, 2)
+            for transformer_block in mid_block.transformer_blocks:
+                x_t = transformer_block(x_t, attention_mask=None, timestep=t)
+            x = mx.swapaxes(x_t, 1, 2)
+
+        # Up blocks
+        for up_block in self.up_blocks:
+            mask_up = masks.pop()
+            skip = hiddens.pop()
+            # Truncate x to match skip length
+            x = mx.concatenate([x[:, :, : skip.shape[-1]], skip], axis=1)
+            x = up_block.resnet(x, mask_up, t)
+
+            x_t = mx.swapaxes(x, 1, 2)
+            for transformer_block in up_block.transformer_blocks:
+                x_t = transformer_block(x_t, attention_mask=None, timestep=t)
+            x = mx.swapaxes(x_t, 1, 2)
+
+            x = up_block.upsample(x * mask_up)
+
+        # Final layers
+        x = self.final_block(x, mask_up)
+        # final_proj: (B, C, T) -> transpose -> conv -> transpose back
+        x_proj = mx.swapaxes(x * mask_up, 1, 2)  # (B, C, T) -> (B, T, C)
+        output = self.final_proj(x_proj)
+        output = mx.swapaxes(output, 1, 2)  # (B, T, C) -> (B, C, T)
+        return output * mask

--- a/mlx_audio/tts/models/chatterbox/s3gen/f0_predictor.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/f0_predictor.py
@@ -1,0 +1,80 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class ConvRNNF0Predictor(nn.Module):
+    """
+    Convolutional F0 (fundamental frequency / pitch) predictor.
+
+    Predicts F0 from mel-spectrogram features using stacked convolutions.
+
+    Weight structure matches PyTorch nn.Sequential naming:
+    - condnet.0, condnet.2, condnet.4, condnet.6, condnet.8 (Conv1d layers)
+    - ELU activations are at indices 1, 3, 5, 7, 9 (not saved in weights)
+    """
+
+    def __init__(
+        self,
+        num_class: int = 1,
+        in_channels: int = 80,
+        cond_channels: int = 512,
+    ):
+        """
+        Args:
+            num_class: Number of output classes (1 for F0 regression)
+            in_channels: Number of input mel channels
+            cond_channels: Number of conditioning channels
+        """
+        super().__init__()
+        self.num_class = num_class
+
+        # Stack of convolutional layers with ELU activation
+        # Use list to match PyTorch nn.Sequential numbering: 0, 2, 4, 6, 8
+        # (ELU layers are at 1, 3, 5, 7, 9 but not stored in weights)
+        self.condnet = [
+            nn.Conv1d(
+                in_channels, cond_channels, kernel_size=3, padding=1
+            ),  # condnet.0
+            nn.Conv1d(
+                cond_channels, cond_channels, kernel_size=3, padding=1
+            ),  # condnet.2
+            nn.Conv1d(
+                cond_channels, cond_channels, kernel_size=3, padding=1
+            ),  # condnet.4
+            nn.Conv1d(
+                cond_channels, cond_channels, kernel_size=3, padding=1
+            ),  # condnet.6
+            nn.Conv1d(
+                cond_channels, cond_channels, kernel_size=3, padding=1
+            ),  # condnet.8
+        ]
+
+        # Final classifier
+        self.classifier = nn.Linear(cond_channels, num_class)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """
+        Predict F0 from mel-spectrogram.
+
+        Args:
+            x: Mel-spectrogram (B, C, T)
+
+        Returns:
+            F0 predictions (B, T)
+        """
+        # x is (B, C, T), but MLX Conv1d expects (B, T, C)
+        x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+
+        # Convolutional stack with ELU activations
+        for conv in self.condnet:
+            x = nn.elu(conv(x))
+
+        # x is now (B, T, C) which is correct for linear layer
+
+        # Classify and take absolute value
+        x = self.classifier(x)
+        x = mx.squeeze(x, axis=-1)  # (B, T, 1) -> (B, T)
+
+        return mx.abs(x)

--- a/mlx_audio/tts/models/chatterbox/s3gen/flow.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/flow.py
@@ -1,0 +1,151 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from typing import Dict, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class CausalMaskedDiffWithXvec(nn.Module):
+    """Causal masked diffusion model with speaker embeddings for streaming TTS."""
+
+    def __init__(
+        self,
+        input_size: int = 512,
+        output_size: int = 80,
+        spk_embed_dim: int = 192,
+        output_type: str = "mel",
+        vocab_size: int = 6561,
+        input_frame_rate: int = 25,
+        only_mask_loss: bool = True,
+        token_mel_ratio: int = 2,
+        pre_lookahead_len: int = 3,
+        encoder: nn.Module = None,
+        decoder: nn.Module = None,
+        decoder_conf: Dict = None,
+        mel_feat_conf: Dict = None,
+    ):
+        """
+        Args:
+            input_size: Size of input token embeddings
+            output_size: Size of output mel features
+            spk_embed_dim: Dimension of speaker embeddings
+            output_type: Type of output ("mel")
+            vocab_size: Size of speech token vocabulary
+            input_frame_rate: Frame rate of input tokens (Hz)
+            only_mask_loss: Whether to use only masked loss
+            token_mel_ratio: Ratio of tokens to mel frames (after upsampling)
+            pre_lookahead_len: Length of lookahead window
+            encoder: UpsampleConformerEncoder instance
+            decoder: ConditionalDecoder instance
+            decoder_conf: Decoder configuration dict
+            mel_feat_conf: Mel feature configuration dict
+        """
+        super().__init__()
+        self.input_size = input_size
+        self.output_size = output_size
+        self.decoder_conf = decoder_conf or {}
+        self.mel_feat_conf = mel_feat_conf or {}
+        self.vocab_size = vocab_size
+        self.output_type = output_type
+        self.input_frame_rate = input_frame_rate
+
+        self.input_embedding = nn.Embedding(vocab_size, input_size)
+        self.spk_embed_affine_layer = nn.Linear(spk_embed_dim, output_size)
+        self.encoder = encoder
+        self.encoder_proj = nn.Linear(self.encoder.output_size(), output_size)
+        self.decoder = decoder
+        self.only_mask_loss = only_mask_loss
+        self.token_mel_ratio = token_mel_ratio
+        self.pre_lookahead_len = pre_lookahead_len
+
+    def inference(
+        self,
+        token: mx.array,
+        token_len: mx.array,
+        prompt_token: mx.array,
+        prompt_token_len: mx.array,
+        prompt_feat: mx.array,
+        prompt_feat_len: mx.array,
+        embedding: mx.array,
+        finalize: bool,
+    ):
+        """
+        Inference for streaming TTS.
+
+        Args:
+            token: Speech tokens (1, T)
+            token_len: Token lengths (1,)
+            prompt_token: Prompt tokens (1, T_p)
+            prompt_token_len: Prompt token lengths (1,)
+            prompt_feat: Prompt mel features (1, T_p_mel, D)
+            prompt_feat_len: Prompt feature lengths (1,)
+            embedding: Speaker embedding (1, spk_embed_dim)
+            finalize: Whether this is the final chunk
+
+        Returns:
+            feat: Generated mel features (1, D, T_mel)
+            flow_cache: Flow cache (None for causal version)
+        """
+        assert token.shape[0] == 1
+
+        # Speaker embedding projection
+        embedding = embedding / mx.linalg.norm(
+            embedding, axis=1, keepdims=True
+        )  # Normalize
+        embedding = self.spk_embed_affine_layer(embedding)
+
+        # Concatenate prompt and new tokens
+        token = mx.concatenate([prompt_token, token], axis=1)
+        token_len = prompt_token_len + token_len
+
+        # Create mask
+        batch_size = token_len.shape[0]
+        max_len = int(mx.max(token_len).item())
+        seq_range = mx.arange(max_len)
+        seq_range_expand = mx.expand_dims(seq_range, 0)
+        seq_range_expand = mx.broadcast_to(seq_range_expand, (batch_size, max_len))
+        seq_length_expand = mx.expand_dims(token_len, -1)
+        mask = seq_range_expand < seq_length_expand
+        mask = mx.expand_dims(mask, -1).astype(embedding.dtype)
+
+        # Embed tokens
+        # MLX Embedding doesn't have num_embeddings attr, use weight shape instead
+        num_embeddings = self.input_embedding.weight.shape[0]
+        token = mx.clip(token, 0, num_embeddings - 1)
+        token = self.input_embedding(token) * mask
+
+        # Encode
+        h, h_lengths = self.encoder(token, token_len)
+
+        # Trim lookahead for streaming (unless finalizing)
+        if not finalize:
+            h = h[:, : -self.pre_lookahead_len * self.token_mel_ratio]
+
+        mel_len1 = prompt_feat.shape[1]
+        mel_len2 = h.shape[1] - prompt_feat.shape[1]
+        h = self.encoder_proj(h)
+
+        # Get conditions (prompt mel features)
+        conds = mx.zeros([1, mel_len1 + mel_len2, self.output_size], dtype=h.dtype)
+        conds[:, :mel_len1] = prompt_feat
+        conds = mx.transpose(conds, [0, 2, 1])  # (1, D, T)
+
+        # Create mask for decoder (float dtype for multiplication)
+        total_len = mel_len1 + mel_len2
+        mask = mx.ones([1, 1, total_len], dtype=h.dtype)
+
+        # Generate mel features
+        feat, _ = self.decoder(
+            mu=mx.transpose(h, [0, 2, 1]),
+            mask=mask,
+            spks=embedding,
+            cond=conds,
+            n_timesteps=10,
+        )
+
+        # Extract only the new portion (after prompt)
+        feat = feat[:, :, mel_len1:]
+        assert feat.shape[2] == mel_len2
+
+        return feat, None

--- a/mlx_audio/tts/models/chatterbox/s3gen/flow_matching.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/flow_matching.py
@@ -1,0 +1,177 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+# Original: chatterbox/models/s3gen/flow_matching.py
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .matcha.flow_matching import BASECFM, CFMParams
+
+# Default CFM parameters for Chatterbox
+CFM_PARAMS = CFMParams()
+
+
+class ConditionalCFM(BASECFM):
+    """Conditional Flow Matching with Classifier-Free Guidance."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        cfm_params: CFMParams,
+        n_spks: int = 1,
+        spk_emb_dim: int = 64,
+        estimator: nn.Module = None,
+    ):
+        super().__init__(
+            n_feats=in_channels,
+            cfm_params=cfm_params,
+            n_spks=n_spks,
+            spk_emb_dim=spk_emb_dim,
+        )
+        self.t_scheduler = cfm_params.t_scheduler
+        self.training_cfg_rate = cfm_params.training_cfg_rate
+        self.inference_cfg_rate = cfm_params.inference_cfg_rate
+        self.estimator = estimator
+
+    def __call__(
+        self,
+        mu: mx.array,
+        mask: mx.array,
+        n_timesteps: int,
+        temperature: float = 1.0,
+        spks: mx.array = None,
+        cond: mx.array = None,
+        prompt_len: int = 0,
+        flow_cache: mx.array = None,
+    ) -> tuple:
+        """
+        Forward diffusion with optional caching.
+
+        Returns:
+            Tuple of (generated_mel, flow_cache)
+        """
+        if flow_cache is None:
+            flow_cache = mx.zeros((1, 80, 0, 2))
+
+        z = mx.random.normal(mu.shape) * temperature
+        cache_size = flow_cache.shape[2]
+
+        # Fix prompt and overlap part
+        if cache_size != 0:
+            z = mx.concatenate([flow_cache[:, :, :, 0], z[:, :, cache_size:]], axis=2)
+            mu = mx.concatenate([flow_cache[:, :, :, 1], mu[:, :, cache_size:]], axis=2)
+
+        z_cache = mx.concatenate([z[:, :, :prompt_len], z[:, :, -34:]], axis=2)
+        mu_cache = mx.concatenate([mu[:, :, :prompt_len], mu[:, :, -34:]], axis=2)
+        flow_cache = mx.stack([z_cache, mu_cache], axis=-1)
+
+        # Time span
+        t_span = mx.linspace(0, 1, n_timesteps + 1)
+        if self.t_scheduler == "cosine":
+            t_span = 1 - mx.cos(t_span * 0.5 * math.pi)
+
+        result = self.solve_euler(
+            z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond
+        )
+        return result, flow_cache
+
+    def solve_euler(
+        self,
+        x: mx.array,
+        t_span: mx.array,
+        mu: mx.array,
+        mask: mx.array,
+        spks: mx.array,
+        cond: mx.array,
+    ) -> mx.array:
+        """
+        Euler solver with Classifier-Free Guidance.
+        """
+        t = mx.expand_dims(t_span[0], 0)
+        dt = t_span[1] - t_span[0]
+
+        sol = []
+
+        # Prepare batch for CFG
+        T_len = x.shape[2]
+        x_in = mx.zeros((2, 80, T_len))
+        mask_in = mx.zeros((2, 1, T_len))
+        mu_in = mx.zeros((2, 80, T_len))
+        t_in = mx.zeros(2)
+        spks_in = mx.zeros((2, 80))
+        cond_in = mx.zeros((2, 80, T_len))
+
+        for step in range(1, len(t_span)):
+            # Prepare inputs for CFG
+            x_in = mx.concatenate([x, x], axis=0)
+            mask_in = mx.concatenate([mask, mask], axis=0)
+            mu_in = mx.concatenate([mu, mx.zeros_like(mu)], axis=0)
+            t_in = mx.concatenate([t, t], axis=0)
+            if spks is not None:
+                spks_in = mx.concatenate([spks, mx.zeros_like(spks)], axis=0)
+            if cond is not None:
+                cond_in = mx.concatenate([cond, mx.zeros_like(cond)], axis=0)
+
+            # Forward estimator
+            dphi_dt = self.estimator(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+
+            # Split and apply CFG
+            dphi_dt_cond = dphi_dt[: x.shape[0]]
+            dphi_dt_uncond = dphi_dt[x.shape[0] :]
+            dphi_dt = (
+                1.0 + self.inference_cfg_rate
+            ) * dphi_dt_cond - self.inference_cfg_rate * dphi_dt_uncond
+
+            x = x + dt * dphi_dt
+            t = t + dt
+            sol.append(x)
+
+            if step < len(t_span) - 1:
+                dt = t_span[step + 1] - t
+
+        return sol[-1]
+
+
+class CausalConditionalCFM(ConditionalCFM):
+    """Causal Conditional Flow Matching with fixed noise."""
+
+    def __init__(
+        self,
+        in_channels: int = 240,
+        cfm_params: CFMParams = CFM_PARAMS,
+        n_spks: int = 1,
+        spk_emb_dim: int = 80,
+        estimator: nn.Module = None,
+    ):
+        super().__init__(in_channels, cfm_params, n_spks, spk_emb_dim, estimator)
+        # Pre-generate random noise for deterministic generation
+        self.rand_noise = mx.random.normal((1, 80, 50 * 300))
+
+    def __call__(
+        self,
+        mu: mx.array,
+        mask: mx.array,
+        n_timesteps: int,
+        temperature: float = 1.0,
+        spks: mx.array = None,
+        cond: mx.array = None,
+    ) -> tuple:
+        """
+        Forward diffusion with fixed noise for causal generation.
+
+        Returns:
+            Tuple of (generated_mel, None)
+        """
+        T = mu.shape[2]
+        z = self.rand_noise[:, :, :T] * temperature
+
+        # Time span
+        t_span = mx.linspace(0, 1, n_timesteps + 1)
+        if self.t_scheduler == "cosine":
+            t_span = 1 - mx.cos(t_span * 0.5 * math.pi)
+
+        result = self.solve_euler(
+            z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond
+        )
+        return result, None

--- a/mlx_audio/tts/models/chatterbox/s3gen/hifigan.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/hifigan.py
@@ -1,0 +1,701 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import math
+from typing import Dict, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def hann_window_periodic(size: int) -> mx.array:
+    """
+    Create periodic Hann window (fftbins=True), matching scipy.signal.get_window('hann', size, fftbins=True).
+
+    Uses size in denominator instead of size-1, which is the correct window for STFT.
+    """
+    return mx.array([0.5 * (1 - math.cos(2 * math.pi * n / size)) for n in range(size)])
+
+
+def get_padding(kernel_size: int, dilation: int = 1) -> int:
+    """Calculate padding for 'same' convolution."""
+    return int((kernel_size * dilation - dilation) / 2)
+
+
+class Snake(nn.Module):
+    """
+    Snake activation function: x + (1/α) * sin²(αx)
+
+    Periodic activation function from:
+    https://arxiv.org/abs/2006.08195
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        alpha: float = 1.0,
+        alpha_trainable: bool = True,
+        alpha_logscale: bool = False,
+    ):
+        """
+        Args:
+            in_features: Number of input features (channels)
+            alpha: Initial alpha value (frequency parameter)
+            alpha_trainable: Whether alpha should be trainable
+            alpha_logscale: Whether to use log-scale for alpha
+        """
+        super().__init__()
+        self.in_features = in_features
+        self.alpha_logscale = alpha_logscale
+
+        # Initialize alpha
+        if alpha_logscale:
+            # Log scale: initialized to zeros
+            self.alpha = mx.zeros(in_features) * alpha
+        else:
+            # Linear scale: initialized to ones * alpha
+            self.alpha = mx.ones(in_features) * alpha
+
+        # Small constant to avoid division by zero
+        self.no_div_by_zero = 1e-9
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """
+        Forward pass: x + (1/α) * sin²(αx)
+
+        Args:
+            x: Input tensor of shape (B, C, T)
+
+        Returns:
+            Output tensor of same shape
+        """
+        # Reshape alpha to align with x: (C,) -> (1, C, 1)
+        alpha = mx.reshape(self.alpha, (1, -1, 1))
+
+        # Apply log scale if needed
+        if self.alpha_logscale:
+            alpha = mx.exp(alpha)
+
+        # Snake activation: x + (1/α) * sin²(αx)
+        return x + (1.0 / (alpha + self.no_div_by_zero)) * mx.power(
+            mx.sin(x * alpha), 2
+        )
+
+
+class ResBlock(nn.Module):
+    """Residual block with Snake activation for HiFi-GAN."""
+
+    def __init__(
+        self,
+        channels: int = 512,
+        kernel_size: int = 3,
+        dilations: List[int] = [1, 3, 5],
+    ):
+        super().__init__()
+        self.channels = channels
+        self.convs1 = []
+        self.convs2 = []
+        self.activations1 = []
+        self.activations2 = []
+
+        for dilation in dilations:
+            # First conv in each dilation block
+            self.convs1.append(
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    stride=1,
+                    padding=get_padding(kernel_size, dilation),
+                    dilation=dilation,
+                )
+            )
+            # Second conv (dilation=1)
+            self.convs2.append(
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    stride=1,
+                    padding=get_padding(kernel_size, 1),
+                )
+            )
+            # Snake activations
+            self.activations1.append(Snake(channels, alpha_logscale=False))
+            self.activations2.append(Snake(channels, alpha_logscale=False))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """
+        Args:
+            x: Input tensor (B, C, T)
+
+        Returns:
+            Output tensor (B, C, T)
+        """
+        for i in range(len(self.convs1)):
+            xt = self.activations1[i](x)
+            # Conv1d: (B, C, T) -> transpose -> conv -> transpose back
+            xt = mx.swapaxes(xt, 1, 2)  # (B, C, T) -> (B, T, C)
+            xt = self.convs1[i](xt)
+            xt = mx.swapaxes(xt, 1, 2)  # (B, T, C) -> (B, C, T)
+            xt = self.activations2[i](xt)
+            xt = mx.swapaxes(xt, 1, 2)  # (B, C, T) -> (B, T, C)
+            xt = self.convs2[i](xt)
+            xt = mx.swapaxes(xt, 1, 2)  # (B, T, C) -> (B, C, T)
+            x = xt + x  # Residual connection
+        return x
+
+
+class SineGen(nn.Module):
+    """
+    Sine wave generator for harmonic synthesis.
+
+    Generates sine waves with harmonics based on F0 (fundamental frequency).
+    """
+
+    def __init__(
+        self,
+        samp_rate: int,
+        harmonic_num: int = 0,
+        sine_amp: float = 0.1,
+        noise_std: float = 0.003,
+        voiced_threshold: float = 0,
+    ):
+        """
+        Args:
+            samp_rate: Sampling rate in Hz
+            harmonic_num: Number of harmonic overtones
+            sine_amp: Amplitude of sine waveform
+            noise_std: Standard deviation of Gaussian noise
+            voiced_threshold: F0 threshold for voiced/unvoiced classification
+        """
+        super().__init__()
+        self.sine_amp = sine_amp
+        self.noise_std = noise_std
+        self.harmonic_num = harmonic_num
+        self.sampling_rate = samp_rate
+        self.voiced_threshold = voiced_threshold
+
+    def _f02uv(self, f0: mx.array) -> mx.array:
+        """Convert F0 to voiced/unvoiced signal."""
+        return (f0 > self.voiced_threshold).astype(mx.float32)
+
+    def __call__(self, f0: mx.array) -> tuple:
+        """
+        Generate sine waves from F0.
+
+        Args:
+            f0: Fundamental frequency tensor (B, 1, T) in Hz
+
+        Returns:
+            Tuple of (sine_waves, uv, noise)
+        """
+        B, _, T = f0.shape
+
+        # Create frequency matrix for harmonics using broadcasting (no loop)
+        # harmonic_multipliers: [1, 2, 3, ..., harmonic_num+1] shape (1, H, 1)
+        harmonic_multipliers = mx.arange(1, self.harmonic_num + 2).reshape(1, -1, 1)
+        # f0 is (B, 1, T), result is (B, H, T)
+        F_mat = f0 * harmonic_multipliers / self.sampling_rate
+
+        # Calculate phase
+        theta_mat = 2 * math.pi * (mx.cumsum(F_mat, axis=-1) % 1)
+
+        # Random phase offset for each harmonic (no loop)
+        phase_vec = mx.random.uniform(
+            low=-math.pi, high=math.pi, shape=(B, self.harmonic_num + 1, 1)
+        )
+        # Zero out fundamental frequency phase offset (index 0) using where
+        mask = mx.arange(self.harmonic_num + 1).reshape(1, -1, 1) > 0
+        phase_vec = mx.where(mask, phase_vec, 0.0)
+
+        # Generate sine waveforms
+        sine_waves = self.sine_amp * mx.sin(theta_mat + phase_vec)
+
+        # Generate voiced/unvoiced signal
+        uv = self._f02uv(f0)
+
+        # Noise: larger for unvoiced, smaller for voiced
+        noise_amp = uv * self.noise_std + (1 - uv) * self.sine_amp / 3
+        noise = noise_amp * mx.random.normal(shape=sine_waves.shape)
+
+        # Voiced regions use sine, unvoiced use noise
+        sine_waves = sine_waves * uv + noise
+
+        return sine_waves, uv, noise
+
+
+class SourceModuleHnNSF(nn.Module):
+    """
+    Neural Source Filter (NSF) module for harmonic and noise generation.
+
+    Combines multiple sine harmonics into a single excitation signal.
+    """
+
+    def __init__(
+        self,
+        sampling_rate: int,
+        upsample_scale: int,
+        harmonic_num: int = 0,
+        sine_amp: float = 0.1,
+        add_noise_std: float = 0.003,
+        voiced_threshod: float = 0,
+    ):
+        super().__init__()
+        self.sine_amp = sine_amp
+        self.noise_std = add_noise_std
+
+        # Sine generator for harmonics
+        self.l_sin_gen = SineGen(
+            sampling_rate, harmonic_num, sine_amp, add_noise_std, voiced_threshod
+        )
+
+        # Linear layer to merge harmonics
+        self.l_linear = nn.Linear(harmonic_num + 1, 1)
+
+    def __call__(self, x: mx.array) -> tuple:
+        """
+        Generate harmonic and noise sources from F0.
+
+        Args:
+            x: F0 tensor (B, T, 1)
+
+        Returns:
+            Tuple of (sine_merge, noise, uv)
+        """
+        # Generate sine harmonics
+        sine_wavs, uv, _ = self.l_sin_gen(mx.swapaxes(x, 1, 2))
+        sine_wavs = mx.swapaxes(sine_wavs, 1, 2)
+        uv = mx.swapaxes(uv, 1, 2)
+
+        # Merge harmonics
+        sine_merge = mx.tanh(self.l_linear(sine_wavs))
+
+        # Source for noise branch, in the same shape as uv
+        noise = mx.random.normal(shape=uv.shape) * self.sine_amp / 3
+
+        return sine_merge, noise, uv
+
+
+def stft(x: mx.array, n_fft: int, hop_length: int, window: mx.array) -> tuple:
+    """
+    Short-Time Fourier Transform.
+
+    Args:
+        x: Input signal (B, T)
+        n_fft: FFT size
+        hop_length: Hop length
+        window: Window function
+
+    Returns:
+        Tuple of (real, imag) each of shape (B, n_fft//2+1, num_frames)
+    """
+    B, T = x.shape
+
+    # Pad signal
+    pad_length = n_fft // 2
+    x_padded = mx.pad(x, [(0, 0), (pad_length, pad_length)])
+
+    # Calculate number of frames
+    num_frames = (x_padded.shape[1] - n_fft) // hop_length + 1
+
+    # Create frames using vectorized slicing (avoid Python loop)
+    # Generate all frame start indices at once
+    frame_starts = mx.arange(num_frames) * hop_length  # (num_frames,)
+    sample_offsets = mx.arange(n_fft)  # (n_fft,)
+    # All indices: (num_frames, n_fft) where indices[f, s] = frame_starts[f] + s
+    all_indices = frame_starts[:, None] + sample_offsets[None, :]  # (num_frames, n_fft)
+    # Gather frames: x_padded is (B, T), gather along axis 1
+    # Result shape: (B, num_frames, n_fft)
+    frames = mx.take(x_padded, all_indices.flatten(), axis=1).reshape(
+        B, num_frames, n_fft
+    )
+    # Transpose to (B, n_fft, num_frames)
+    frames = mx.swapaxes(frames, 1, 2)
+
+    # Apply window
+    window_expanded = mx.reshape(window, (1, -1, 1))
+    frames = frames * window_expanded
+
+    # FFT
+    # MLX doesn't have a direct rfft, so we use fft and take the first half
+    fft_result = mx.fft.fft(frames, axis=1)
+
+    # Take positive frequencies
+    real = mx.real(fft_result[:, : n_fft // 2 + 1, :])
+    imag = mx.imag(fft_result[:, : n_fft // 2 + 1, :])
+
+    return real, imag
+
+
+def istft(
+    magnitude: mx.array, phase: mx.array, n_fft: int, hop_length: int, window: mx.array
+) -> mx.array:
+    """
+    Inverse Short-Time Fourier Transform (pure MLX implementation).
+
+    Args:
+        magnitude: Magnitude (B, n_fft//2+1, num_frames)
+        phase: Phase (B, n_fft//2+1, num_frames)
+        n_fft: FFT size
+        hop_length: Hop length
+        window: Window function
+
+    Returns:
+        Reconstructed signal (B, T)
+    """
+    # Clip magnitude
+    magnitude = mx.clip(magnitude, a_min=None, a_max=1e2)
+
+    # Convert to complex
+    real = magnitude * mx.cos(phase)
+    imag = magnitude * mx.sin(phase)
+
+    # Create full spectrum (conjugate symmetric)
+    B, F, num_frames = real.shape
+
+    # Mirror the spectrum for negative frequencies
+    real_mirror = real[:, 1:-1, :][:, ::-1, :]
+    imag_mirror = imag[:, 1:-1, :][:, ::-1, :]
+    real_full = mx.concatenate([real, real_mirror], axis=1)
+    imag_full = mx.concatenate([imag, -imag_mirror], axis=1)
+
+    # Combine into complex
+    spectrum = real_full + 1j * imag_full
+
+    # Inverse FFT
+    frames = mx.fft.ifft(spectrum, axis=1)
+    frames = mx.real(frames)  # Take real part
+
+    # Apply window
+    window_expanded = mx.reshape(window, (1, -1, 1))
+    frames = frames * window_expanded
+
+    # Pure MLX overlap-add
+    output_length = (num_frames - 1) * hop_length + n_fft
+
+    # Create index arrays for scatter-add
+    frame_offsets = mx.arange(num_frames) * hop_length
+    sample_indices = mx.arange(n_fft)
+    # indices[f, s] = frame_offsets[f] + sample_indices[s]
+    indices = frame_offsets[:, None] + sample_indices[None, :]  # (num_frames, n_fft)
+    indices_flat = indices.flatten()  # (num_frames * n_fft,)
+
+    # Window squared for normalization - compute once (same for all batches)
+    window_sq = window**2
+    window_sum = mx.zeros(output_length)
+    window_updates = mx.tile(window_sq, (num_frames,))
+    window_sum = window_sum.at[indices_flat].add(window_updates)
+    window_sum = mx.maximum(window_sum, 1e-8)
+
+    # Vectorized overlap-add for all batch items at once
+    # frames is (B, n_fft, num_frames), need (B, num_frames, n_fft) for indexing
+    frame_data = mx.swapaxes(frames, 1, 2)  # (B, num_frames, n_fft)
+    updates = frame_data.reshape(B, -1)  # (B, num_frames * n_fft)
+
+    # Use vmap-style vectorized scatter-add via index expansion
+    # Expand indices to (B, num_frames * n_fft) - same indices for all batches
+    output = mx.zeros((B, output_length))
+    # Process with a single batched at[] operation using advanced indexing
+    # batch_indices: [0,0,...,0, 1,1,...,1, ...] for each element
+    batch_indices = mx.repeat(mx.arange(B), num_frames * n_fft)
+    flat_indices = mx.tile(indices_flat, (B,))
+    # Scatter add using 2D indexing
+    flat_output = output.flatten()
+    # Convert 2D indices to 1D: batch * output_length + sample_idx
+    linear_indices = batch_indices * output_length + flat_indices
+    flat_output = flat_output.at[linear_indices].add(updates.flatten())
+    output = flat_output.reshape(B, output_length)
+
+    # Normalize with precomputed window_sum (broadcasts across batch)
+    output = output / window_sum
+
+    # Remove padding
+    pad_length = n_fft // 2
+    output = output[:, pad_length:-pad_length]
+
+    return output
+
+
+class HiFTGenerator(nn.Module):
+    """
+    HiFi-GAN with Neural Source Filter (HiFT-Net) generator.
+
+    Combines mel-spectrogram upsampling with neural source filter
+    for high-quality speech synthesis using ISTFT.
+
+    Reference: https://arxiv.org/abs/2309.09493
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 80,
+        base_channels: int = 512,
+        nb_harmonics: int = 8,
+        sampling_rate: int = 22050,
+        nsf_alpha: float = 0.1,
+        nsf_sigma: float = 0.003,
+        nsf_voiced_threshold: float = 10,
+        upsample_rates: List[int] = [8, 8],
+        upsample_kernel_sizes: List[int] = [16, 16],
+        istft_params: Dict[str, int] = {"n_fft": 16, "hop_len": 4},
+        resblock_kernel_sizes: List[int] = [3, 7, 11],
+        resblock_dilation_sizes: List[List[int]] = [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+        source_resblock_kernel_sizes: List[int] = [7, 11],
+        source_resblock_dilation_sizes: List[List[int]] = [[1, 3, 5], [1, 3, 5]],
+        lrelu_slope: float = 0.1,
+        audio_limit: float = 0.99,
+        f0_predictor: Optional[nn.Module] = None,
+    ):
+        """
+        Args:
+            in_channels: Number of input mel channels
+            base_channels: Base number of channels
+            nb_harmonics: Number of harmonics for NSF
+            sampling_rate: Audio sampling rate
+            nsf_alpha: NSF sine amplitude
+            nsf_sigma: NSF noise std
+            nsf_voiced_threshold: F0 threshold for voiced/unvoiced
+            upsample_rates: Upsampling factors
+            upsample_kernel_sizes: Upsampling kernel sizes
+            istft_params: ISTFT parameters (n_fft, hop_len)
+            resblock_kernel_sizes: ResBlock kernel sizes
+            resblock_dilation_sizes: ResBlock dilations
+            source_resblock_kernel_sizes: Source ResBlock kernel sizes
+            source_resblock_dilation_sizes: Source ResBlock dilations
+            lrelu_slope: LeakyReLU negative slope
+            audio_limit: Audio clipping limit
+            f0_predictor: Optional F0 prediction module
+        """
+        super().__init__()
+
+        self.out_channels = 1
+        self.nb_harmonics = nb_harmonics
+        self.sampling_rate = sampling_rate
+        self.istft_params = istft_params
+        self.lrelu_slope = lrelu_slope
+        self.audio_limit = audio_limit
+
+        self.num_kernels = len(resblock_kernel_sizes)
+        self.num_upsamples = len(upsample_rates)
+
+        upsample_scale = math.prod(upsample_rates) * istft_params["hop_len"]
+
+        # Neural Source Filter
+        self.m_source = SourceModuleHnNSF(
+            sampling_rate=sampling_rate,
+            upsample_scale=upsample_scale,
+            harmonic_num=nb_harmonics,
+            sine_amp=nsf_alpha,
+            add_noise_std=nsf_sigma,
+            voiced_threshod=nsf_voiced_threshold,
+        )
+
+        # F0 upsampler
+        self.f0_upsample_scale = upsample_scale
+
+        # Pre-convolution
+        self.conv_pre = nn.Conv1d(in_channels, base_channels, 7, stride=1, padding=3)
+
+        # Upsampling layers
+        self.ups = []
+        for i, (u, k) in enumerate(zip(upsample_rates, upsample_kernel_sizes)):
+            self.ups.append(
+                nn.ConvTranspose1d(
+                    base_channels // (2**i),
+                    base_channels // (2 ** (i + 1)),
+                    k,
+                    stride=u,
+                    padding=(k - u) // 2,
+                )
+            )
+
+        # Source downsampling and resblocks for frequency domain fusion
+        self.source_downs = []
+        self.source_resblocks = []
+        downsample_rates = [1] + upsample_rates[::-1][:-1]
+        # Compute cumulative product manually (replaces np.cumprod)
+        downsample_cum_rates = []
+        cum_prod = 1
+        for rate in downsample_rates:
+            cum_prod *= rate
+            downsample_cum_rates.append(cum_prod)
+
+        for i, (u, k, d) in enumerate(
+            zip(
+                downsample_cum_rates[::-1],
+                source_resblock_kernel_sizes,
+                source_resblock_dilation_sizes,
+            )
+        ):
+            if u == 1:
+                self.source_downs.append(
+                    nn.Conv1d(
+                        istft_params["n_fft"] + 2,
+                        base_channels // (2 ** (i + 1)),
+                        1,
+                        stride=1,
+                    )
+                )
+            else:
+                self.source_downs.append(
+                    nn.Conv1d(
+                        istft_params["n_fft"] + 2,
+                        base_channels // (2 ** (i + 1)),
+                        u * 2,
+                        stride=u,
+                        padding=u // 2,
+                    )
+                )
+            self.source_resblocks.append(
+                ResBlock(base_channels // (2 ** (i + 1)), k, d)
+            )
+
+        # Residual blocks after each upsampling
+        self.resblocks = []
+        for i in range(len(self.ups)):
+            ch = base_channels // (2 ** (i + 1))
+            for j, (k, d) in enumerate(
+                zip(resblock_kernel_sizes, resblock_dilation_sizes)
+            ):
+                self.resblocks.append(ResBlock(ch, k, d))
+
+        # Post-convolution (outputs to frequency domain)
+        ch = base_channels // (2 ** len(self.ups))
+        self.conv_post = nn.Conv1d(
+            ch, istft_params["n_fft"] + 2, 7, stride=1, padding=3
+        )
+
+        # STFT window (Hann window - periodic, matching scipy fftbins=True)
+        self.stft_window = hann_window_periodic(istft_params["n_fft"])
+
+        self.f0_predictor = f0_predictor
+
+    def _f0_upsample(self, f0: mx.array) -> mx.array:
+        """Upsample F0 using nearest neighbor interpolation."""
+        # f0 shape: (B, 1, T)
+        # Use mx.repeat for efficient nearest-neighbor upsampling
+        return mx.repeat(f0, self.f0_upsample_scale, axis=2)
+
+    def _stft(self, x: mx.array) -> tuple:
+        """Perform STFT on input signal."""
+        return stft(
+            x,
+            self.istft_params["n_fft"],
+            self.istft_params["hop_len"],
+            self.stft_window,
+        )
+
+    def _istft(self, magnitude: mx.array, phase: mx.array) -> mx.array:
+        """Perform inverse STFT."""
+        return istft(
+            magnitude,
+            phase,
+            self.istft_params["n_fft"],
+            self.istft_params["hop_len"],
+            self.stft_window,
+        )
+
+    def decode(self, x: mx.array, s: mx.array) -> mx.array:
+        """
+        Decode mel-spectrogram to waveform.
+
+        Args:
+            x: Mel-spectrogram (B, C, T)
+            s: Source signal (B, 1, T_s)
+
+        Returns:
+            Generated waveform (B, T)
+        """
+        # STFT of source signal
+        s_stft_real, s_stft_imag = self._stft(s.squeeze(1))
+        s_stft = mx.concatenate([s_stft_real, s_stft_imag], axis=1)
+
+        # Pre-convolution: (B, C, T) -> transpose -> conv -> transpose back
+        x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+        x = self.conv_pre(x)
+        x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+
+        for i in range(self.num_upsamples):
+            x = nn.leaky_relu(x, negative_slope=self.lrelu_slope)
+            # ConvTranspose1d: (B, C, T) -> transpose -> conv -> transpose back
+            x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+            x = self.ups[i](x)
+            x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+
+            if i == self.num_upsamples - 1:
+                # Reflection pad: pad 1 sample on left using reflection
+                # For (1, 0) reflection: prepend x[:, :, 1:2] to the beginning
+                x = mx.concatenate([x[:, :, 1:2], x], axis=2)
+
+            # Source fusion: (B, C, T) -> transpose -> conv -> transpose back
+            si = mx.swapaxes(s_stft, 1, 2)  # (B, C, T) -> (B, T, C)
+            si = self.source_downs[i](si)
+            si = mx.swapaxes(si, 1, 2)  # (B, T, C) -> (B, C, T)
+            si = self.source_resblocks[i](si)
+            x = x + si
+
+            # Apply residual blocks
+            xs = None
+            for j in range(self.num_kernels):
+                idx = i * self.num_kernels + j
+                if xs is None:
+                    xs = self.resblocks[idx](x)
+                else:
+                    xs = xs + self.resblocks[idx](x)
+            x = xs / self.num_kernels
+
+        x = nn.leaky_relu(x, negative_slope=self.lrelu_slope)
+        # conv_post: (B, C, T) -> transpose -> conv -> transpose back
+        x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+        x = self.conv_post(x)
+        x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+
+        # Split into magnitude and phase
+        n_fft_half = self.istft_params["n_fft"] // 2 + 1
+        magnitude = mx.exp(x[:, :n_fft_half, :])
+        phase = mx.sin(x[:, n_fft_half:, :])  # sin is redundancy, matches original
+
+        # Inverse STFT
+        x = self._istft(magnitude, phase)
+        x = mx.clip(x, -self.audio_limit, self.audio_limit)
+
+        return x
+
+    def __call__(self, speech_feat: mx.array, cache_source: mx.array = None) -> tuple:
+        """
+        Generate waveform from mel-spectrogram.
+
+        Args:
+            speech_feat: Mel-spectrogram (B, C, T)
+            cache_source: Cached source for streaming
+
+        Returns:
+            Tuple of (waveform, source)
+        """
+        if cache_source is None:
+            cache_source = mx.zeros((1, 1, 0))
+
+        # Predict F0 from mel
+        f0 = self.f0_predictor(speech_feat)
+
+        # Upsample F0
+        s = self._f0_upsample(mx.expand_dims(f0, 1))
+        s = mx.swapaxes(s, 1, 2)  # (B, T, 1)
+
+        # Generate source from F0
+        s, _, _ = self.m_source(s)
+        s = mx.swapaxes(s, 1, 2)  # (B, 1, T)
+
+        # Use cache to avoid glitch in streaming
+        if cache_source.shape[2] != 0:
+            cache_len = cache_source.shape[2]
+            s = mx.concatenate([cache_source, s[:, :, cache_len:]], axis=2)
+
+        # Decode mel + source to audio
+        generated_speech = self.decode(x=speech_feat, s=s)
+
+        return generated_speech, s
+
+    def inference(self, speech_feat: mx.array, cache_source: mx.array = None) -> tuple:
+        """Inference-mode forward pass."""
+        return self(speech_feat, cache_source)

--- a/mlx_audio/tts/models/chatterbox/s3gen/matcha/__init__.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/matcha/__init__.py
@@ -1,0 +1,24 @@
+# Ported from https://github.com/shivammehta25/Matcha-TTS
+# Used by Chatterbox for the decoder components
+
+from .decoder import (
+    Block1D,
+    Downsample1D,
+    ResnetBlock1D,
+    SinusoidalPosEmb,
+    TimestepEmbedding,
+    Upsample1D,
+)
+from .flow_matching import BASECFM
+from .transformer import BasicTransformerBlock
+
+__all__ = [
+    "SinusoidalPosEmb",
+    "TimestepEmbedding",
+    "Block1D",
+    "ResnetBlock1D",
+    "Downsample1D",
+    "Upsample1D",
+    "BASECFM",
+    "BasicTransformerBlock",
+]

--- a/mlx_audio/tts/models/chatterbox/s3gen/matcha/decoder.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/matcha/decoder.py
@@ -1,0 +1,134 @@
+# Ported from https://github.com/shivammehta25/Matcha-TTS
+# Original: matcha/models/components/decoder.py
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class SinusoidalPosEmb(nn.Module):
+    """Sinusoidal position embeddings for timestep encoding."""
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+        assert self.dim % 2 == 0, "SinusoidalPosEmb requires dim to be even"
+
+    def __call__(self, x: mx.array, scale: float = 1000) -> mx.array:
+        if x.ndim < 1:
+            x = mx.expand_dims(x, 0)
+        half_dim = self.dim // 2
+        emb = math.log(10000) / (half_dim - 1)
+        emb = mx.exp(mx.arange(half_dim, dtype=mx.float32) * -emb)
+        emb = scale * mx.expand_dims(x, 1) * mx.expand_dims(emb, 0)
+        emb = mx.concatenate([mx.sin(emb), mx.cos(emb)], axis=-1)
+        return emb
+
+
+class TimestepEmbedding(nn.Module):
+    """MLP for timestep embedding."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        time_embed_dim: int,
+        act_fn: str = "silu",
+    ):
+        super().__init__()
+        self.linear_1 = nn.Linear(in_channels, time_embed_dim)
+        self.linear_2 = nn.Linear(time_embed_dim, time_embed_dim)
+        self.act_fn = act_fn
+
+    def __call__(self, sample: mx.array) -> mx.array:
+        sample = self.linear_1(sample)
+        sample = nn.silu(sample) if self.act_fn == "silu" else nn.gelu(sample)
+        sample = self.linear_2(sample)
+        return sample
+
+
+class Block1D(nn.Module):
+    """1D convolutional block with group norm."""
+
+    def __init__(self, dim: int, dim_out: int, groups: int = 8):
+        super().__init__()
+        self.conv = nn.Conv1d(dim, dim_out, kernel_size=3, padding=1)
+        self.norm = nn.GroupNorm(groups, dim_out)
+
+    def __call__(self, x: mx.array, mask: mx.array) -> mx.array:
+        # x is (B, C, T) but MLX Conv1d expects (B, T, C)
+        x_in = mx.swapaxes(x * mask, 1, 2)  # (B, C, T) -> (B, T, C)
+        output = self.conv(x_in)
+        output = mx.swapaxes(output, 1, 2)  # (B, T, C) -> (B, C, T)
+        output = self.norm(output)
+        output = nn.mish(output)
+        return output * mask
+
+
+class ResnetBlock1D(nn.Module):
+    """1D ResNet block with time embedding."""
+
+    def __init__(self, dim: int, dim_out: int, time_emb_dim: int, groups: int = 8):
+        super().__init__()
+        # MLP: Mish activation is applied before the linear layer to match original
+        self.mlp_linear = nn.Linear(time_emb_dim, dim_out)
+        self.block1 = Block1D(dim, dim_out, groups=groups)
+        self.block2 = Block1D(dim_out, dim_out, groups=groups)
+        self.res_conv = nn.Conv1d(dim, dim_out, 1)
+
+    def __call__(self, x: mx.array, mask: mx.array, time_emb: mx.array) -> mx.array:
+        h = self.block1(x, mask)
+        # Original: h += self.mlp(time_emb) where mlp = Sequential(Mish(), Linear())
+        # So Mish is applied first, then Linear
+        h = h + mx.expand_dims(self.mlp_linear(nn.mish(time_emb)), -1)
+        h = self.block2(h, mask)
+        # res_conv: (B, C, T) -> transpose -> conv -> transpose back
+        x_res = mx.swapaxes(x * mask, 1, 2)  # (B, C, T) -> (B, T, C)
+        res_out = self.res_conv(x_res)
+        res_out = mx.swapaxes(res_out, 1, 2)  # (B, T, C) -> (B, C, T)
+        output = h + res_out
+        return output
+
+
+class Downsample1D(nn.Module):
+    """1D downsampling with stride-2 convolution."""
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.conv = nn.Conv1d(dim, dim, kernel_size=3, stride=2, padding=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # x is (B, C, T) but MLX Conv1d expects (B, T, C)
+        x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+        x = self.conv(x)
+        x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+        return x
+
+
+class Upsample1D(nn.Module):
+    """1D upsampling with transposed convolution."""
+
+    def __init__(self, channels: int, use_conv_transpose: bool = True):
+        super().__init__()
+        self.channels = channels
+        self.use_conv_transpose = use_conv_transpose
+
+        if use_conv_transpose:
+            self.conv = nn.ConvTranspose1d(
+                channels, channels, kernel_size=4, stride=2, padding=1
+            )
+        else:
+            self.conv = None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        if self.use_conv_transpose:
+            # x is (B, C, T) but MLX ConvTranspose1d expects (B, T, C)
+            x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+            x = self.conv(x)
+            x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+            return x
+        else:
+            # Nearest neighbor upsampling
+            B, C, T = x.shape
+            x = mx.repeat(x, 2, axis=2)
+            return x

--- a/mlx_audio/tts/models/chatterbox/s3gen/matcha/flow_matching.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/matcha/flow_matching.py
@@ -1,0 +1,105 @@
+# Ported from https://github.com/shivammehta25/Matcha-TTS
+# Original: matcha/models/components/flow_matching.py
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@dataclass
+class CFMParams:
+    """Configuration for Conditional Flow Matching."""
+
+    sigma_min: float = 1e-06
+    solver: str = "euler"
+    t_scheduler: str = "cosine"
+    training_cfg_rate: float = 0.2
+    inference_cfg_rate: float = 0.7
+    reg_loss_type: str = "l1"
+
+
+class BASECFM(nn.Module):
+    """Base Conditional Flow Matching module."""
+
+    def __init__(
+        self,
+        n_feats: int,
+        cfm_params: CFMParams,
+        n_spks: int = 1,
+        spk_emb_dim: int = 128,
+    ):
+        super().__init__()
+        self.n_feats = n_feats
+        self.n_spks = n_spks
+        self.spk_emb_dim = spk_emb_dim
+        self.solver = cfm_params.solver
+        self.sigma_min = cfm_params.sigma_min
+        self.estimator = None
+
+    def __call__(
+        self,
+        mu: mx.array,
+        mask: mx.array,
+        n_timesteps: int,
+        temperature: float = 1.0,
+        spks: mx.array = None,
+        cond: mx.array = None,
+    ) -> mx.array:
+        """
+        Forward diffusion.
+
+        Args:
+            mu: Encoder output (B, n_feats, T)
+            mask: Output mask (B, 1, T)
+            n_timesteps: Number of diffusion steps
+            temperature: Temperature for scaling noise
+            spks: Speaker embeddings (B, spk_emb_dim)
+            cond: Optional conditioning
+
+        Returns:
+            Generated mel-spectrogram (B, n_feats, T)
+        """
+        z = mx.random.normal(mu.shape) * temperature
+        t_span = mx.linspace(0, 1, n_timesteps + 1)
+        return self.solve_euler(
+            z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond
+        )
+
+    def solve_euler(
+        self,
+        x: mx.array,
+        t_span: mx.array,
+        mu: mx.array,
+        mask: mx.array,
+        spks: mx.array,
+        cond: mx.array,
+    ) -> mx.array:
+        """
+        Fixed Euler solver for ODEs.
+
+        Args:
+            x: Random noise (B, n_feats, T)
+            t_span: Time steps (n_timesteps + 1,)
+            mu: Encoder output (B, n_feats, T)
+            mask: Output mask (B, 1, T)
+            spks: Speaker embeddings (B, spk_emb_dim)
+            cond: Optional conditioning
+
+        Returns:
+            Solution at final timestep
+        """
+        t = t_span[0]
+        dt = t_span[1] - t_span[0]
+
+        sol = []
+        for step in range(1, len(t_span)):
+            dphi_dt = self.estimator(x, mask, mu, t, spks, cond)
+            x = x + dt * dphi_dt
+            t = t + dt
+            sol.append(x)
+
+            if step < len(t_span) - 1:
+                dt = t_span[step + 1] - t
+
+        return sol[-1]

--- a/mlx_audio/tts/models/chatterbox/s3gen/matcha/transformer.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/matcha/transformer.py
@@ -1,0 +1,154 @@
+# Ported from https://github.com/shivammehta25/Matcha-TTS
+# Original: matcha/models/components/transformer.py
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class DiffusersAttention(nn.Module):
+    """
+    Attention module matching diffusers.models.attention_processor.Attention.
+
+    PyTorch diffusers uses:
+        inner_dim = heads * dim_head  (e.g., 8 * 64 = 512)
+        to_q, to_k, to_v: (query_dim, inner_dim)  (256 -> 512)
+        to_out.0: (inner_dim, query_dim)  (512 -> 256)
+
+    This differs from standard MHA where all dims equal query_dim.
+
+    Weight names match sanitized format: query_proj, key_proj, value_proj, out_proj
+    """
+
+    def __init__(
+        self,
+        query_dim: int,
+        heads: int = 8,
+        dim_head: int = 64,
+        bias: bool = False,
+    ):
+        super().__init__()
+        self.heads = heads
+        self.dim_head = dim_head
+        self.inner_dim = heads * dim_head
+        self.scale = dim_head**-0.5
+
+        # Match sanitized weight naming: query_proj, key_proj, value_proj, out_proj
+        self.query_proj = nn.Linear(query_dim, self.inner_dim, bias=bias)
+        self.key_proj = nn.Linear(query_dim, self.inner_dim, bias=bias)
+        self.value_proj = nn.Linear(query_dim, self.inner_dim, bias=bias)
+        self.out_proj = nn.Linear(self.inner_dim, query_dim, bias=bias)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array = None,
+    ) -> mx.array:
+        B, T, _ = hidden_states.shape
+
+        # Project to q, k, v
+        q = self.query_proj(hidden_states)  # (B, T, inner_dim)
+        k = self.key_proj(hidden_states)  # (B, T, inner_dim)
+        v = self.value_proj(hidden_states)  # (B, T, inner_dim)
+
+        # Reshape to (B, heads, T, dim_head)
+        q = q.reshape(B, T, self.heads, self.dim_head).transpose(0, 2, 1, 3)
+        k = k.reshape(B, T, self.heads, self.dim_head).transpose(0, 2, 1, 3)
+        v = v.reshape(B, T, self.heads, self.dim_head).transpose(0, 2, 1, 3)
+
+        # Prepare mask for mx.fast.scaled_dot_product_attention
+        # MLX expects boolean mask broadcastable to (B, heads, T_q, T_kv)
+        # where True = attend, False = mask out
+        mask = None
+        if attention_mask is not None:
+            # attention_mask: (B, T) -> (B, 1, 1, T)
+            if attention_mask.ndim == 2:
+                mask = attention_mask[:, None, None, :]
+            else:
+                mask = attention_mask
+
+        # Use MLX fast attention (fused kernel)
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale, mask=mask)
+
+        # Reshape back: (B, heads, T, dim_head) -> (B, T, inner_dim)
+        out = out.transpose(0, 2, 1, 3).reshape(B, T, self.inner_dim)
+
+        # Output projection
+        out = self.out_proj(out)
+
+        return out
+
+
+class BasicTransformerBlock(nn.Module):
+    """
+    Basic transformer block for decoder.
+
+    This is a simplified version used by Chatterbox. The full Matcha-TTS
+    implementation includes cross-attention and other features not needed here.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        dropout: float = 0.0,
+        activation_fn: str = "gelu",
+    ):
+        super().__init__()
+        # Separate norms for attention and feed-forward (matches original)
+        self.norm1 = nn.LayerNorm(dim)
+        self.norm3 = nn.LayerNorm(dim)
+        # Use DiffusersAttention to match PyTorch weight shapes
+        # PyTorch: inner_dim = heads * dim_head = 8 * 64 = 512
+        # Projections: (256, 512) for q/k/v, (512, 256) for out
+        # Named 'attn' to match sanitized weight keys (e.g., .attn.query_proj)
+        self.attn = DiffusersAttention(
+            query_dim=dim,
+            heads=num_attention_heads,
+            dim_head=attention_head_dim,
+            bias=False,
+        )
+        # Feed-forward with GEGLU
+        # Sanitize converts: ff.net.0.proj -> ff.layers.0, ff.net.2 -> ff.layers.1
+        self.ff = FeedForward(dim, dim * 4)
+        self.activation_fn = activation_fn
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array = None,
+        timestep: mx.array = None,
+    ) -> mx.array:
+        # Self-attention
+        normed = self.norm1(hidden_states)
+        attn_out = self.attn(normed, attention_mask=attention_mask)
+        hidden_states = hidden_states + attn_out
+
+        # Feed-forward
+        normed = self.norm3(hidden_states)
+        ff_out = self.ff(normed)
+        hidden_states = hidden_states + ff_out
+
+        return hidden_states
+
+
+class FeedForward(nn.Module):
+    """Feed-forward network with GELU activation."""
+
+    def __init__(self, dim: int, mult: int = 4):
+        super().__init__()
+        inner_dim = mult  # mult is passed as dim * 4, so inner_dim = dim * 4
+        # Weights: ff.net.0.proj (256->1024), ff.net.2 (1024->256)
+        # Sanitize renames: ff.net.0.proj -> ff.layers.0, ff.net.2 -> ff.layers.1
+        self.layers = [
+            nn.Linear(dim, inner_dim),  # 256 -> 1024
+            nn.Linear(inner_dim, dim),  # 1024 -> 256
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.layers[0](x)
+        x = nn.gelu(x)
+        x = self.layers[1](x)
+        return x

--- a/mlx_audio/tts/models/chatterbox/s3gen/mel.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/mel.py
@@ -1,0 +1,97 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import mlx.core as mx
+
+from mlx_audio.utils import mel_filters, stft
+
+
+def _reflect_pad_2d(x: mx.array, pad_amount: int) -> mx.array:
+    """
+    Reflect pad a 2D array (B, T) along axis 1.
+    Vectorized version that works on entire batch at once.
+    """
+    if pad_amount == 0:
+        return x
+    # Reflect at start: x[:, 1:pad_amount+1][:, ::-1]
+    prefix = x[:, 1 : pad_amount + 1][:, ::-1]
+    # Reflect at end: x[:, -(pad_amount+1):-1][:, ::-1]
+    suffix = x[:, -(pad_amount + 1) : -1][:, ::-1]
+    return mx.concatenate([prefix, x, suffix], axis=1)
+
+
+def mel_spectrogram(
+    y: mx.array,
+    n_fft: int = 1920,
+    num_mels: int = 80,
+    sampling_rate: int = 24000,
+    hop_size: int = 480,
+    win_size: int = 1920,
+    fmin: int = 0,
+    fmax: int = 8000,
+    center: bool = False,
+) -> mx.array:
+    """
+    Extract mel-spectrogram from waveform.
+
+    Args:
+        y: Waveform (B, T) or (T,)
+        n_fft: FFT size
+        num_mels: Number of mel bins
+        sampling_rate: Sample rate
+        hop_size: Hop size
+        win_size: Window size
+        fmin: Minimum frequency
+        fmax: Maximum frequency
+        center: Whether to center the window
+
+    Returns:
+        Mel-spectrogram (B, num_mels, T')
+    """
+    was_1d = len(y.shape) == 1
+    if was_1d:
+        y = mx.expand_dims(y, 0)
+
+    # Pad signal with reflection - vectorized for entire batch
+    pad_amount = (n_fft - hop_size) // 2
+    y = _reflect_pad_2d(y, pad_amount)
+
+    # STFT - process each batch item since shared stft expects 1D
+    # Use center=False since we already applied reflection padding above
+    # TODO: Consider batched STFT if mlx_audio.utils.stft supports it
+    specs = []
+    for i in range(y.shape[0]):
+        spec = stft(
+            y[i],  # 1D input
+            window="hann",
+            n_fft=n_fft,
+            hop_length=hop_size,
+            win_length=win_size,
+            center=False,
+        )
+        specs.append(spec)
+    # Stack: each spec is (T', F) -> stack to (B, T', F)
+    spec = mx.stack(specs, axis=0)
+
+    # Magnitude spectrogram
+    magnitudes = mx.abs(spec)  # (B, T', F)
+
+    # Create mel filterbank
+    # Use slaney normalization to match librosa defaults (used by original PyTorch)
+    filters = mel_filters(
+        sample_rate=sampling_rate,
+        n_fft=n_fft,
+        n_mels=num_mels,
+        f_min=fmin,
+        f_max=fmax,
+        norm="slaney",
+        mel_scale="slaney",
+    )
+
+    # Apply mel filterbank: (B, T', F) @ (F, M) -> (B, T', M)
+    mel_spec = magnitudes @ filters.T
+    mel_spec = mx.transpose(mel_spec, [0, 2, 1])  # (B, M, T')
+
+    # Log compression
+    mel_spec = mx.log(mx.maximum(mel_spec, 1e-5))
+
+    return mel_spec

--- a/mlx_audio/tts/models/chatterbox/s3gen/s3gen.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/s3gen.py
@@ -1,0 +1,542 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import math
+from typing import Dict, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from scipy import signal
+
+from .decoder import ConditionalDecoder
+from .f0_predictor import ConvRNNF0Predictor
+from .flow import CausalMaskedDiffWithXvec
+from .flow_matching import CFM_PARAMS, CausalConditionalCFM
+from .hifigan import HiFTGenerator
+from .mel import mel_spectrogram
+from .transformer.upsample_encoder import UpsampleConformerEncoder
+from .xvector import CAMPPlus
+
+
+def resample_audio(audio: mx.array, orig_sr: int, target_sr: int) -> mx.array:
+    """Resample audio using scipy (numpy required for scipy)."""
+    if orig_sr == target_sr:
+        return audio
+    import numpy as np
+
+    audio_np = np.array(audio)
+    gcd = math.gcd(orig_sr, target_sr)
+    up = target_sr // gcd
+    down = orig_sr // gcd
+    resampled = signal.resample_poly(audio_np, up, down, padtype="edge")
+    return mx.array(resampled.astype(np.float32))
+
+
+# Constants
+S3GEN_SR = 24000
+S3_SR = 16000
+SPEECH_VOCAB_SIZE = 6561
+
+
+class S3Token2Mel(nn.Module):
+    """
+    S3Gen CFM decoder maps S3 speech tokens to mel-spectrograms.
+
+    This is the flow matching component that converts speech tokens to mel spectrograms
+    using a Conformer encoder and flow matching decoder with speaker conditioning.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        # Speaker encoder
+        self.speaker_encoder = CAMPPlus()
+
+        # Conformer encoder with upsampling
+        encoder = UpsampleConformerEncoder(
+            output_size=512,
+            attention_heads=8,
+            linear_units=2048,
+            num_blocks=6,
+            dropout_rate=0.1,
+            positional_dropout_rate=0.1,
+            attention_dropout_rate=0.1,
+            normalize_before=True,
+            input_layer="linear",
+            pos_enc_layer_type="rel_pos_espnet",
+            selfattention_layer_type="rel_selfattn",
+            input_size=512,
+            use_cnn_module=False,
+            macaron_style=False,
+        )
+
+        # Flow matching decoder
+        estimator = ConditionalDecoder(
+            in_channels=320,
+            out_channels=80,
+            causal=True,
+            channels=[256],
+            dropout=0.0,
+            attention_head_dim=64,
+            n_blocks=4,
+            num_mid_blocks=12,
+            num_heads=8,
+            act_fn="gelu",
+        )
+
+        cfm_params = CFM_PARAMS
+        decoder = CausalConditionalCFM(
+            spk_emb_dim=80,
+            cfm_params=cfm_params,
+            estimator=estimator,
+        )
+
+        # Integration wrapper
+        self.flow = CausalMaskedDiffWithXvec(encoder=encoder, decoder=decoder)
+
+    def embed_ref(
+        self,
+        ref_wav: mx.array,
+        ref_sr: int,
+        ref_speech_tokens: mx.array,
+        ref_speech_token_lens: mx.array,
+    ):
+        """
+        Embed reference audio for speaker conditioning.
+
+        Args:
+            ref_wav: Reference waveform (1, T) at ref_sr
+            ref_sr: Reference sample rate
+            ref_speech_tokens: Reference speech tokens (1, T_tok)
+            ref_speech_token_lens: Reference token lengths (1,)
+
+        Returns:
+            Dictionary with prompt_token, prompt_token_len, prompt_feat, embedding
+        """
+        if len(ref_wav.shape) == 1:
+            ref_wav = mx.expand_dims(ref_wav, 0)
+
+        # Resample to 24kHz for mel extraction if needed
+        if ref_sr == S3GEN_SR:
+            ref_wav_24 = ref_wav
+        else:
+            ref_wav_24 = resample_audio(ref_wav.squeeze(0), ref_sr, S3GEN_SR)
+            ref_wav_24 = mx.expand_dims(ref_wav_24, 0)
+
+        # Extract mel features at 24kHz
+        ref_mels_24 = mel_spectrogram(
+            ref_wav_24,
+            n_fft=1920,
+            num_mels=80,
+            sampling_rate=S3GEN_SR,
+            hop_size=480,
+            win_size=1920,
+            fmin=0,
+            fmax=8000,
+            center=False,
+        )
+        ref_mels_24 = mx.transpose(ref_mels_24, [0, 2, 1])  # (B, T, D)
+
+        # Speaker embedding (expects 16kHz audio)
+        if ref_sr == S3_SR:
+            ref_wav_16 = ref_wav
+        else:
+            ref_wav_16 = resample_audio(ref_wav.squeeze(0), ref_sr, S3_SR)
+            ref_wav_16 = mx.expand_dims(ref_wav_16, 0)
+
+        ref_x_vector = self.speaker_encoder.inference(ref_wav_16)
+
+        # Make sure mel_len = 2 * stoken_len
+        # The relationship should be: mel_frames = 2 * num_tokens
+        # If they don't match, we need to align them.
+        # Original PyTorch truncates TOKENS to match MEL: tokens = mel // 2
+        # But if tokens are already shorter than mel // 2, we need to truncate MEL instead
+        actual_token_len = ref_speech_tokens.shape[1]
+        expected_token_len = ref_mels_24.shape[1] // 2
+
+        if actual_token_len != expected_token_len:
+            if actual_token_len < expected_token_len:
+                # Tokens are shorter - truncate mel to match (mel = 2 * tokens)
+                expected_mel_len = 2 * actual_token_len
+                ref_mels_24 = ref_mels_24[:, :expected_mel_len, :]
+            else:
+                # Tokens are longer - truncate tokens to match mel
+                ref_speech_tokens = ref_speech_tokens[:, :expected_token_len]
+                actual_token_len = expected_token_len
+
+        # Ensure token_len matches actual shape
+        ref_speech_token_lens = mx.array([actual_token_len])
+
+        return dict(
+            prompt_token=ref_speech_tokens,
+            prompt_token_len=ref_speech_token_lens,
+            prompt_feat=ref_mels_24,
+            prompt_feat_len=mx.array([ref_mels_24.shape[1]]),
+            embedding=ref_x_vector,
+        )
+
+    def __call__(
+        self,
+        speech_tokens: mx.array,
+        ref_dict: dict,
+        finalize: bool = False,
+    ):
+        """
+        Generate mel-spectrograms from S3 speech tokens.
+
+        Args:
+            speech_tokens: S3 speech tokens (1, T)
+            ref_dict: Reference embeddings from embed_ref()
+            finalize: Whether streaming is finished (if False, last 3 tokens ignored)
+
+        Returns:
+            output_mels: Generated mel-spectrograms (1, D, T')
+        """
+        if len(speech_tokens.shape) == 1:
+            speech_tokens = mx.expand_dims(speech_tokens, 0)
+
+        speech_token_lens = mx.array([speech_tokens.shape[1]])
+
+        output_mels, _ = self.flow.inference(
+            token=speech_tokens,
+            token_len=speech_token_lens,
+            finalize=finalize,
+            **ref_dict,
+        )
+
+        return output_mels
+
+
+class S3Token2Wav(S3Token2Mel):
+    """
+    Full S3Gen decoder: token-to-mel (CFM) + mel-to-waveform (HiFiGAN).
+
+    This combines the flow matching decoder with the HiFi-GAN vocoder to
+    generate high-quality waveforms from speech tokens.
+    """
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """
+        Sanitize PyTorch weights for MLX.
+
+        Handles:
+        - Speaker encoder routing through CAMPPlus.sanitize
+        - Conv1d/Conv2d weight transposition (PyTorch: out, in, kernel -> MLX: out, kernel, in)
+        - ConvTranspose1d weight transposition
+        - Decoder block naming (down_blocks.0.0 -> down_blocks_0.resnet)
+        - Transformer attention naming (attn1.to_q -> attn.query_proj)
+        - FFN naming (ff.net.0.proj -> ff.layers.0)
+        - Weight normalization handling (parametrizations.weight.original0/1)
+
+        This method is idempotent - it checks shapes before transposing to support
+        both PyTorch-format and pre-converted MLX-format weights.
+        """
+        import re
+
+        from mlx.utils import tree_flatten
+
+        new_weights = {}
+
+        # Get expected shapes from model for idempotent transposition
+        curr_weights = dict(tree_flatten(self.parameters()))
+
+        # Separate speaker_encoder weights and route through CAMPPlus.sanitize
+        speaker_weights = {}
+        other_weights = {}
+        for key, value in weights.items():
+            if key.startswith("speaker_encoder."):
+                speaker_weights[key[len("speaker_encoder.") :]] = value
+            else:
+                other_weights[key] = value
+
+        # Sanitize speaker encoder weights
+        if speaker_weights:
+            sanitized_speaker = self.speaker_encoder.sanitize(speaker_weights)
+            for k, v in sanitized_speaker.items():
+                new_weights[f"speaker_encoder.{k}"] = v
+
+        # First pass: collect weight normalization pairs (g and v)
+        # Weight norm formula: w = g * v / ||v||
+        wn_pairs = {}  # base_key -> {"g": tensor, "v": tensor}
+        non_wn_weights = {}
+
+        for key, value in other_weights.items():
+            if "parametrizations.weight.original0" in key:
+                base_key = key.replace(".parametrizations.weight.original0", ".weight")
+                if base_key not in wn_pairs:
+                    wn_pairs[base_key] = {}
+                wn_pairs[base_key]["g"] = value
+            elif "parametrizations.weight.original1" in key:
+                base_key = key.replace(".parametrizations.weight.original1", ".weight")
+                if base_key not in wn_pairs:
+                    wn_pairs[base_key] = {}
+                wn_pairs[base_key]["v"] = value
+            else:
+                non_wn_weights[key] = value
+
+        # Merge weight-normalized weights
+        for base_key, pair in wn_pairs.items():
+            if "g" in pair and "v" in pair:
+                g = pair["g"]  # magnitude, shape (out_ch, 1, 1)
+                v = pair[
+                    "v"
+                ]  # weight, shape (out_ch, in_ch, kernel) or (out_ch, kernel, in_ch) for ConvT
+                # Compute ||v|| over all dimensions except the first (output channels)
+                # For 3D weights: norm over dims 1 and 2
+                v_norm = mx.sqrt(
+                    mx.sum(v * v, axis=tuple(range(1, v.ndim)), keepdims=True)
+                )
+                # Normalized weight: w = g * v / ||v||
+                w = g * v / (v_norm + 1e-12)
+                non_wn_weights[base_key] = w
+            elif "v" in pair:
+                # Only v available, use directly (shouldn't happen)
+                non_wn_weights[base_key] = pair["v"]
+
+        # Process remaining weights
+        for key, value in non_wn_weights.items():
+            new_key = key
+
+            # Skip num_batches_tracked for BatchNorm
+            if "num_batches_tracked" in key:
+                continue
+
+            # === Decoder block naming ===
+            # down_blocks.X.0 -> down_blocks_X.resnet (first tuple element is resnet)
+            new_key = re.sub(
+                r"down_blocks\.(\d+)\.0\.", r"down_blocks_\1.resnet.", new_key
+            )
+            # down_blocks.X.1.Y -> down_blocks_X.transformer_Y (second tuple element is transformer list)
+            new_key = re.sub(
+                r"down_blocks\.(\d+)\.1\.(\d+)\.",
+                r"down_blocks_\1.transformer_\2.",
+                new_key,
+            )
+            # down_blocks.X.2 -> down_blocks_X.downsample (third tuple element is downsample)
+            new_key = re.sub(
+                r"down_blocks\.(\d+)\.2\.", r"down_blocks_\1.downsample.", new_key
+            )
+
+            # mid_blocks.X.0 -> mid_blocks_X.resnet
+            new_key = re.sub(
+                r"mid_blocks\.(\d+)\.0\.", r"mid_blocks_\1.resnet.", new_key
+            )
+            # mid_blocks.X.1.Y -> mid_blocks_X.transformer_Y
+            new_key = re.sub(
+                r"mid_blocks\.(\d+)\.1\.(\d+)\.",
+                r"mid_blocks_\1.transformer_\2.",
+                new_key,
+            )
+
+            # up_blocks.X.0 -> up_blocks_X.resnet
+            new_key = re.sub(r"up_blocks\.(\d+)\.0\.", r"up_blocks_\1.resnet.", new_key)
+            # up_blocks.X.1.Y -> up_blocks_X.transformer_Y
+            new_key = re.sub(
+                r"up_blocks\.(\d+)\.1\.(\d+)\.",
+                r"up_blocks_\1.transformer_\2.",
+                new_key,
+            )
+            # up_blocks.X.2 -> up_blocks_X.upsample
+            new_key = re.sub(
+                r"up_blocks\.(\d+)\.2\.", r"up_blocks_\1.upsample.", new_key
+            )
+
+            # === ResNet block naming (CausalBlock1D structure) ===
+            # .block1.block.0. -> .block1.conv.conv. (CausalConv1d)
+            new_key = re.sub(r"\.block1\.block\.0\.", r".block1.conv.conv.", new_key)
+            # .block1.block.2. -> .block1.norm. (LayerNorm)
+            new_key = re.sub(r"\.block1\.block\.2\.", r".block1.norm.", new_key)
+            new_key = re.sub(r"\.block2\.block\.0\.", r".block2.conv.conv.", new_key)
+            new_key = re.sub(r"\.block2\.block\.2\.", r".block2.norm.", new_key)
+            # .mlp.1. -> .mlp_linear. (Linear in MLP)
+            new_key = re.sub(r"\.mlp\.1\.", r".mlp_linear.", new_key)
+
+            # === Transformer attention naming ===
+            # PyTorch: attn1.to_q -> MLX: attn.query_proj (sanitized format)
+            new_key = new_key.replace(".attn1.to_q.", ".attn.query_proj.")
+            new_key = new_key.replace(".attn1.to_k.", ".attn.key_proj.")
+            new_key = new_key.replace(".attn1.to_v.", ".attn.value_proj.")
+            new_key = new_key.replace(".attn1.to_out.0.", ".attn.out_proj.")
+
+            # === Transformer FFN naming ===
+            new_key = new_key.replace(".ff.net.0.proj.", ".ff.layers.0.")
+            new_key = new_key.replace(".ff.net.2.", ".ff.layers.1.")
+
+            # === Downsample/Upsample naming ===
+            # Downsample1D and Upsample1D wrap conv in self.conv
+            new_key = re.sub(
+                r"\.downsample\.(weight|bias)$", r".downsample.conv.\1", new_key
+            )
+            new_key = re.sub(
+                r"\.upsample\.(weight|bias)$", r".upsample.conv.\1", new_key
+            )
+
+            # === Final block naming ===
+            new_key = new_key.replace(
+                ".final_block.block.0.", ".final_block.conv.conv."
+            )
+            new_key = new_key.replace(".final_block.block.2.", ".final_block.norm.")
+
+            # === Encoder naming ===
+            # .embed.out.0. -> .embed.linear. (first linear)
+            new_key = re.sub(r"\.embed\.out\.0\.", r".embed.linear.", new_key)
+            # .embed.out.1. -> .embed.norm. (layer norm)
+            new_key = re.sub(r"\.embed\.out\.1\.", r".embed.norm.", new_key)
+            # Same for up_embed
+            new_key = re.sub(r"\.up_embed\.out\.0\.", r".up_embed.linear.", new_key)
+            new_key = re.sub(r"\.up_embed\.out\.1\.", r".up_embed.norm.", new_key)
+
+            # === HiFi-GAN F0 predictor naming (idempotent) ===
+            # PyTorch Sequential indices: 0, 2, 4, 6, 8 -> MLX list indices: 0, 1, 2, 3, 4
+            # Only apply if we detect PyTorch-style indices (8 or 6 present in weights)
+            # This makes it idempotent - already-converted weights won't be touched
+            # Use a function to map indices in a single step to avoid cascading replacements
+            has_pytorch_indices = any(
+                ".condnet.6." in k or ".condnet.8." in k for k in weights.keys()
+            )
+            if has_pytorch_indices:
+
+                def remap_condnet_idx(match):
+                    idx_map = {"0": "0", "2": "1", "4": "2", "6": "3", "8": "4"}
+                    return f".condnet.{idx_map[match.group(1)]}."
+
+                new_key = re.sub(r"\.condnet\.([02468])\.", remap_condnet_idx, new_key)
+            # condnet.0 stays condnet.0
+
+            # === Conv weight transposition (idempotent) ===
+            # Only transpose if shape doesn't match expected MLX format
+            if "weight" in new_key and value.ndim == 3:
+                if (
+                    new_key in curr_weights
+                    and value.shape != curr_weights[new_key].shape
+                ):
+                    # Check if this is ConvTranspose (ups) or regular Conv
+                    if ".ups." in new_key:
+                        # ConvTranspose1d: PyTorch (in, out, kernel) -> MLX (out, kernel, in)
+                        value = mx.transpose(value, (1, 2, 0))
+                    else:
+                        # Conv1d: PyTorch (out, in, kernel) -> MLX (out, kernel, in)
+                        value = mx.swapaxes(value, 1, 2)
+            elif "weight" in new_key and value.ndim == 4:
+                # Conv2d: PyTorch (out, in, H, W) -> MLX (out, H, W, in)
+                if (
+                    new_key in curr_weights
+                    and value.shape != curr_weights[new_key].shape
+                ):
+                    value = mx.transpose(value, (0, 2, 3, 1))
+
+            new_weights[new_key] = value
+
+        # Filter out keys that don't exist in the model
+        # (e.g., attn.out_proj.bias from PyTorch when our model uses bias=False)
+        filtered_weights = {k: v for k, v in new_weights.items() if k in curr_weights}
+
+        return filtered_weights
+
+    def __init__(self):
+        super().__init__()
+
+        # F0 predictor for vocoder
+        f0_predictor = ConvRNNF0Predictor()
+
+        # HiFi-GAN vocoder
+        self.mel2wav = HiFTGenerator(
+            sampling_rate=S3GEN_SR,
+            upsample_rates=[8, 5, 3],
+            upsample_kernel_sizes=[16, 11, 7],
+            source_resblock_kernel_sizes=[7, 7, 11],
+            source_resblock_dilation_sizes=[[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+            f0_predictor=f0_predictor,
+        )
+
+        # Fade-in window to reduce artifacts (20ms)
+        n_trim = S3GEN_SR // 50
+        trim_fade = mx.zeros(2 * n_trim)
+        trim_fade_cos = (mx.cos(mx.linspace(mx.pi, 0, n_trim)) + 1) / 2
+        trim_fade = mx.concatenate([trim_fade[:n_trim], trim_fade_cos])
+        self.trim_fade = trim_fade
+
+    def __call__(
+        self,
+        speech_tokens: mx.array,
+        ref_dict: dict,
+        finalize: bool = False,
+    ):
+        """
+        Generate waveforms from S3 speech tokens.
+
+        Args:
+            speech_tokens: S3 speech tokens (1, T)
+            ref_dict: Reference embeddings from embed_ref()
+            finalize: Whether streaming is finished
+
+        Returns:
+            output_wavs: Generated waveforms (1, T_wav)
+        """
+        # Generate mel-spectrograms
+        output_mels = super().__call__(
+            speech_tokens, ref_dict=ref_dict, finalize=finalize
+        )
+
+        # Generate waveform from mels
+        hift_cache_source = mx.zeros((1, 1, 0))
+        output_wavs, _ = self.mel2wav.inference(
+            speech_feat=output_mels, cache_source=hift_cache_source
+        )
+
+        # Fade in to reduce spillover artifacts
+        fade_len = len(self.trim_fade)
+        if output_wavs.shape[1] >= fade_len:
+            output_wavs[:, :fade_len] *= self.trim_fade
+
+        return output_wavs
+
+    def flow_inference(
+        self,
+        speech_tokens: mx.array,
+        ref_dict: dict,
+        finalize: bool = False,
+    ):
+        """Run only the flow matching (token-to-mel) inference."""
+        return super().__call__(speech_tokens, ref_dict=ref_dict, finalize=finalize)
+
+    def hift_inference(
+        self, speech_feat: mx.array, cache_source: Optional[mx.array] = None
+    ):
+        """Run only the HiFi-GAN (mel-to-wav) inference."""
+        if cache_source is None:
+            cache_source = mx.zeros((1, 1, 0))
+        return self.mel2wav.inference(
+            speech_feat=speech_feat, cache_source=cache_source
+        )
+
+    def inference(
+        self,
+        speech_tokens: mx.array,
+        ref_dict: dict,
+        cache_source: Optional[mx.array] = None,
+        finalize: bool = True,
+    ):
+        """
+        Full inference pipeline with separate flow and vocoder steps.
+
+        Args:
+            speech_tokens: S3 speech tokens (1, T)
+            ref_dict: Reference embeddings from embed_ref()
+            cache_source: Source cache for HiFi-GAN (for streaming)
+            finalize: Whether streaming is finished
+
+        Returns:
+            output_wavs: Generated waveforms (1, T_wav)
+            output_sources: Source features from HiFi-GAN
+        """
+        output_mels = self.flow_inference(
+            speech_tokens, ref_dict=ref_dict, finalize=finalize
+        )
+        output_wavs, output_sources = self.hift_inference(output_mels, cache_source)
+
+        # Fade in to reduce spillover artifacts
+        fade_len = len(self.trim_fade)
+        if output_wavs.shape[1] >= fade_len:
+            output_wavs[:, :fade_len] *= self.trim_fade
+
+        return output_wavs, output_sources

--- a/mlx_audio/tts/models/chatterbox/s3gen/transformer/__init__.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/transformer/__init__.py
@@ -1,0 +1,22 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from .activation import Swish
+from .attention import MultiHeadedAttention, RelPositionMultiHeadedAttention
+from .convolution import ConvolutionModule
+from .embedding import RelPositionalEncoding
+from .encoder_layer import ConformerEncoderLayer
+from .positionwise_feed_forward import PositionwiseFeedForward
+from .subsampling import LinearNoSubsampling
+from .upsample_encoder import UpsampleConformerEncoder
+
+__all__ = [
+    "MultiHeadedAttention",
+    "RelPositionMultiHeadedAttention",
+    "Swish",
+    "ConvolutionModule",
+    "PositionwiseFeedForward",
+    "ConformerEncoderLayer",
+    "RelPositionalEncoding",
+    "LinearNoSubsampling",
+    "UpsampleConformerEncoder",
+]

--- a/mlx_audio/tts/models/chatterbox/s3gen/transformer/activation.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/transformer/activation.py
@@ -1,0 +1,6 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import mlx.nn as nn
+
+# Swish is equivalent to SiLU, which is built into MLX
+Swish = nn.SiLU

--- a/mlx_audio/tts/models/chatterbox/s3gen/transformer/attention.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/transformer/attention.py
@@ -1,0 +1,234 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import math
+from typing import Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class MultiHeadedAttention(nn.Module):
+    """Multi-Head Attention layer."""
+
+    def __init__(
+        self, n_head: int, n_feat: int, dropout_rate: float, key_bias: bool = True
+    ):
+        """
+        Args:
+            n_head: Number of attention heads
+            n_feat: Number of features
+            dropout_rate: Dropout rate
+            key_bias: Whether to use bias in key projection
+        """
+        super().__init__()
+        assert n_feat % n_head == 0, "n_feat must be divisible by n_head"
+
+        self.d_k = n_feat // n_head
+        self.h = n_head
+        self.linear_q = nn.Linear(n_feat, n_feat)
+        self.linear_k = nn.Linear(n_feat, n_feat, bias=key_bias)
+        self.linear_v = nn.Linear(n_feat, n_feat)
+        self.linear_out = nn.Linear(n_feat, n_feat)
+        self.dropout_rate = dropout_rate
+
+    def forward_qkv(
+        self, query: mx.array, key: mx.array, value: mx.array
+    ) -> Tuple[mx.array, mx.array, mx.array]:
+        """
+        Transform query, key and value.
+
+        Args:
+            query: (B, T1, D)
+            key: (B, T2, D)
+            value: (B, T2, D)
+
+        Returns:
+            q: (B, n_head, T1, d_k)
+            k: (B, n_head, T2, d_k)
+            v: (B, n_head, T2, d_k)
+        """
+        n_batch = query.shape[0]
+        q = self.linear_q(query).reshape(n_batch, -1, self.h, self.d_k)
+        k = self.linear_k(key).reshape(n_batch, -1, self.h, self.d_k)
+        v = self.linear_v(value).reshape(n_batch, -1, self.h, self.d_k)
+
+        q = mx.transpose(q, (0, 2, 1, 3))  # (B, h, T1, d_k)
+        k = mx.transpose(k, (0, 2, 1, 3))  # (B, h, T2, d_k)
+        v = mx.transpose(v, (0, 2, 1, 3))  # (B, h, T2, d_k)
+
+        return q, k, v
+
+    def forward_attention(
+        self, value: mx.array, scores: mx.array, mask: mx.array = None
+    ) -> mx.array:
+        """
+        Compute attention context vector.
+
+        Args:
+            value: (B, n_head, T2, d_k)
+            scores: (B, n_head, T1, T2)
+            mask: (B, 1, T2) or (B, T1, T2) or None
+
+        Returns:
+            output: (B, T1, d_model)
+        """
+        n_batch = value.shape[0]
+
+        if mask is not None and mask.shape[2] > 0:
+            # Expand mask: (B, 1, T2) -> (B, 1, 1, T2)
+            mask = mx.expand_dims(mask, 1)
+            # Truncate mask to match scores length
+            mask = mask[:, :, :, : scores.shape[-1]]
+            # Apply mask
+            scores = mx.where(mask == 0, -float("inf"), scores)
+            attn = mx.softmax(scores, axis=-1)
+            attn = mx.where(mask == 0, 0.0, attn)
+        else:
+            attn = mx.softmax(scores, axis=-1)
+
+        # Apply dropout during training
+        if self.training and self.dropout_rate > 0:
+            attn = nn.Dropout(self.dropout_rate)(attn)
+
+        x = attn @ value  # (B, h, T1, d_k)
+        x = mx.transpose(x, (0, 2, 1, 3))  # (B, T1, h, d_k)
+        x = mx.reshape(x, (n_batch, -1, self.h * self.d_k))  # (B, T1, d_model)
+
+        return self.linear_out(x)
+
+    def __call__(
+        self,
+        query: mx.array,
+        key: mx.array,
+        value: mx.array,
+        mask: mx.array = None,
+        pos_emb: mx.array = None,
+        cache: mx.array = None,
+    ) -> Tuple[mx.array, mx.array]:
+        """
+        Scaled dot product attention.
+
+        Args:
+            query: (B, T1, size)
+            key: (B, T2, size)
+            value: (B, T2, size)
+            mask: (B, 1, T2) or (B, T1, T2) or None
+            pos_emb: Not used in base class
+            cache: (1, head, cache_t, d_k * 2) for KV caching
+
+        Returns:
+            output: (B, T1, d_model)
+            new_cache: (1, head, cache_t + T1, d_k * 2)
+        """
+        q, k, v = self.forward_qkv(query, key, value)
+
+        # Handle KV caching
+        if cache is not None and cache.shape[0] > 0:
+            key_cache, value_cache = mx.split(cache, 2, axis=-1)
+            k = mx.concatenate([key_cache, k], axis=2)
+            v = mx.concatenate([value_cache, v], axis=2)
+
+        new_cache = mx.concatenate([k, v], axis=-1)
+
+        scores = (q @ mx.swapaxes(k, -2, -1)) / math.sqrt(self.d_k)
+        return self.forward_attention(v, scores, mask), new_cache
+
+
+class RelPositionMultiHeadedAttention(MultiHeadedAttention):
+    """Multi-Head Attention with relative positional encoding."""
+
+    def __init__(
+        self, n_head: int, n_feat: int, dropout_rate: float, key_bias: bool = True
+    ):
+        super().__init__(n_head, n_feat, dropout_rate, key_bias)
+
+        # Linear transformation for positional encoding
+        self.linear_pos = nn.Linear(n_feat, n_feat, bias=False)
+
+        # Learnable biases for relative position
+        self.pos_bias_u = mx.random.uniform(
+            low=-1.0, high=1.0, shape=(self.h, self.d_k)
+        ) * math.sqrt(6.0 / (self.h + self.d_k))
+        self.pos_bias_v = mx.random.uniform(
+            low=-1.0, high=1.0, shape=(self.h, self.d_k)
+        ) * math.sqrt(6.0 / (self.h + self.d_k))
+
+    def rel_shift(self, x: mx.array) -> mx.array:
+        """
+        Compute relative positional encoding.
+
+        Args:
+            x: (B, head, T1, 2*T1-1)
+
+        Returns:
+            shifted: (B, head, T1, T1)
+        """
+        zero_pad = mx.zeros((x.shape[0], x.shape[1], x.shape[2], 1))
+        x_padded = mx.concatenate([zero_pad, x], axis=-1)
+
+        x_padded = mx.reshape(
+            x_padded, (x.shape[0], x.shape[1], x.shape[3] + 1, x.shape[2])
+        )
+        x = mx.reshape(x_padded[:, :, 1:], x.shape)[:, :, :, : x.shape[-1] // 2 + 1]
+
+        return x
+
+    def __call__(
+        self,
+        query: mx.array,
+        key: mx.array,
+        value: mx.array,
+        mask: mx.array = None,
+        pos_emb: mx.array = None,
+        cache: mx.array = None,
+    ) -> Tuple[mx.array, mx.array]:
+        """
+        Scaled dot product attention with relative positional encoding.
+
+        Args:
+            query: (B, T1, size)
+            key: (B, T2, size)
+            value: (B, T2, size)
+            mask: (B, 1, T2) or (B, T1, T2)
+            pos_emb: (B, T2, size) positional embeddings
+            cache: (1, head, cache_t, d_k * 2)
+
+        Returns:
+            output: (B, T1, d_model)
+            new_cache: (1, head, cache_t + T1, d_k * 2)
+        """
+        q, k, v = self.forward_qkv(query, key, value)
+        q = mx.transpose(q, (0, 2, 1, 3))  # (B, T1, h, d_k)
+
+        # Handle KV caching
+        if cache is not None and cache.shape[0] > 0:
+            key_cache, value_cache = mx.split(cache, 2, axis=-1)
+            k = mx.concatenate([key_cache, k], axis=2)
+            v = mx.concatenate([value_cache, v], axis=2)
+
+        new_cache = mx.concatenate([k, v], axis=-1)
+
+        # Process positional embeddings
+        n_batch_pos = pos_emb.shape[0]
+        p = self.linear_pos(pos_emb).reshape(n_batch_pos, -1, self.h, self.d_k)
+        p = mx.transpose(p, (0, 2, 1, 3))  # (B, h, T1, d_k)
+
+        # Add biases to query
+        q_with_bias_u = mx.transpose(
+            q + self.pos_bias_u, (0, 2, 1, 3)
+        )  # (B, h, T1, d_k)
+        q_with_bias_v = mx.transpose(
+            q + self.pos_bias_v, (0, 2, 1, 3)
+        )  # (B, h, T1, d_k)
+
+        # Compute attention scores with relative position
+        matrix_ac = q_with_bias_u @ mx.swapaxes(k, -2, -1)
+        matrix_bd = q_with_bias_v @ mx.swapaxes(p, -2, -1)
+
+        # Apply relative shift if needed
+        if matrix_ac.shape != matrix_bd.shape:
+            matrix_bd = self.rel_shift(matrix_bd)
+
+        scores = (matrix_ac + matrix_bd) / math.sqrt(self.d_k)
+
+        return self.forward_attention(v, scores, mask), new_cache

--- a/mlx_audio/tts/models/chatterbox/s3gen/transformer/convolution.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/transformer/convolution.py
@@ -1,0 +1,149 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from typing import Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class ConvolutionModule(nn.Module):
+    """Convolution module for Conformer."""
+
+    def __init__(
+        self,
+        channels: int,
+        kernel_size: int = 15,
+        activation: nn.Module = None,
+        norm: str = "batch_norm",
+        causal: bool = False,
+        bias: bool = True,
+    ):
+        """
+        Args:
+            channels: Number of channels
+            kernel_size: Kernel size of depthwise convolution
+            activation: Activation function (defaults to SiLU)
+            norm: Normalization type ('batch_norm' or 'layer_norm')
+            causal: Whether to use causal convolution
+            bias: Whether to use bias
+        """
+        super().__init__()
+
+        # Pointwise expansion
+        self.pointwise_conv1 = nn.Conv1d(
+            channels,
+            2 * channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=bias,
+        )
+
+        # Causal vs symmetric padding
+        if causal:
+            padding = 0
+            self.lorder = kernel_size - 1
+        else:
+            assert (
+                kernel_size - 1
+            ) % 2 == 0, "kernel_size must be odd for symmetric conv"
+            padding = (kernel_size - 1) // 2
+            self.lorder = 0
+
+        # Depthwise convolution (groups=channels for depthwise)
+        self.depthwise_conv = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size,
+            stride=1,
+            padding=padding,
+            groups=channels,
+            bias=bias,
+        )
+        self.channels = channels
+        self.kernel_size = kernel_size
+
+        # Normalization
+        assert norm in ["batch_norm", "layer_norm"]
+        if norm == "batch_norm":
+            self.use_layer_norm = False
+            self.norm = nn.BatchNorm(channels)
+        else:
+            self.use_layer_norm = True
+            self.norm = nn.LayerNorm(channels)
+
+        # Pointwise compression
+        self.pointwise_conv2 = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=bias,
+        )
+
+        self.activation = activation if activation is not None else nn.SiLU()
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask_pad: mx.array = None,
+        cache: mx.array = None,
+    ) -> Tuple[mx.array, mx.array]:
+        """
+        Compute convolution module.
+
+        Args:
+            x: Input tensor (B, T, C)
+            mask_pad: Padding mask (B, 1, T)
+            cache: Left context cache for causal conv (B, C, cache_t)
+
+        Returns:
+            output: (B, T, C)
+            new_cache: (B, C, lorder) for causal, or empty
+        """
+        # Transpose to (B, C, T)
+        x = mx.swapaxes(x, 1, 2)
+
+        # Apply mask
+        if mask_pad is not None and mask_pad.shape[2] > 0:
+            x = mx.where(mask_pad, x, 0.0)
+
+        # Handle causal convolution caching
+        if self.lorder > 0:
+            if cache is None or cache.shape[2] == 0:
+                # Pad on left for causal conv
+                x = mx.pad(x, [(0, 0), (0, 0), (self.lorder, 0)])
+            else:
+                # Use cache
+                x = mx.concatenate([cache, x], axis=2)
+            new_cache = x[:, :, -self.lorder :]
+        else:
+            new_cache = mx.zeros((0, 0, 0))
+
+        # GLU mechanism: pointwise expansion + gated linear unit
+        x = self.pointwise_conv1(x)  # (B, 2C, T)
+        x = nn.glu(x, axis=1)  # (B, C, T)
+
+        # Depthwise convolution
+        x = self.depthwise_conv(x)
+
+        # Normalization
+        if self.use_layer_norm:
+            x = mx.swapaxes(x, 1, 2)  # (B, T, C)
+            x = self.norm(x)
+            x = self.activation(x)
+            x = mx.swapaxes(x, 1, 2)  # (B, C, T)
+        else:
+            x = self.norm(x)
+            x = self.activation(x)
+
+        # Pointwise compression
+        x = self.pointwise_conv2(x)
+
+        # Apply mask again
+        if mask_pad is not None and mask_pad.shape[2] > 0:
+            x = mx.where(mask_pad, x, 0.0)
+
+        # Transpose back to (B, T, C)
+        return mx.swapaxes(x, 1, 2), new_cache

--- a/mlx_audio/tts/models/chatterbox/s3gen/transformer/embedding.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/transformer/embedding.py
@@ -1,0 +1,230 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import math
+from typing import Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class PositionalEncoding(nn.Module):
+    """
+    Sinusoidal positional encoding.
+
+    PE(pos, 2i)   = sin(pos/(10000^(2i/d_model)))
+    PE(pos, 2i+1) = cos(pos/(10000^(2i/d_model)))
+    """
+
+    def __init__(self, d_model: int, dropout_rate: float, max_len: int = 5000):
+        """
+        Args:
+            d_model: Embedding dimension
+            dropout_rate: Dropout rate
+            max_len: Maximum input length
+        """
+        super().__init__()
+        self.d_model = d_model
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout_rate = dropout_rate
+        self.max_len = max_len
+
+        # Precompute positional encodings
+        self.pe = self._create_pe(max_len, d_model)
+
+    def _create_pe(self, max_len: int, d_model: int) -> mx.array:
+        """Create positional encoding matrix."""
+        pe = mx.zeros((max_len, d_model))
+        position = mx.arange(0, max_len, dtype=mx.float32)[:, None]
+        div_term = mx.exp(
+            mx.arange(0, d_model, 2, dtype=mx.float32) * -(math.log(10000.0) / d_model)
+        )
+
+        pe_sin = mx.sin(position * div_term)
+        pe_cos = mx.cos(position * div_term)
+
+        # Interleave sin and cos
+        pe = mx.zeros((max_len, d_model))
+        pe = pe.at[:, 0::2].add(pe_sin)
+        pe = pe.at[:, 1::2].add(pe_cos)
+
+        return mx.expand_dims(pe, 0)  # (1, max_len, d_model)
+
+    def __call__(self, x: mx.array, offset: int = 0) -> Tuple[mx.array, mx.array]:
+        """
+        Add positional encoding.
+
+        Args:
+            x: Input tensor (B, T, D)
+            offset: Position offset
+
+        Returns:
+            x: Encoded input (B, T, D)
+            pos_emb: Positional embeddings (1, T, D)
+        """
+        pos_emb = self.position_encoding(offset, x.shape[1])
+        x = x * self.xscale + pos_emb
+
+        if self.training and self.dropout_rate > 0:
+            x = nn.Dropout(self.dropout_rate)(x)
+            pos_emb = nn.Dropout(self.dropout_rate)(pos_emb)
+
+        return x, pos_emb
+
+    def position_encoding(self, offset: int, size: int) -> mx.array:
+        """Get positional encoding for a range."""
+        assert offset + size <= self.max_len
+        return self.pe[:, offset : offset + size, :]
+
+
+class RelPositionalEncoding(PositionalEncoding):
+    """
+    Relative positional encoding module.
+
+    See Appendix B in https://arxiv.org/abs/1901.02860
+
+    Unlike PositionalEncoding, this does NOT add pos_emb to input.
+    The pos_emb is returned separately for use in relative attention.
+    """
+
+    def __init__(self, d_model: int, dropout_rate: float, max_len: int = 5000):
+        super().__init__(d_model, dropout_rate, max_len)
+
+    def __call__(self, x: mx.array, offset: int = 0) -> Tuple[mx.array, mx.array]:
+        """
+        Compute positional encoding.
+
+        Args:
+            x: Input tensor (B, T, D)
+            offset: Position offset
+
+        Returns:
+            x: Scaled input (B, T, D) - NOT added to pos_emb
+            pos_emb: Positional embeddings (1, T, D)
+        """
+        x = x * self.xscale
+        pos_emb = self.position_encoding(offset, x.shape[1])
+
+        if self.training and self.dropout_rate > 0:
+            x = nn.Dropout(self.dropout_rate)(x)
+            pos_emb = nn.Dropout(self.dropout_rate)(pos_emb)
+
+        return x, pos_emb
+
+
+class EspnetRelPositionalEncoding(nn.Module):
+    """
+    Relative positional encoding module (ESPnet implementation).
+
+    This version computes both positive and negative position encodings
+    for bidirectional relative attention.
+
+    See https://github.com/espnet/espnet/pull/2816
+    and Appendix B in https://arxiv.org/abs/1901.02860
+    """
+
+    def __init__(self, d_model: int, dropout_rate: float, max_len: int = 5000):
+        super().__init__()
+        self.d_model = d_model
+        self.xscale = math.sqrt(self.d_model)
+        self.dropout_rate = dropout_rate
+        self.max_len = max_len
+
+        # Initialize PE - will be extended as needed
+        self.pe = None
+        self._extend_pe(max_len)
+
+    def _extend_pe(self, size: int):
+        """Create or extend positional encodings."""
+        if self.pe is not None and self.pe.shape[1] >= size * 2 - 1:
+            return
+
+        # Create positive and negative position encodings
+        position = mx.arange(0, size, dtype=mx.float32)[:, None]
+        div_term = mx.exp(
+            mx.arange(0, self.d_model, 2, dtype=mx.float32)
+            * -(math.log(10000.0) / self.d_model)
+        )
+
+        # Positive positions
+        pe_positive_sin = mx.sin(position * div_term)
+        pe_positive_cos = mx.cos(position * div_term)
+        pe_positive = mx.zeros((size, self.d_model))
+        pe_positive = pe_positive.at[:, 0::2].add(pe_positive_sin)
+        pe_positive = pe_positive.at[:, 1::2].add(pe_positive_cos)
+
+        # Negative positions
+        pe_negative_sin = mx.sin(-1 * position * div_term)
+        pe_negative_cos = mx.cos(-1 * position * div_term)
+        pe_negative = mx.zeros((size, self.d_model))
+        pe_negative = pe_negative.at[:, 0::2].add(pe_negative_sin)
+        pe_negative = pe_negative.at[:, 1::2].add(pe_negative_cos)
+
+        # Reverse positive and concatenate
+        # pe_positive: [0, 1, 2, ...] -> reversed: [..., 2, 1, 0]
+        pe_positive = mx.expand_dims(mx.flip(pe_positive, axis=0), 0)
+        # pe_negative: skip first (which is 0) -> [1, 2, 3, ...]
+        pe_negative = mx.expand_dims(pe_negative[1:], 0)
+
+        # Concatenate: [..., 2, 1, 0, 1, 2, ...]
+        self.pe = mx.concatenate([pe_positive, pe_negative], axis=1)
+
+    def __call__(self, x: mx.array, offset: int = 0) -> Tuple[mx.array, mx.array]:
+        """
+        Add positional encoding.
+
+        Args:
+            x: Input tensor (B, T, D)
+            offset: Position offset (not used in this implementation)
+
+        Returns:
+            x: Scaled input (B, T, D)
+            pos_emb: Positional embeddings (1, 2*T-1, D)
+        """
+        self._extend_pe(x.shape[1])
+        x = x * self.xscale
+        pos_emb = self.position_encoding(x.shape[1], offset)
+
+        if self.training and self.dropout_rate > 0:
+            x = nn.Dropout(self.dropout_rate)(x)
+            pos_emb = nn.Dropout(self.dropout_rate)(pos_emb)
+
+        return x, pos_emb
+
+    def position_encoding(self, size: int, offset: int = 0) -> mx.array:
+        """
+        Get positional encoding for relative attention.
+
+        Args:
+            size: Required size
+            offset: Position offset (not used)
+
+        Returns:
+            pos_emb: Positional embeddings (1, 2*size-1, d_model)
+        """
+        # Extract from center: positions from -(size-1) to +(size-1)
+        center = self.pe.shape[1] // 2
+        start = center - size + 1
+        end = center + size
+        return self.pe[:, start:end, :]
+
+
+class NoPositionalEncoding(nn.Module):
+    """No positional encoding - returns zeros."""
+
+    def __init__(self, d_model: int, dropout_rate: float):
+        super().__init__()
+        self.d_model = d_model
+        self.dropout_rate = dropout_rate
+
+    def __call__(self, x: mx.array, offset: int = 0) -> Tuple[mx.array, mx.array]:
+        """Return input unchanged with zero positional embeddings."""
+        pos_emb = mx.zeros((1, x.shape[1], self.d_model))
+
+        if self.training and self.dropout_rate > 0:
+            x = nn.Dropout(self.dropout_rate)(x)
+
+        return x, pos_emb
+
+    def position_encoding(self, offset: int, size: int) -> mx.array:
+        """Return zero positional encoding."""
+        return mx.zeros((1, size, self.d_model))

--- a/mlx_audio/tts/models/chatterbox/s3gen/transformer/encoder_layer.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/transformer/encoder_layer.py
@@ -1,0 +1,147 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class ConformerEncoderLayer(nn.Module):
+    """
+    Conformer encoder layer module.
+
+    Combines self-attention, convolution, and feed-forward modules
+    with residual connections and layer normalization.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        self_attn: nn.Module,
+        feed_forward: Optional[nn.Module] = None,
+        feed_forward_macaron: Optional[nn.Module] = None,
+        conv_module: Optional[nn.Module] = None,
+        dropout_rate: float = 0.1,
+        normalize_before: bool = True,
+    ):
+        """
+        Args:
+            size: Input/output dimension
+            self_attn: Self-attention module
+            feed_forward: Feed-forward module
+            feed_forward_macaron: Optional macaron-style feed-forward
+            conv_module: Optional convolution module
+            dropout_rate: Dropout rate
+            normalize_before: Whether to apply layer norm before or after sub-blocks
+        """
+        super().__init__()
+        self.self_attn = self_attn
+        self.feed_forward = feed_forward
+        self.feed_forward_macaron = feed_forward_macaron
+        self.conv_module = conv_module
+
+        self.norm_ff = nn.LayerNorm(size, eps=1e-12)
+        self.norm_mha = nn.LayerNorm(size, eps=1e-12)
+
+        if feed_forward_macaron is not None:
+            self.norm_ff_macaron = nn.LayerNorm(size, eps=1e-12)
+            self.ff_scale = 0.5
+        else:
+            self.ff_scale = 1.0
+
+        if self.conv_module is not None:
+            self.norm_conv = nn.LayerNorm(size, eps=1e-12)
+            self.norm_final = nn.LayerNorm(size, eps=1e-12)
+
+        self.dropout_rate = dropout_rate
+        self.size = size
+        self.normalize_before = normalize_before
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: mx.array,
+        pos_emb: mx.array,
+        mask_pad: mx.array = None,
+        att_cache: mx.array = None,
+        cnn_cache: mx.array = None,
+    ) -> Tuple[mx.array, mx.array, mx.array, mx.array]:
+        """
+        Compute encoded features.
+
+        Args:
+            x: Input tensor (B, T, D)
+            mask: Attention mask (B, T, T)
+            pos_emb: Positional embeddings
+            mask_pad: Padding mask (B, 1, T)
+            att_cache: Attention KV cache (1, head, cache_t, d_k * 2)
+            cnn_cache: Convolution cache (1, D, cache_t)
+
+        Returns:
+            x: Output tensor (B, T, D)
+            mask: Mask tensor (B, T, T)
+            new_att_cache: Updated attention cache
+            new_cnn_cache: Updated convolution cache
+        """
+        # Macaron-style feed-forward (optional, half-step)
+        if self.feed_forward_macaron is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_ff_macaron(x)
+            ff_out = self.feed_forward_macaron(x)
+            if self.training and self.dropout_rate > 0:
+                ff_out = nn.Dropout(self.dropout_rate)(ff_out)
+            x = residual + self.ff_scale * ff_out
+            if not self.normalize_before:
+                x = self.norm_ff_macaron(x)
+
+        # Multi-headed self-attention
+        residual = x
+        if self.normalize_before:
+            x = self.norm_mha(x)
+
+        x_att, new_att_cache = self.self_attn(
+            x, x, x, mask, pos_emb=pos_emb, cache=att_cache
+        )
+
+        if self.training and self.dropout_rate > 0:
+            x_att = nn.Dropout(self.dropout_rate)(x_att)
+        x = residual + x_att
+
+        if not self.normalize_before:
+            x = self.norm_mha(x)
+
+        # Convolution module (optional)
+        new_cnn_cache = mx.zeros((0, 0, 0))
+        if self.conv_module is not None:
+            residual = x
+            if self.normalize_before:
+                x = self.norm_conv(x)
+
+            x, new_cnn_cache = self.conv_module(x, mask_pad, cnn_cache)
+
+            if self.training and self.dropout_rate > 0:
+                x = nn.Dropout(self.dropout_rate)(x)
+            x = residual + x
+
+            if not self.normalize_before:
+                x = self.norm_conv(x)
+
+        # Feed-forward module
+        residual = x
+        if self.normalize_before:
+            x = self.norm_ff(x)
+
+        ff_out = self.feed_forward(x)
+        if self.training and self.dropout_rate > 0:
+            ff_out = nn.Dropout(self.dropout_rate)(ff_out)
+        x = residual + self.ff_scale * ff_out
+
+        if not self.normalize_before:
+            x = self.norm_ff(x)
+
+        # Final normalization (if using conv module)
+        if self.conv_module is not None:
+            x = self.norm_final(x)
+
+        return x, mask, new_att_cache, new_cnn_cache

--- a/mlx_audio/tts/models/chatterbox/s3gen/transformer/positionwise_feed_forward.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/transformer/positionwise_feed_forward.py
@@ -1,0 +1,51 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class PositionwiseFeedForward(nn.Module):
+    """
+    Positionwise feed forward layer.
+
+    Feed forward applied on each position of the sequence.
+    The output dim is same as the input dim.
+    """
+
+    def __init__(
+        self,
+        idim: int,
+        hidden_units: int,
+        dropout_rate: float,
+        activation: nn.Module = None,
+    ):
+        """
+        Args:
+            idim: Input dimension
+            hidden_units: Number of hidden units
+            dropout_rate: Dropout rate
+            activation: Activation function (defaults to ReLU)
+        """
+        super().__init__()
+        self.w_1 = nn.Linear(idim, hidden_units)
+        self.activation = activation if activation is not None else nn.ReLU()
+        self.dropout_rate = dropout_rate
+        self.w_2 = nn.Linear(hidden_units, idim)
+
+    def __call__(self, xs: mx.array) -> mx.array:
+        """
+        Forward function.
+
+        Args:
+            xs: Input tensor (B, L, D)
+
+        Returns:
+            Output tensor (B, L, D)
+        """
+        x = self.w_1(xs)
+        x = self.activation(x)
+
+        if self.training and self.dropout_rate > 0:
+            x = nn.Dropout(self.dropout_rate)(x)
+
+        return self.w_2(x)

--- a/mlx_audio/tts/models/chatterbox/s3gen/transformer/subsampling.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/transformer/subsampling.py
@@ -1,0 +1,70 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from typing import Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class BaseSubsampling(nn.Module):
+    """Base class for subsampling modules."""
+
+    def __init__(self):
+        super().__init__()
+        self.right_context = 0
+        self.subsampling_rate = 1
+
+    def position_encoding(self, offset: int, size: int) -> mx.array:
+        """Get position encoding from pos_enc module."""
+        return self.pos_enc.position_encoding(offset, size)
+
+
+class LinearNoSubsampling(BaseSubsampling):
+    """
+    Linear transform the input without subsampling.
+
+    Used in UpsampleConformerEncoder.
+    """
+
+    def __init__(
+        self, idim: int, odim: int, dropout_rate: float, pos_enc_class: nn.Module
+    ):
+        """
+        Args:
+            idim: Input dimension
+            odim: Output dimension
+            dropout_rate: Dropout rate
+            pos_enc_class: Positional encoding module
+        """
+        super().__init__()
+        self.linear = nn.Linear(idim, odim)
+        self.norm = nn.LayerNorm(odim, eps=1e-5)
+        self.dropout_rate = dropout_rate
+        self.pos_enc = pos_enc_class
+        self.right_context = 0
+        self.subsampling_rate = 1
+
+    def __call__(
+        self, x: mx.array, x_mask: mx.array, offset: int = 0
+    ) -> Tuple[mx.array, mx.array, mx.array]:
+        """
+        Apply linear transformation without subsampling.
+
+        Args:
+            x: Input tensor (B, T, idim)
+            x_mask: Input mask (B, 1, T)
+            offset: Position offset
+
+        Returns:
+            x: Output tensor (B, T, odim)
+            pos_emb: Positional embeddings
+            x_mask: Output mask (B, 1, T) - unchanged
+        """
+        x = self.linear(x)
+        x = self.norm(x)
+
+        if self.training and self.dropout_rate > 0:
+            x = nn.Dropout(self.dropout_rate)(x)
+
+        x, pos_emb = self.pos_enc(x, offset)
+        return x, pos_emb, x_mask

--- a/mlx_audio/tts/models/chatterbox/s3gen/transformer/upsample_encoder.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/transformer/upsample_encoder.py
@@ -1,0 +1,530 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from typing import Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .attention import MultiHeadedAttention, RelPositionMultiHeadedAttention
+from .convolution import ConvolutionModule
+from .embedding import RelPositionalEncoding
+from .encoder_layer import ConformerEncoderLayer
+from .positionwise_feed_forward import PositionwiseFeedForward
+from .subsampling import LinearNoSubsampling
+
+
+class Upsample1D(nn.Module):
+    """A 1D upsampling layer with an optional convolution.
+
+    Parameters:
+        channels (int): number of channels in the inputs and outputs.
+        out_channels (int): number of output channels.
+        stride (int): upsampling factor. Defaults to 2.
+    """
+
+    def __init__(self, channels: int, out_channels: int, stride: int = 2):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels
+        self.stride = stride
+        # In this mode, first repeat interpolate, then conv with stride=1
+        self.conv = nn.Conv1d(
+            self.channels, self.out_channels, stride * 2 + 1, stride=1, padding=0
+        )
+
+    def __call__(
+        self, inputs: mx.array, input_lengths: mx.array
+    ) -> Tuple[mx.array, mx.array]:
+        """
+        Args:
+            inputs: Input tensor (B, C, T) - PyTorch format
+            input_lengths: Lengths tensor (B,)
+
+        Returns:
+            outputs: Upsampled tensor (B, C, T*stride) - PyTorch format
+            output_lengths: Updated lengths (B,)
+        """
+        # Upsample using nearest neighbor interpolation
+        B, C, T = inputs.shape
+        new_T = T * self.stride
+
+        # Repeat each timestep stride times
+        outputs = mx.repeat(inputs, self.stride, axis=2)
+
+        # Pad on the left (axis 2 in PyTorch format B,C,T)
+        outputs = mx.pad(outputs, [(0, 0), (0, 0), (self.stride * 2, 0)])
+
+        # Transpose to MLX format (B, T, C) for conv
+        outputs = mx.transpose(outputs, [0, 2, 1])
+
+        # Apply convolution (MLX Conv1d expects B, T, C)
+        outputs = self.conv(outputs)
+
+        # Transpose back to PyTorch format (B, C, T)
+        outputs = mx.transpose(outputs, [0, 2, 1])
+
+        return outputs, input_lengths * self.stride
+
+
+class PreLookaheadLayer(nn.Module):
+    """Pre-lookahead layer for causal processing."""
+
+    def __init__(self, channels: int, pre_lookahead_len: int = 1):
+        super().__init__()
+        self.channels = channels
+        self.pre_lookahead_len = pre_lookahead_len
+        self.conv1 = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=pre_lookahead_len + 1,
+            stride=1,
+            padding=0,
+        )
+        self.conv2 = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=3,
+            stride=1,
+            padding=0,
+        )
+
+    def __call__(self, inputs: mx.array) -> mx.array:
+        """
+        Args:
+            inputs: Input tensor (B, T, C)
+
+        Returns:
+            outputs: Output tensor (B, T, C)
+        """
+        # Input is (B, T, C) - MLX Conv1d expects (B, T, C)
+        outputs = inputs
+
+        # Look ahead padding on time dimension (axis 1)
+        outputs = mx.pad(outputs, [(0, 0), (0, self.pre_lookahead_len), (0, 0)])
+        outputs = nn.leaky_relu(self.conv1(outputs))
+
+        # Output padding on time dimension (axis 1)
+        outputs = mx.pad(outputs, [(0, 0), (2, 0), (0, 0)])
+        outputs = self.conv2(outputs)
+
+        # Residual connection
+        outputs = outputs + inputs
+        return outputs
+
+
+def make_pad_mask(lengths: mx.array, max_len: int = 0) -> mx.array:
+    """Make mask tensor containing indices of padded part.
+
+    Args:
+        lengths: Batch of lengths (B,).
+        max_len: Maximum length. If 0, uses max of lengths.
+
+    Returns:
+        Mask tensor containing indices of padded part (B, T).
+
+    Examples:
+        >>> lengths = [5, 3, 2]
+        >>> make_pad_mask(lengths)
+        masks = [[0, 0, 0, 0, 0],
+                 [0, 0, 0, 1, 1],
+                 [0, 0, 1, 1, 1]]
+    """
+    batch_size = lengths.shape[0]
+    max_len = max_len if max_len > 0 else int(mx.max(lengths).item())
+
+    seq_range = mx.arange(max_len)
+    seq_range_expand = mx.expand_dims(seq_range, 0)  # (1, T)
+    seq_range_expand = mx.broadcast_to(
+        seq_range_expand, (batch_size, max_len)
+    )  # (B, T)
+
+    seq_length_expand = mx.expand_dims(lengths, -1)  # (B, 1)
+    mask = seq_range_expand >= seq_length_expand
+    return mask
+
+
+def subsequent_chunk_mask(
+    size: int,
+    chunk_size: int,
+    num_left_chunks: int = -1,
+) -> mx.array:
+    """Create mask for subsequent steps (size, size) with chunk size.
+
+    This is for streaming encoder.
+
+    Args:
+        size: size of mask
+        chunk_size: size of chunk
+        num_left_chunks: number of left chunks
+            <0: use full chunk
+            >=0: use num_left_chunks
+
+    Returns:
+        Mask tensor (size, size)
+
+    Examples:
+        >>> subsequent_chunk_mask(4, 2)
+        [[1, 1, 0, 0],
+         [1, 1, 0, 0],
+         [1, 1, 1, 1],
+         [1, 1, 1, 1]]
+    """
+    pos_idx = mx.arange(size)
+    block_value = ((pos_idx // chunk_size) + 1) * chunk_size
+    ret = mx.expand_dims(pos_idx, 0) < mx.expand_dims(block_value, 1)
+    return ret
+
+
+def add_optional_chunk_mask(
+    xs: mx.array,
+    masks: mx.array,
+    use_dynamic_chunk: bool,
+    use_dynamic_left_chunk: bool,
+    decoding_chunk_size: int,
+    static_chunk_size: int,
+    num_decoding_left_chunks: int,
+    enable_full_context: bool = True,
+) -> mx.array:
+    """Apply optional mask for encoder.
+
+    Args:
+        xs: padded input, (B, L, D), L for max length
+        masks: mask for xs, (B, 1, L)
+        use_dynamic_chunk: whether to use dynamic chunk or not
+        use_dynamic_left_chunk: whether to use dynamic left chunk for training.
+        decoding_chunk_size: decoding chunk size for dynamic chunk, it's
+            0: default for training, use random dynamic chunk.
+            <0: for decoding, use full chunk.
+            >0: for decoding, use fixed chunk size as set.
+        static_chunk_size: chunk size for static chunk training/decoding
+        num_decoding_left_chunks: number of left chunks
+            >=0: use num_decoding_left_chunks
+            <0: use all left chunks
+        enable_full_context:
+            True: chunk size is either [1, 25] or full context(max_len)
+            False: chunk size ~ U[1, 25]
+
+    Returns:
+        chunk mask of the input xs.
+    """
+    # Whether to use chunk mask or not
+    if use_dynamic_chunk:
+        max_len = xs.shape[1]
+        if decoding_chunk_size < 0:
+            chunk_size = max_len
+            num_left_chunks = -1
+        elif decoding_chunk_size > 0:
+            chunk_size = decoding_chunk_size
+            num_left_chunks = num_decoding_left_chunks
+        else:
+            # For training, use random chunk size
+            import random
+
+            chunk_size = random.randint(1, max_len - 1)
+            num_left_chunks = -1
+            if chunk_size > max_len // 2 and enable_full_context:
+                chunk_size = max_len
+            else:
+                chunk_size = chunk_size % 25 + 1
+                if use_dynamic_left_chunk:
+                    max_left_chunks = (max_len - 1) // chunk_size
+                    num_left_chunks = random.randint(0, max_left_chunks)
+
+        chunk_masks = subsequent_chunk_mask(xs.shape[1], chunk_size, num_left_chunks)
+        chunk_masks = mx.expand_dims(chunk_masks, 0)  # (1, L, L)
+        chunk_masks = masks & chunk_masks  # (B, L, L)
+    elif static_chunk_size > 0:
+        num_left_chunks = num_decoding_left_chunks
+        chunk_masks = subsequent_chunk_mask(
+            xs.shape[1], static_chunk_size, num_left_chunks
+        )
+        chunk_masks = mx.expand_dims(chunk_masks, 0)  # (1, L, L)
+        chunk_masks = masks & chunk_masks  # (B, L, L)
+    else:
+        chunk_masks = masks
+
+    # Check for all-false masks and fix them
+    mask_sums = mx.sum(chunk_masks, axis=-1)
+    if mx.any(mask_sums == 0):
+        # Force set to true where all false
+        chunk_masks = mx.where(
+            mx.expand_dims(mask_sums == 0, -1), mx.ones_like(chunk_masks), chunk_masks
+        )
+
+    return chunk_masks
+
+
+class UpsampleConformerEncoder(nn.Module):
+    """Conformer encoder with upsampling for speech synthesis."""
+
+    def __init__(
+        self,
+        input_size: int = 512,
+        output_size: int = 512,
+        attention_heads: int = 8,
+        linear_units: int = 2048,
+        num_blocks: int = 6,
+        dropout_rate: float = 0.1,
+        positional_dropout_rate: float = 0.1,
+        attention_dropout_rate: float = 0.1,
+        input_layer: str = "linear",
+        pos_enc_layer_type: str = "rel_pos_espnet",
+        normalize_before: bool = True,
+        static_chunk_size: int = 0,
+        use_dynamic_chunk: bool = False,
+        use_dynamic_left_chunk: bool = False,
+        positionwise_conv_kernel_size: int = 1,
+        macaron_style: bool = False,
+        selfattention_layer_type: str = "rel_selfattn",
+        activation_type: str = "swish",
+        use_cnn_module: bool = False,
+        cnn_module_kernel: int = 15,
+        causal: bool = False,
+        cnn_module_norm: str = "batch_norm",
+        key_bias: bool = True,
+    ):
+        """
+        Args:
+            input_size: input dimension
+            output_size: dimension of attention
+            attention_heads: the number of heads of multi head attention
+            linear_units: the hidden units number of position-wise feed forward
+            num_blocks: the number of encoder blocks
+            dropout_rate: dropout rate
+            attention_dropout_rate: dropout rate in attention
+            positional_dropout_rate: dropout rate after adding positional encoding
+            input_layer: input layer type (currently only "linear" supported)
+            pos_enc_layer_type: positional encoding layer type
+            normalize_before: use layer_norm before each sub-block
+            static_chunk_size: chunk size for static chunk training/decoding
+            use_dynamic_chunk: whether use dynamic chunk size for training
+            use_dynamic_left_chunk: whether use dynamic left chunk
+            macaron_style: whether to use macaron style FFN
+            selfattention_layer_type: self-attention layer type
+            activation_type: activation function type
+            use_cnn_module: whether to use convolution module
+            cnn_module_kernel: kernel size of convolution module
+            causal: whether to use causal convolution
+            cnn_module_norm: normalization type for convolution module
+            key_bias: whether use bias in attention.linear_k
+        """
+        super().__init__()
+        self._output_size = output_size
+
+        # Input embedding layer
+        if input_layer == "linear":
+            self.embed = LinearNoSubsampling(
+                input_size,
+                output_size,
+                dropout_rate,
+                RelPositionalEncoding(output_size, positional_dropout_rate),
+            )
+        else:
+            raise ValueError(f"Unsupported input_layer: {input_layer}")
+
+        self.normalize_before = normalize_before
+        self.after_norm = nn.LayerNorm(output_size, eps=1e-5)
+        self.static_chunk_size = static_chunk_size
+        self.use_dynamic_chunk = use_dynamic_chunk
+        self.use_dynamic_left_chunk = use_dynamic_left_chunk
+
+        # Activation function
+        if activation_type == "swish":
+            activation = nn.SiLU()
+        else:
+            raise ValueError(f"Unsupported activation: {activation_type}")
+
+        # Self-attention layer
+        if selfattention_layer_type == "rel_selfattn":
+            self_attn_class = RelPositionMultiHeadedAttention
+        elif selfattention_layer_type == "selfattn":
+            self_attn_class = MultiHeadedAttention
+        else:
+            raise ValueError(
+                f"Unsupported selfattention_layer_type: {selfattention_layer_type}"
+            )
+
+        # Pre-lookahead layer
+        self.pre_lookahead_layer = PreLookaheadLayer(channels=512, pre_lookahead_len=3)
+
+        # Main encoder layers
+        self.encoders = [
+            ConformerEncoderLayer(
+                output_size,
+                self_attn_class(
+                    attention_heads,
+                    output_size,
+                    attention_dropout_rate,
+                    key_bias,
+                ),
+                PositionwiseFeedForward(
+                    output_size, linear_units, dropout_rate, activation
+                ),
+                (
+                    PositionwiseFeedForward(
+                        output_size, linear_units, dropout_rate, activation
+                    )
+                    if macaron_style
+                    else None
+                ),
+                (
+                    ConvolutionModule(
+                        output_size,
+                        cnn_module_kernel,
+                        activation,
+                        cnn_module_norm,
+                        causal,
+                    )
+                    if use_cnn_module
+                    else None
+                ),
+                dropout_rate,
+                normalize_before,
+            )
+            for _ in range(num_blocks)
+        ]
+
+        # Upsampling layer
+        self.up_layer = Upsample1D(channels=512, out_channels=512, stride=2)
+
+        # Upsampling embedding layer
+        if input_layer == "linear":
+            self.up_embed = LinearNoSubsampling(
+                input_size,
+                output_size,
+                dropout_rate,
+                RelPositionalEncoding(output_size, positional_dropout_rate),
+            )
+        else:
+            raise ValueError(f"Unsupported input_layer: {input_layer}")
+
+        # Upsampling encoder layers
+        self.up_encoders = [
+            ConformerEncoderLayer(
+                output_size,
+                self_attn_class(
+                    attention_heads,
+                    output_size,
+                    attention_dropout_rate,
+                    key_bias,
+                ),
+                PositionwiseFeedForward(
+                    output_size, linear_units, dropout_rate, activation
+                ),
+                (
+                    PositionwiseFeedForward(
+                        output_size, linear_units, dropout_rate, activation
+                    )
+                    if macaron_style
+                    else None
+                ),
+                (
+                    ConvolutionModule(
+                        output_size,
+                        cnn_module_kernel,
+                        activation,
+                        cnn_module_norm,
+                        causal,
+                    )
+                    if use_cnn_module
+                    else None
+                ),
+                dropout_rate,
+                normalize_before,
+            )
+            for _ in range(4)
+        ]
+
+    def output_size(self) -> int:
+        return self._output_size
+
+    def __call__(
+        self,
+        xs: mx.array,
+        xs_lens: mx.array,
+        decoding_chunk_size: int = 0,
+        num_decoding_left_chunks: int = -1,
+    ) -> Tuple[mx.array, mx.array]:
+        """Embed positions in tensor.
+
+        Args:
+            xs: padded input tensor (B, T, D)
+            xs_lens: input length (B)
+            decoding_chunk_size: decoding chunk size for dynamic chunk
+                0: default for training, use random dynamic chunk.
+                <0: for decoding, use full chunk.
+                >0: for decoding, use fixed chunk size as set.
+            num_decoding_left_chunks: number of left chunks
+                >=0: use num_decoding_left_chunks
+                <0: use all left chunks
+
+        Returns:
+            encoder output tensor xs, and subsampled masks
+            xs: padded output tensor (B, T' ~= T*2, D)
+            masks: batch padding mask (B, 1, T' ~= T*2)
+        """
+        T = xs.shape[1]
+        masks = mx.logical_not(make_pad_mask(xs_lens, T))
+        masks = mx.expand_dims(masks, 1)  # (B, 1, T)
+
+        xs, pos_emb, masks = self.embed(xs, masks)
+        mask_pad = masks  # (B, 1, T)
+
+        chunk_masks = add_optional_chunk_mask(
+            xs,
+            masks,
+            self.use_dynamic_chunk,
+            self.use_dynamic_left_chunk,
+            decoding_chunk_size,
+            self.static_chunk_size,
+            num_decoding_left_chunks,
+        )
+
+        # Lookahead + conformer encoder
+        xs = self.pre_lookahead_layer(xs)
+        xs = self.forward_layers(xs, chunk_masks, pos_emb, mask_pad)
+
+        # Upsample + conformer encoder
+        xs = mx.transpose(xs, [0, 2, 1])  # (B, D, T)
+        xs, xs_lens = self.up_layer(xs, xs_lens)
+        xs = mx.transpose(xs, [0, 2, 1])  # (B, T', D)
+
+        T = xs.shape[1]
+        masks = mx.logical_not(make_pad_mask(xs_lens, T))
+        masks = mx.expand_dims(masks, 1)  # (B, 1, T')
+
+        xs, pos_emb, masks = self.up_embed(xs, masks)
+        mask_pad = masks  # (B, 1, T')
+
+        chunk_masks = add_optional_chunk_mask(
+            xs,
+            masks,
+            self.use_dynamic_chunk,
+            self.use_dynamic_left_chunk,
+            decoding_chunk_size,
+            self.static_chunk_size * self.up_layer.stride,
+            num_decoding_left_chunks,
+        )
+
+        xs = self.forward_up_layers(xs, chunk_masks, pos_emb, mask_pad)
+
+        if self.normalize_before:
+            xs = self.after_norm(xs)
+
+        return xs, masks
+
+    def forward_layers(
+        self, xs: mx.array, chunk_masks: mx.array, pos_emb: mx.array, mask_pad: mx.array
+    ) -> mx.array:
+        """Forward through main encoder layers."""
+        for layer in self.encoders:
+            xs, chunk_masks, _, _ = layer(xs, chunk_masks, pos_emb, mask_pad)
+        return xs
+
+    def forward_up_layers(
+        self, xs: mx.array, chunk_masks: mx.array, pos_emb: mx.array, mask_pad: mx.array
+    ) -> mx.array:
+        """Forward through upsampling encoder layers."""
+        for layer in self.up_encoders:
+            xs, chunk_masks, _, _ = layer(xs, chunk_masks, pos_emb, mask_pad)
+        return xs

--- a/mlx_audio/tts/models/chatterbox/s3gen/xvector.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/xvector.py
@@ -1,0 +1,795 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+# Modified from 3D-Speaker (https://github.com/alibaba-damo-academy/3D-Speaker)
+
+from collections import OrderedDict
+from typing import Dict
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_audio.utils import mel_filters, stft
+
+
+def _povey_window(size: int) -> mx.array:
+    """
+    Create a Povey window (used by Kaldi).
+
+    The Povey window is a modified Hann window raised to the power of 0.85.
+    """
+    # Hann window: 0.5 - 0.5 * cos(2*pi*n/(N-1))
+    n = mx.arange(size)
+    hann = 0.5 - 0.5 * mx.cos(2 * mx.pi * n / (size - 1))
+    # Povey window: hann^0.85
+    return mx.power(hann, 0.85)
+
+
+def _next_power_of_2(n: int) -> int:
+    """Return next power of 2 >= n."""
+    if n <= 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+def kaldi_fbank(
+    audio: mx.array,
+    sample_rate: int = 16000,
+    num_mel_bins: int = 80,
+    frame_length: float = 25.0,  # ms
+    frame_shift: float = 10.0,  # ms
+) -> mx.array:
+    """
+    Extract Kaldi-compatible filterbank features.
+
+    Matches torchaudio.compliance.kaldi.fbank defaults:
+    - window_type: povey (hann^0.85)
+    - round_to_power_of_two: True
+    - snip_edges: True (no padding at edges)
+    - remove_dc_offset: True
+    - preemphasis_coefficient: 0.97
+
+    Args:
+        audio: Audio waveform (T,) at 16kHz
+        sample_rate: Sample rate (default 16000)
+        num_mel_bins: Number of mel bins (default 80)
+        frame_length: Frame length in milliseconds
+        frame_shift: Frame shift in milliseconds
+
+    Returns:
+        Filterbank features (T', num_mel_bins)
+    """
+    # Calculate frame parameters
+    win_length = int(sample_rate * frame_length / 1000)  # 400 for 25ms @ 16kHz
+    hop_length = int(sample_rate * frame_shift / 1000)  # 160 for 10ms @ 16kHz
+
+    # Kaldi rounds n_fft to next power of 2
+    n_fft = _next_power_of_2(win_length)  # 400 -> 512
+
+    # Ensure 1D
+    if audio.ndim > 1:
+        audio = audio.squeeze()
+
+    # Kaldi snip_edges=True: only process frames that fully fit in the signal
+    # Number of frames: floor((signal_len - win_length) / hop_length) + 1
+    signal_len = audio.shape[0]
+    num_frames = (signal_len - win_length) // hop_length + 1
+    if num_frames < 1:
+        num_frames = 1
+
+    # Create Povey window
+    window = _povey_window(win_length)
+
+    # Vectorized frame extraction using mx.take (no Python loop)
+    if num_frames > 0:
+        # Create indices for all frames at once: (num_frames, win_length)
+        frame_starts = mx.arange(num_frames) * hop_length  # (num_frames,)
+        frame_offsets = mx.arange(win_length)  # (win_length,)
+        # Broadcast to get all indices: (num_frames, win_length)
+        indices = frame_starts[:, None] + frame_offsets[None, :]
+
+        # Extract all frames at once
+        frames = mx.take(audio, indices.flatten()).reshape(num_frames, win_length)
+
+        # Remove DC offset per frame (vectorized)
+        frames = frames - mx.mean(frames, axis=1, keepdims=True)
+
+        # Apply pre-emphasis (vectorized): frame[1:] - 0.97 * frame[:-1]
+        preemph = 0.97
+        frames = mx.concatenate(
+            [frames[:, :1], frames[:, 1:] - preemph * frames[:, :-1]], axis=1
+        )
+
+        # Apply window (vectorized)
+        frames = frames * window[None, :]
+    else:
+        # Edge case: audio too short - single frame
+        frame = audio
+        if frame.shape[0] < win_length:
+            frame = mx.concatenate([frame, mx.zeros((win_length - frame.shape[0],))])
+        frame = frame[:win_length]
+        frame = frame - mx.mean(frame)
+        frame = mx.concatenate([frame[:1], frame[1:] - 0.97 * frame[:-1]])
+        frame = frame * window
+        frames = frame[None, :]  # (1, win_length)
+
+    # Zero-pad to n_fft for FFT
+    if win_length < n_fft:
+        pad_amount = n_fft - win_length
+        frames = mx.concatenate(
+            [frames, mx.zeros((frames.shape[0], pad_amount))], axis=1
+        )
+
+    # FFT
+    spec = mx.fft.rfft(frames)  # (num_frames, n_fft//2 + 1)
+
+    # Power spectrum
+    power_spec = mx.abs(spec) ** 2  # (num_frames, n_fft//2 + 1)
+
+    # Mel filterbank (Kaldi uses HTK mel scale)
+    filters = mel_filters(
+        sample_rate=sample_rate,
+        n_fft=n_fft,
+        n_mels=num_mel_bins,
+        f_min=20.0,
+        f_max=sample_rate / 2,
+        norm=None,
+        mel_scale="htk",
+    )
+
+    # Apply filterbank: (num_frames, F) @ (F, M) -> (num_frames, M)
+    mel_spec = power_spec @ filters.T
+
+    # Log compression with small floor (Kaldi uses std::numeric_limits<float>::epsilon())
+    # Note: energy_floor=1.0 applies to signal energy for dither, not mel bins
+    fbank = mx.log(mx.maximum(mel_spec, 1.1920929e-07))
+
+    return fbank
+
+
+class BasicResBlock(nn.Module):
+    """Basic residual block for 2D convolution."""
+
+    expansion = 1
+
+    def __init__(self, in_planes: int, planes: int, stride: int = 1):
+        super().__init__()
+        # PyTorch uses stride=(stride, 1) - stride in H dim only
+        # MLX Conv2d expects NHWC format
+        self.conv1 = nn.Conv2d(
+            in_planes, planes, kernel_size=3, stride=(stride, 1), padding=1, bias=False
+        )
+        self.bn1 = nn.BatchNorm(planes)
+        self.conv2 = nn.Conv2d(
+            planes, planes, kernel_size=3, stride=1, padding=1, bias=False
+        )
+        self.bn2 = nn.BatchNorm(planes)
+
+        self.shortcut = []
+        if stride != 1 or in_planes != self.expansion * planes:
+            self.shortcut = [
+                nn.Conv2d(
+                    in_planes,
+                    self.expansion * planes,
+                    kernel_size=1,
+                    stride=(stride, 1),
+                    bias=False,
+                ),
+                nn.BatchNorm(self.expansion * planes),
+            ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        out = nn.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+
+        # Shortcut connection
+        shortcut = x
+        for layer in self.shortcut:
+            shortcut = layer(shortcut)
+        out = out + shortcut
+
+        return nn.relu(out)
+
+
+class FCM(nn.Module):
+    """Feature Channel Module - processes input features."""
+
+    def __init__(
+        self, block=BasicResBlock, num_blocks=[2, 2], m_channels=32, feat_dim=80
+    ):
+        super().__init__()
+        self.in_planes = m_channels
+        self.conv1 = nn.Conv2d(
+            1, m_channels, kernel_size=3, stride=1, padding=1, bias=False
+        )
+        self.bn1 = nn.BatchNorm(m_channels)
+
+        self.layer1 = self._make_layer(block, m_channels, num_blocks[0], stride=2)
+        self.layer2 = self._make_layer(block, m_channels, num_blocks[0], stride=2)
+
+        # PyTorch uses stride=(2, 1) - stride 2 in H dim only
+        self.conv2 = nn.Conv2d(
+            m_channels, m_channels, kernel_size=3, stride=(2, 1), padding=1, bias=False
+        )
+        self.bn2 = nn.BatchNorm(m_channels)
+        self.out_channels = m_channels * (feat_dim // 8)
+
+    def _make_layer(self, block, planes: int, num_blocks: int, stride: int):
+        strides = [stride] + [1] * (num_blocks - 1)
+        layers = []
+        for s in strides:
+            layers.append(block(self.in_planes, planes, s))
+            self.in_planes = planes * block.expansion
+        return layers
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # Input x: (B, F, T) where F is features, T is time
+        # (after swapaxes in CAMPPlus to match PyTorch's permute(0,2,1))
+        # MLX Conv2d expects NHWC format: (B, H, W, C)
+        # We treat F as H, T as W, and add C=1
+        x = mx.expand_dims(x, -1)  # (B, F, T, 1) = (B, H, W, C)
+        out = nn.relu(self.bn1(self.conv1(x)))
+
+        for layer in self.layer1:
+            out = layer(out)
+        for layer in self.layer2:
+            out = layer(out)
+
+        out = nn.relu(self.bn2(self.conv2(out)))
+
+        # Reshape: (B, H, W, C) -> (B, C*H, W) to match PyTorch output
+        # Note: PyTorch output is (B, C, H, W) reshaped to (B, C*H, W)
+        # Our output is (B, H, W, C), need to permute first then reshape
+        B, H, W, C = out.shape
+        # Permute to (B, C, H, W) then reshape
+        out = mx.transpose(out, (0, 3, 1, 2))  # (B, C, H, W)
+        out = mx.reshape(out, (B, C * H, W))
+        return out
+
+
+def get_nonlinear(config_str: str, channels: int):
+    """Create non-linear activation layers based on config string."""
+    layers = []
+    for name in config_str.split("-"):
+        if name == "relu":
+            layers.append(lambda x: nn.relu(x))
+        elif name == "prelu":
+            layers.append(nn.PReLU(channels))
+        elif name == "batchnorm":
+            layers.append(nn.BatchNorm(channels))
+        elif name == "batchnorm_":
+            layers.append(nn.BatchNorm(channels, affine=False))
+        else:
+            raise ValueError(f"Unexpected module: {name}")
+    return layers
+
+
+def statistics_pooling(x: mx.array, axis: int = -1, keepdim: bool = False) -> mx.array:
+    """Compute mean and std statistics along axis."""
+    mean = mx.mean(x, axis=axis, keepdims=keepdim)
+    std = mx.sqrt(mx.var(x, axis=axis, keepdims=keepdim) + 1e-5)
+    stats = mx.concatenate([mean, std], axis=-1 if not keepdim else axis)
+    return stats
+
+
+def conv1d_pytorch_format(x: mx.array, conv_layer) -> mx.array:
+    """Apply MLX Conv1d to input in PyTorch format (B, C, T)."""
+    # MLX Conv1d expects (B, T, C)
+    x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+    x = conv_layer(x)  # (B, T', C')
+    x = mx.swapaxes(x, 1, 2)  # (B, T', C') -> (B, C', T')
+    return x
+
+
+class StatsPool(nn.Module):
+    """Statistics pooling layer."""
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return statistics_pooling(x)
+
+
+class TDNNLayer(nn.Module):
+    """Time-Delay Neural Network layer."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        padding: int = 0,
+        dilation: int = 1,
+        bias: bool = False,
+        config_str: str = "batchnorm-relu",
+    ):
+        super().__init__()
+        if padding < 0:
+            assert kernel_size % 2 == 1, f"Expected odd kernel size, got {kernel_size}"
+            padding = (kernel_size - 1) // 2 * dilation
+
+        self.linear = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias,
+        )
+        self.nonlinear = get_nonlinear(config_str, out_channels)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # Input x: (B, C, T) - PyTorch format
+        # MLX Conv1d expects (B, T, C)
+        x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+        x = self.linear(x)  # (B, T', C')
+        # Apply nonlinear in MLX format (B, T, C) - BatchNorm expects features last
+        for layer in self.nonlinear:
+            x = layer(x) if callable(layer) else layer(x)
+        # Convert back to PyTorch format
+        x = mx.swapaxes(x, 1, 2)  # (B, T', C') -> (B, C', T')
+        return x
+
+
+class CAMLayer(nn.Module):
+    """Context Attentive Module layer."""
+
+    def __init__(
+        self,
+        bn_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int,
+        padding: int,
+        dilation: int,
+        bias: bool,
+        reduction: int = 2,
+    ):
+        super().__init__()
+        self.linear_local = nn.Conv1d(
+            bn_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias,
+        )
+        self.linear1 = nn.Conv1d(bn_channels, bn_channels // reduction, 1)
+        self.linear2 = nn.Conv1d(bn_channels // reduction, out_channels, 1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # Input x: (B, C, T) - PyTorch format
+        y = conv1d_pytorch_format(x, self.linear_local)
+        context = mx.mean(x, axis=-1, keepdims=True) + self.seg_pooling(x)
+        context = nn.relu(conv1d_pytorch_format(context, self.linear1))
+        m = nn.sigmoid(conv1d_pytorch_format(context, self.linear2))
+        return y * m
+
+    def seg_pooling(
+        self, x: mx.array, seg_len: int = 100, stype: str = "avg"
+    ) -> mx.array:
+        """Segment pooling - pool each segment independently then expand back."""
+        B, C, T = x.shape
+
+        # Calculate number of segments (ceil mode)
+        n_segs = (T + seg_len - 1) // seg_len
+
+        # Pad x to be divisible by seg_len
+        pad_len = n_segs * seg_len - T
+        if pad_len > 0:
+            x_padded = mx.concatenate([x, mx.zeros((B, C, pad_len))], axis=-1)
+        else:
+            x_padded = x
+
+        # Reshape to (B, C, n_segs, seg_len)
+        x_reshaped = mx.reshape(x_padded, (B, C, n_segs, seg_len))
+
+        # Pool each segment
+        if stype == "avg":
+            seg = mx.mean(x_reshaped, axis=-1)  # (B, C, n_segs)
+        elif stype == "max":
+            seg = mx.max(x_reshaped, axis=-1)  # (B, C, n_segs)
+        else:
+            raise ValueError("Wrong segment pooling type.")
+
+        # Expand back: (B, C, n_segs) -> (B, C, n_segs, seg_len) -> (B, C, n_segs*seg_len)
+        seg = mx.expand_dims(seg, -1)  # (B, C, n_segs, 1)
+        seg = mx.broadcast_to(seg, (B, C, n_segs, seg_len))  # (B, C, n_segs, seg_len)
+        seg = mx.reshape(seg, (B, C, -1))  # (B, C, n_segs*seg_len)
+
+        # Truncate to original length
+        seg = seg[:, :, :T]
+        return seg
+
+
+class CAMDenseTDNNLayer(nn.Module):
+    """CAM Dense TDNN layer."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        bn_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+        bias: bool = False,
+        config_str: str = "batchnorm-relu",
+        memory_efficient: bool = False,
+    ):
+        super().__init__()
+        assert kernel_size % 2 == 1, f"Expected odd kernel size, got {kernel_size}"
+        padding = (kernel_size - 1) // 2 * dilation
+
+        self.nonlinear1 = get_nonlinear(config_str, in_channels)
+        self.linear1 = nn.Conv1d(in_channels, bn_channels, 1, bias=False)
+        self.nonlinear2 = get_nonlinear(config_str, bn_channels)
+        self.cam_layer = CAMLayer(
+            bn_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias,
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # Input x: (B, C, T) - PyTorch format
+        # Convert to MLX format for BatchNorm
+        x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+
+        # Apply nonlinear1 (BatchNorm) in MLX format
+        for layer in self.nonlinear1:
+            x = layer(x) if callable(layer) else layer(x)
+
+        # Apply linear1 (Conv1d) - stays in MLX format
+        x = self.linear1(x)
+
+        # Apply nonlinear2 (BatchNorm) in MLX format
+        for layer in self.nonlinear2:
+            x = layer(x) if callable(layer) else layer(x)
+
+        # Convert back to PyTorch format for CAM layer
+        x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+
+        # CAM layer expects PyTorch format
+        x = self.cam_layer(x)
+        return x
+
+
+class CAMDenseTDNNBlock(nn.Module):
+    """CAM Dense TDNN block with multiple layers."""
+
+    def __init__(
+        self,
+        num_layers: int,
+        in_channels: int,
+        out_channels: int,
+        bn_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+        bias: bool = False,
+        config_str: str = "batchnorm-relu",
+        memory_efficient: bool = False,
+    ):
+        super().__init__()
+        self.layers = []
+        for i in range(num_layers):
+            layer = CAMDenseTDNNLayer(
+                in_channels=in_channels + i * out_channels,
+                out_channels=out_channels,
+                bn_channels=bn_channels,
+                kernel_size=kernel_size,
+                stride=stride,
+                dilation=dilation,
+                bias=bias,
+                config_str=config_str,
+                memory_efficient=memory_efficient,
+            )
+            self.layers.append(layer)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for layer in self.layers:
+            x = mx.concatenate([x, layer(x)], axis=1)
+        return x
+
+
+class TransitLayer(nn.Module):
+    """Transition layer between dense blocks."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        bias: bool = True,
+        config_str: str = "batchnorm-relu",
+    ):
+        super().__init__()
+        self.nonlinear = get_nonlinear(config_str, in_channels)
+        self.linear = nn.Conv1d(in_channels, out_channels, 1, bias=bias)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # Input x: (B, C, T) - PyTorch format
+        # Convert to MLX format for BatchNorm
+        x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+
+        for layer in self.nonlinear:
+            x = layer(x) if callable(layer) else layer(x)
+
+        # Apply Conv1d - stays in MLX format
+        x = self.linear(x)
+
+        # Convert back to PyTorch format
+        x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+        return x
+
+
+class DenseLayer(nn.Module):
+    """Dense layer for final embedding."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        bias: bool = False,
+        config_str: str = "batchnorm-relu",
+    ):
+        super().__init__()
+        self.linear = nn.Conv1d(in_channels, out_channels, 1, bias=bias)
+        self.nonlinear = get_nonlinear(config_str, out_channels)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        if len(x.shape) == 2:
+            # 2D input: (B, C) - expand to (B, 1, C) for MLX conv1d
+            x = mx.expand_dims(x, 1)  # (B, C) -> (B, 1, C)
+            x = self.linear(x)  # (B, 1, C') - MLX Conv1d
+            # Apply nonlinear in MLX format (B, T, C)
+            for layer in self.nonlinear:
+                x = layer(x) if callable(layer) else layer(x)
+            x = mx.squeeze(x, 1)  # (B, C')
+        else:
+            # 3D input: (B, C, T) - PyTorch format
+            # Convert to MLX format
+            x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+            x = self.linear(x)  # MLX Conv1d
+
+            # Apply nonlinear in MLX format
+            for layer in self.nonlinear:
+                x = layer(x) if callable(layer) else layer(x)
+
+            # Convert back to PyTorch format
+            x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+
+        return x
+
+
+class CAMPPlus(nn.Module):
+    """
+    CAM++ speaker embedding model.
+
+    Context-Aware Module Plus for speaker verification.
+    """
+
+    def __init__(
+        self,
+        feat_dim: int = 80,
+        embedding_size: int = 192,
+        growth_rate: int = 32,
+        bn_size: int = 4,
+        init_channels: int = 128,
+        config_str: str = "batchnorm-relu",
+        memory_efficient: bool = True,
+        output_level: str = "segment",
+        **kwargs,
+    ):
+        super().__init__()
+
+        self.head = FCM(feat_dim=feat_dim)
+        channels = self.head.out_channels
+        self.output_level = output_level
+
+        # Build xvector network
+        self.tdnn = TDNNLayer(
+            channels,
+            init_channels,
+            5,
+            stride=2,
+            dilation=1,
+            padding=-1,
+            config_str=config_str,
+        )
+        channels = init_channels
+
+        # Dense TDNN blocks
+        self.blocks = []
+        self.transits = []
+
+        for i, (num_layers, kernel_size, dilation) in enumerate(
+            zip((12, 24, 16), (3, 3, 3), (1, 2, 2))
+        ):
+            block = CAMDenseTDNNBlock(
+                num_layers=num_layers,
+                in_channels=channels,
+                out_channels=growth_rate,
+                bn_channels=bn_size * growth_rate,
+                kernel_size=kernel_size,
+                dilation=dilation,
+                config_str=config_str,
+                memory_efficient=memory_efficient,
+            )
+            self.blocks.append(block)
+            channels = channels + num_layers * growth_rate
+
+            transit = TransitLayer(
+                channels, channels // 2, bias=False, config_str=config_str
+            )
+            self.transits.append(transit)
+            channels //= 2
+
+        self.out_nonlinear = get_nonlinear(config_str, channels)
+
+        if output_level == "segment":
+            self.stats = StatsPool()
+            self.dense = DenseLayer(
+                channels * 2, embedding_size, config_str="batchnorm_"
+            )
+
+    def sanitize(self, weights: dict) -> dict:
+        """
+        Sanitize PyTorch weights for MLX.
+
+        Handles:
+        - Name mapping: xvector.block1 -> blocks.0, xvector.transit1 -> transits.0, etc.
+        - Conv2d weight transposition: PyTorch (O,I,H,W) -> MLX (O,H,W,I)
+        - Conv1d weight transposition: PyTorch (O,I,K) -> MLX (O,K,I)
+        - Skip num_batches_tracked for BatchNorm
+
+        This method is idempotent - it checks shapes before transposing to support
+        both PyTorch-format and pre-converted MLX-format weights.
+        """
+        import re
+
+        from mlx.utils import tree_flatten
+
+        new_weights = {}
+
+        # Get expected shapes from model for idempotent transposition
+        curr_weights = dict(tree_flatten(self.parameters()))
+
+        for key, value in weights.items():
+            new_key = key
+
+            # Skip num_batches_tracked
+            if "num_batches_tracked" in key:
+                continue
+
+            # === Name mapping for xvector structure ===
+            # xvector.block1 -> blocks.0, xvector.block2 -> blocks.1, etc.
+            new_key = re.sub(
+                r"xvector\.block(\d+)\.",
+                lambda m: f"blocks.{int(m.group(1))-1}.",
+                new_key,
+            )
+            # xvector.transit1 -> transits.0, etc.
+            new_key = re.sub(
+                r"xvector\.transit(\d+)\.",
+                lambda m: f"transits.{int(m.group(1))-1}.",
+                new_key,
+            )
+            # xvector.tdnn -> tdnn (remove xvector prefix)
+            new_key = new_key.replace("xvector.tdnn.", "tdnn.")
+            # xvector.dense -> dense
+            new_key = new_key.replace("xvector.dense.", "dense.")
+            # xvector.out_nonlinear -> out_nonlinear
+            new_key = new_key.replace("xvector.out_nonlinear.", "out_nonlinear.")
+
+            # === DenseBlock internal structure ===
+            # .tdnnd1. -> .layers.0., .tdnnd2. -> .layers.1., etc.
+            new_key = re.sub(
+                r"\.tdnnd(\d+)\.", lambda m: f".layers.{int(m.group(1))-1}.", new_key
+            )
+
+            # === NonLinear structure ===
+            # .nonlinear1.batchnorm. -> .nonlinear1.0. (BatchNorm in Sequential)
+            new_key = re.sub(
+                r"\.nonlinear(\d+)\.batchnorm\.", r".nonlinear\1.0.", new_key
+            )
+            # .nonlinear.batchnorm. -> .nonlinear.0.
+            new_key = new_key.replace(".nonlinear.batchnorm.", ".nonlinear.0.")
+            # out_nonlinear.batchnorm. -> out_nonlinear.0. (at start or with dot)
+            new_key = new_key.replace(".out_nonlinear.batchnorm.", ".out_nonlinear.0.")
+            if new_key.startswith("out_nonlinear.batchnorm."):
+                new_key = new_key.replace(
+                    "out_nonlinear.batchnorm.", "out_nonlinear.0.", 1
+                )
+
+            # === Conv weight transposition (idempotent) ===
+            # Only transpose if shape doesn't match expected MLX format
+            # Handle both "conv" layers and "shortcut" layers (which are also Conv2d)
+            if "weight" in new_key and value.ndim == 4:
+                # Conv2d: PyTorch (O,I,H,W) -> MLX (O,H,W,I)
+                if (
+                    new_key in curr_weights
+                    and value.shape != curr_weights[new_key].shape
+                ):
+                    value = value.transpose(0, 2, 3, 1)
+            elif "weight" in new_key and value.ndim == 3:
+                # Conv1d: PyTorch (O,I,K) -> MLX (O,K,I)
+                if (
+                    new_key in curr_weights
+                    and value.shape != curr_weights[new_key].shape
+                ):
+                    value = value.swapaxes(1, 2)
+
+            new_weights[new_key] = value
+
+        return new_weights
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """
+        Args:
+            x: Input features (B, T, F) where F is feat_dim
+
+        Returns:
+            Speaker embeddings (B, embedding_size) if segment-level
+        """
+        x = mx.swapaxes(x, 1, 2)  # (B, T, F) => (B, F, T) - PyTorch format
+        x = self.head(x)
+        x = self.tdnn(x)
+
+        # Dense blocks with transitions
+        for block, transit in zip(self.blocks, self.transits):
+            x = block(x)
+            x = transit(x)
+
+        # Output nonlinearity - convert to MLX format for BatchNorm
+        x = mx.swapaxes(x, 1, 2)  # (B, C, T) -> (B, T, C)
+        for layer in self.out_nonlinear:
+            x = layer(x) if callable(layer) else layer(x)
+        x = mx.swapaxes(x, 1, 2)  # (B, T, C) -> (B, C, T)
+
+        if self.output_level == "segment":
+            x = self.stats(x)
+            x = self.dense(x)
+            # Remove last dimension if needed
+            if x.ndim == 3 and x.shape[-1] == 1:
+                x = mx.squeeze(x, -1)
+
+        return x
+
+    def inference(self, audio: mx.array) -> mx.array:
+        """
+        Inference on raw audio waveform.
+
+        Args:
+            audio: Audio waveform (B, T) or (T,) at 16kHz
+
+        Returns:
+            Speaker embeddings (B, embedding_size)
+        """
+        # Handle batched or single audio
+        if audio.ndim == 1:
+            audio = mx.expand_dims(audio, 0)
+
+        # Extract fbank features for each audio in batch
+        features = []
+        for i in range(audio.shape[0]):
+            fbank = kaldi_fbank(audio[i], num_mel_bins=80)
+            # Mean normalization (as in original Chatterbox)
+            fbank = fbank - mx.mean(fbank, axis=0, keepdims=True)
+            features.append(fbank)
+
+        # Pad to same length
+        max_len = max(f.shape[0] for f in features)
+        padded_features = []
+        for f in features:
+            if f.shape[0] < max_len:
+                pad = mx.zeros((max_len - f.shape[0], f.shape[1]))
+                f = mx.concatenate([f, pad], axis=0)
+            padded_features.append(f)
+
+        # Stack to batch: (B, T, F)
+        batch_features = mx.stack(padded_features)
+
+        return self(batch_features)

--- a/mlx_audio/tts/models/chatterbox/s3tokenizer/__init__.py
+++ b/mlx_audio/tts/models/chatterbox/s3tokenizer/__init__.py
@@ -1,0 +1,35 @@
+# Re-export from codec S3 implementation
+# Chatterbox uses the same S3TokenizerV2 as CosyVoice (from s3tokenizer package)
+
+from mlx_audio.codec.models.s3 import (
+    S3_HOP,
+    S3_SR,
+    S3_TOKEN_HOP,
+    S3_TOKEN_RATE,
+    SPEECH_VOCAB_SIZE,
+    ModelConfig,
+    S3TokenizerV2,
+    make_non_pad_mask,
+    mask_to_bias,
+    merge_tokenized_segments,
+    padding,
+)
+
+# Chatterbox uses a specific log_mel_spectrogram that matches PyTorch's torch.stft behavior
+# (drops the last frame). We keep this local implementation for compatibility.
+from .utils import log_mel_spectrogram
+
+__all__ = [
+    "S3TokenizerV2",
+    "ModelConfig",
+    "log_mel_spectrogram",
+    "make_non_pad_mask",
+    "mask_to_bias",
+    "padding",
+    "merge_tokenized_segments",
+    "S3_SR",
+    "S3_HOP",
+    "S3_TOKEN_HOP",
+    "S3_TOKEN_RATE",
+    "SPEECH_VOCAB_SIZE",
+]

--- a/mlx_audio/tts/models/chatterbox/s3tokenizer/utils.py
+++ b/mlx_audio/tts/models/chatterbox/s3tokenizer/utils.py
@@ -1,0 +1,73 @@
+# Chatterbox-specific mel spectrogram computation
+# This matches PyTorch's torch.stft behavior (drops the last frame)
+
+import mlx.core as mx
+
+from mlx_audio.utils import mel_filters, stft
+
+
+def log_mel_spectrogram(
+    audio: mx.array,
+    n_mels: int = 128,
+    padding: int = 0,
+) -> mx.array:
+    """
+    Compute the log-Mel spectrogram.
+
+    This implementation matches the PyTorch S3Tokenizer which uses:
+    - torch.stft with return_complex=True
+    - Drops the last frame (magnitudes[..., :-1])
+    - librosa-style mel filterbank (slaney norm, slaney mel scale)
+
+    Args:
+        audio: Audio waveform (T,) or (B, T) in 16 kHz
+        n_mels: Number of Mel-frequency filters (80 or 128)
+        padding: Number of zero samples to pad to the right
+
+    Returns:
+        Log-Mel spectrogram (n_mels, T') or (B, n_mels, T')
+    """
+    was_1d = len(audio.shape) == 1
+    if was_1d:
+        audio = mx.expand_dims(audio, 0)
+
+    if padding > 0:
+        audio = mx.pad(audio, [(0, 0), (0, padding)])
+
+    # STFT with S3Tokenizer parameters
+    specs = []
+    for i in range(audio.shape[0]):
+        spec = stft(
+            audio[i],
+            window="hann",
+            n_fft=400,
+            hop_length=160,
+            win_length=400,
+        )
+        specs.append(spec)
+
+    # Stack: each spec is (T', F) -> stack to (B, T', F)
+    spec = mx.stack(specs, axis=0)
+
+    # Magnitude squared - drop last frame to match PyTorch torch.stft behavior
+    magnitudes = mx.abs(spec[:, :-1, :]) ** 2
+
+    # Use slaney-style mel filterbank
+    filters = mel_filters(
+        sample_rate=16000,
+        n_fft=400,
+        n_mels=n_mels,
+        norm="slaney",
+        mel_scale="slaney",
+    )
+
+    # Apply mel filterbank: (B, T, F) @ (F, M) -> (B, T, M)
+    mel_spec = magnitudes @ filters.T
+    mel_spec = mx.transpose(mel_spec, [0, 2, 1])  # (B, M, T)
+
+    # Log compression with S3Tokenizer-style normalization
+    log_spec = mx.log10(mx.maximum(mel_spec, 1e-10))
+    log_spec = mx.maximum(log_spec, mx.max(log_spec) - 8.0)
+    log_spec = (log_spec + 4.0) / 4.0
+
+    return log_spec.squeeze(0) if was_1d else log_spec

--- a/mlx_audio/tts/models/chatterbox/scripts/convert_chatterbox.py
+++ b/mlx_audio/tts/models/chatterbox/scripts/convert_chatterbox.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""
+Convert Chatterbox weights from PyTorch/ONNX to MLX format.
+
+This script downloads the original weights and converts them to MLX-compatible
+safetensors format. It uses the model's own sanitize() methods to ensure
+consistency between conversion and runtime loading.
+
+Usage:
+    # Convert to fp16 (local only)
+    python scripts/convert_chatterbox.py
+
+    # Convert to 4-bit quantized (local only)
+    python scripts/convert_chatterbox.py --quantize
+
+    # Convert to 8-bit quantized
+    python scripts/convert_chatterbox.py --quantize --q-bits 8
+
+    # Upload to Hugging Face (uses mlx-community/Chatterbox-TTS-fp16 by default)
+    python scripts/convert_chatterbox.py --upload-repo
+
+    # Upload quantized version (uses mlx-community/Chatterbox-TTS-4bit by default)
+    python scripts/convert_chatterbox.py --quantize --upload-repo
+
+    # Custom output dir and repo
+    python scripts/convert_chatterbox.py --mlx-path ./my-model --upload-repo my-org/my-model
+
+Requirements (for conversion only):
+    pip install torch safetensors huggingface_hub onnx s3tokenizer
+
+After conversion, the model only needs:
+    pip install mlx mlx-lm
+"""
+
+import argparse
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+
+def download_chatterbox_weights(cache_dir: Path) -> Path:
+    """Download Chatterbox weights from Hugging Face."""
+    from huggingface_hub import snapshot_download
+
+    print("Downloading Chatterbox weights from Hugging Face...")
+    ckpt_dir = Path(
+        snapshot_download(
+            repo_id="ResembleAI/chatterbox",
+            allow_patterns=[
+                "ve.safetensors",
+                "t3_cfg.safetensors",
+                "s3gen.safetensors",
+                "tokenizer.json",
+            ],
+            cache_dir=cache_dir,
+        )
+    )
+    print(f"Downloaded to: {ckpt_dir}")
+    return ckpt_dir
+
+
+def download_s3tokenizer_onnx(cache_dir: Path) -> Path:
+    """Download S3Tokenizer ONNX weights from Hugging Face."""
+    from huggingface_hub import hf_hub_download
+
+    print("Downloading S3Tokenizer ONNX from Hugging Face...")
+    onnx_path = hf_hub_download(
+        repo_id="FunAudioLLM/CosyVoice2-0.5B",
+        filename="speech_tokenizer_v2.onnx",
+        cache_dir=cache_dir,
+    )
+    print(f"Downloaded to: {onnx_path}")
+    return Path(onnx_path)
+
+
+def load_pytorch_safetensors(path: Path) -> Dict[str, np.ndarray]:
+    """Load PyTorch safetensors and convert to numpy."""
+    import torch
+    from safetensors.torch import load_file
+
+    state_dict = load_file(path)
+    return {k: v.cpu().numpy() for k, v in state_dict.items()}
+
+
+def load_onnx_weights(path: Path) -> Dict[str, np.ndarray]:
+    """Load ONNX weights as numpy arrays using s3tokenizer's onnx2torch."""
+    try:
+        # Use s3tokenizer's conversion utility for proper key naming
+        import torch
+        from s3tokenizer.utils import onnx2torch
+
+        pytorch_weights = onnx2torch(str(path), None, False)
+
+        # Convert PyTorch tensors to numpy arrays
+        weights = {}
+        for key, value in pytorch_weights.items():
+            if isinstance(value, torch.Tensor):
+                weights[key] = value.cpu().numpy()
+            else:
+                weights[key] = np.array(value)
+
+        return weights
+
+    except ImportError:
+        # Fallback: direct ONNX parsing (gives onnx:: internal names)
+        print("WARNING: s3tokenizer not installed, using raw ONNX parsing")
+        print("         This may result in incorrect weight names")
+        import onnx
+        from onnx import numpy_helper
+
+        model = onnx.load(str(path))
+        weights = {}
+
+        for initializer in model.graph.initializer:
+            weights[initializer.name] = numpy_helper.to_array(initializer)
+
+        return weights
+
+
+def numpy_to_mlx(weights: Dict[str, np.ndarray]) -> Dict:
+    """Convert numpy arrays to MLX arrays for sanitization."""
+    import mlx.core as mx
+
+    return {k: mx.array(v) for k, v in weights.items()}
+
+
+def mlx_to_numpy(weights: Dict) -> Dict[str, np.ndarray]:
+    """Convert MLX arrays back to numpy for saving."""
+    import numpy as np
+
+    return {k: np.array(v) for k, v in weights.items()}
+
+
+def save_mlx_safetensors(weights: Dict[str, np.ndarray], path: Path):
+    """Save weights as MLX-compatible safetensors (for non-quantized weights)."""
+    from safetensors.numpy import save_file
+
+    # Ensure all values are numpy arrays with correct dtype
+    clean_weights = {}
+    for k, v in weights.items():
+        if isinstance(v, np.ndarray):
+            # Keep original dtype but ensure it's a supported type
+            if v.dtype == np.float64:
+                v = v.astype(np.float32)
+            clean_weights[k] = v
+        else:
+            clean_weights[k] = np.array(v)
+
+    save_file(clean_weights, path)
+    print(f"Saved: {path} ({len(clean_weights)} tensors)")
+
+
+def save_mlx_quantized(weights: Dict, path: Path):
+    """Save quantized MLX weights directly using mx.save_safetensors.
+
+    This preserves the packed uint32 format for quantized weights.
+    """
+    import mlx.core as mx
+
+    mx.save_safetensors(str(path), weights, metadata={"format": "mlx"})
+    print(f"Saved: {path} ({len(weights)} tensors)")
+
+
+def quantize_t3_backbone(model, bits: int = 4, group_size: int = 64):
+    """
+    Selectively quantize the T3 LLaMA backbone.
+
+    Only quantizes t3.tfmr.model.layers.* (MLP and attention layers).
+    Other components (S3Gen, S3Tokenizer, VoiceEncoder) are kept in full precision
+    as they are sensitive to quantization.
+
+    Args:
+        model: Chatterbox Model instance
+        bits: Quantization bits (default: 4)
+        group_size: Quantization group size (default: 64)
+
+    Returns:
+        Number of layers quantized
+    """
+    import mlx.nn as nn
+
+    quantized_count = [0]
+
+    def should_quantize(path, module):
+        """Only quantize T3 transformer layers."""
+        if isinstance(module, nn.Linear):
+            if "t3.tfmr.model.layers" in path:
+                quantized_count[0] += 1
+                return True
+        return False
+
+    nn.quantize(
+        model, bits=bits, group_size=group_size, class_predicate=should_quantize
+    )
+    return quantized_count[0]
+
+
+def generate_readme(path: Path, upload_repo: str):
+    """Generate README.md model card for Hugging Face."""
+    from mlx_audio.version import __version__
+
+    card_text = f"""---
+library_name: mlx-audio
+base_model:
+- ResembleAI/chatterbox
+- FunAudioLLM/CosyVoice2-0.5B
+tags:
+- mlx
+pipeline_tag: text-to-speech
+---
+
+# {upload_repo}
+
+This model was converted to MLX format from [ResembleAI/chatterbox](https://huggingface.co/ResembleAI/chatterbox) using mlx-audio version **{__version__}**.
+
+The S3Tokenizer weights are from [FunAudioLLM/CosyVoice2-0.5B](https://huggingface.co/FunAudioLLM/CosyVoice2-0.5B).
+
+## Use with mlx-audio
+
+```bash
+pip install -U mlx-audio
+```
+
+### Command line
+
+```bash
+mlx_audio.tts --model {upload_repo} --text "Hello, this is Chatterbox on MLX!" --ref_audio reference.wav --ref_text "."
+```
+
+### Python
+
+```python
+from mlx_audio.tts.generate import generate_audio
+
+generate_audio(
+    text="Hello, this is Chatterbox on MLX!",
+    model="{upload_repo}",
+    ref_audio="reference.wav",
+    ref_text=".",
+    file_prefix="output",
+)
+```
+"""
+    card_path = path / "README.md"
+    with open(card_path, "w") as f:
+        f.write(card_text)
+    print(f"Created: {card_path}")
+
+
+def upload_to_hub(path: Path, upload_repo: str):
+    """Upload converted model to Hugging Face Hub."""
+    from huggingface_hub import HfApi
+
+    print(f"\nUploading to {upload_repo}...")
+    api = HfApi()
+    api.create_repo(repo_id=upload_repo, exist_ok=True)
+    api.upload_folder(
+        folder_path=str(path),
+        repo_id=upload_repo,
+        repo_type="model",
+    )
+    print(f"Upload successful! Visit https://huggingface.co/{upload_repo}")
+
+
+def convert_all(
+    output_dir: Path,
+    cache_dir: Path = None,
+    upload_repo: str = None,
+    quantize: bool = False,
+    bits: int = 4,
+    group_size: int = 64,
+    dry_run: bool = False,
+):
+    """
+    Convert all Chatterbox weights to MLX format.
+
+    Saves all weights to a single model.safetensors file with component prefixes
+    (ve.*, t3.*, s3gen.*, s3_tokenizer.*) for compatibility with utils.load_model().
+
+    Uses the model's own sanitize() methods to ensure consistency
+    between conversion and runtime loading.
+
+    Args:
+        output_dir: Directory to save converted weights
+        cache_dir: Directory to cache downloaded weights
+        upload_repo: Optional Hugging Face repo to upload to (e.g., "mlx-community/Chatterbox-TTS-fp16")
+        quantize: Whether to apply selective quantization to T3 backbone
+        bits: Quantization bits (default: 4)
+        group_size: Quantization group size (default: 64)
+        dry_run: If True, generate all files including README but skip upload
+    """
+    import json
+    import shutil
+
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+
+    if cache_dir is None:
+        cache_dir = Path.home() / ".cache" / "chatterbox-convert"
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Download Chatterbox weights
+    ckpt_dir = download_chatterbox_weights(cache_dir)
+
+    # Import model components for their sanitize methods
+    from mlx_audio.tts.models.chatterbox.s3gen import S3Token2Wav
+    from mlx_audio.tts.models.chatterbox.s3tokenizer import S3TokenizerV2
+    from mlx_audio.tts.models.chatterbox.t3 import T3
+    from mlx_audio.tts.models.chatterbox.voice_encoder import VoiceEncoder
+
+    # Combined weights dict with prefixes
+    all_weights = {}
+
+    # Convert VoiceEncoder
+    print("\nConverting VoiceEncoder...")
+    ve_weights = load_pytorch_safetensors(ckpt_dir / "ve.safetensors")
+    ve_weights_mx = numpy_to_mlx(ve_weights)
+    ve = VoiceEncoder()
+    ve_weights_mx = ve.sanitize(ve_weights_mx)
+    ve_weights = mlx_to_numpy(ve_weights_mx)
+    # Add with prefix
+    for k, v in ve_weights.items():
+        all_weights[f"ve.{k}"] = v
+    print(f"  Added {len(ve_weights)} VoiceEncoder weights")
+
+    # Convert T3
+    print("\nConverting T3...")
+    t3_weights = load_pytorch_safetensors(ckpt_dir / "t3_cfg.safetensors")
+    t3_weights_mx = numpy_to_mlx(t3_weights)
+    t3 = T3()
+    t3_weights_mx = t3.sanitize(t3_weights_mx)
+    t3_weights = mlx_to_numpy(t3_weights_mx)
+    # Add with prefix
+    for k, v in t3_weights.items():
+        all_weights[f"t3.{k}"] = v
+    print(f"  Added {len(t3_weights)} T3 weights")
+
+    # Convert S3Gen (excluding tokenizer.* keys which come from ONNX)
+    print("\nConverting S3Gen...")
+    s3gen_weights = load_pytorch_safetensors(ckpt_dir / "s3gen.safetensors")
+    # Filter out tokenizer.* keys - we'll use ONNX weights instead
+    s3gen_weights = {
+        k: v for k, v in s3gen_weights.items() if not k.startswith("tokenizer.")
+    }
+    s3gen_weights_mx = numpy_to_mlx(s3gen_weights)
+    s3gen = S3Token2Wav()
+    s3gen_weights_mx = s3gen.sanitize(s3gen_weights_mx)
+    s3gen_weights = mlx_to_numpy(s3gen_weights_mx)
+    # Add with prefix
+    for k, v in s3gen_weights.items():
+        all_weights[f"s3gen.{k}"] = v
+    print(f"  Added {len(s3gen_weights)} S3Gen weights")
+
+    # Download and convert S3Tokenizer from ONNX
+    print("\nConverting S3Tokenizer...")
+    onnx_path = download_s3tokenizer_onnx(cache_dir)
+    s3tok_weights = load_onnx_weights(onnx_path)
+    s3tok_weights_mx = numpy_to_mlx(s3tok_weights)
+    s3tok = S3TokenizerV2("speech_tokenizer_v2_25hz")
+    s3tok_weights_mx = s3tok.sanitize(s3tok_weights_mx)
+    s3tok_weights = mlx_to_numpy(s3tok_weights_mx)
+    # Add with prefix
+    for k, v in s3tok_weights.items():
+        all_weights[f"s3_tokenizer.{k}"] = v
+    print(f"  Added {len(s3tok_weights)} S3Tokenizer weights")
+
+    # Apply quantization if requested
+    if quantize:
+        print(f"\nApplying {bits}-bit quantization to T3 backbone...")
+
+        # Load full model to apply quantization
+        from mlx_audio.tts.models.chatterbox import Model
+
+        model = Model()
+        # Load the weights we just converted
+        all_weights_mx = numpy_to_mlx(all_weights)
+        model.load_weights(list(all_weights_mx.items()))
+        mx.eval(model.parameters())
+
+        # Get original size
+        orig_size = sum(
+            v.nbytes for v in dict(tree_flatten(model.parameters())).values()
+        )
+        print(f"  Original size: {orig_size / 1e9:.2f} GB")
+
+        # Apply selective quantization
+        num_quantized = quantize_t3_backbone(model, bits=bits, group_size=group_size)
+        mx.eval(model.parameters())
+        print(f"  Quantized {num_quantized} Linear layers")
+
+        # Get new size - keep as MLX arrays for proper quantized saving
+        new_weights = dict(tree_flatten(model.parameters()))
+        new_size = sum(v.nbytes for v in new_weights.values())
+        print(f"  New size: {new_size / 1e9:.2f} GB")
+        print(f"  Reduction: {(1 - new_size / orig_size) * 100:.1f}%")
+
+        # Save quantized weights directly using MLX (preserves uint32 packed format)
+        print("\nSaving combined model.safetensors (quantized)...")
+        save_mlx_quantized(new_weights, output_dir / "model.safetensors")
+    else:
+        # Save non-quantized weights using numpy format
+        print("\nSaving combined model.safetensors...")
+        save_mlx_safetensors(all_weights, output_dir / "model.safetensors")
+
+    # Copy tokenizer.json
+    print("\nCopying tokenizer.json...")
+    shutil.copy(ckpt_dir / "tokenizer.json", output_dir / "tokenizer.json")
+
+    # Create config.json
+    print("\nCreating config.json...")
+    config = {
+        "model_type": "chatterbox",
+        "version": "1.0",
+    }
+    if quantize:
+        config["quantization"] = {
+            "bits": bits,
+            "group_size": group_size,
+            "quantized_components": ["t3.tfmr.model.layers"],
+        }
+    with open(output_dir / "config.json", "w") as f:
+        json.dump(config, f, indent=2)
+
+    # Generate README if upload_repo is specified
+    if upload_repo:
+        print("\nGenerating README.md...")
+        generate_readme(output_dir, upload_repo)
+
+    print(
+        f"\n{'🔢' if quantize else '✅'} Conversion complete! Output directory: {output_dir}"
+    )
+    total_weights = len(new_weights) if quantize else len(all_weights)
+    print(f"\nTotal weights: {total_weights}")
+    print("\nFiles created:")
+    for f in sorted(output_dir.iterdir()):
+        size_mb = f.stat().st_size / (1024 * 1024)
+        print(f"  {f.name}: {size_mb:.1f} MB")
+
+    # Upload to Hugging Face if requested (and not dry run)
+    if not dry_run:
+        upload_to_hub(output_dir, upload_repo)
+    else:
+        print(f"\n📁 To upload to {upload_repo}, run with --upload-repo")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert Chatterbox weights to MLX format"
+    )
+    parser.add_argument(
+        "--mlx-path",
+        type=Path,
+        default=None,
+        help="Output directory for MLX weights (default: ./Chatterbox-TTS-{fp16|Nbit})",
+    )
+    parser.add_argument(
+        "--cache-dir", type=Path, default=None, help="Cache directory for downloads"
+    )
+    parser.add_argument(
+        "--upload-repo",
+        type=str,
+        nargs="?",
+        const="",
+        default=None,
+        help="Upload to Hugging Face. Optionally specify repo (default: mlx-community/Chatterbox-TTS-{fp16|Nbit})",
+    )
+    parser.add_argument(
+        "--quantize",
+        "-q",
+        action="store_true",
+        help="Apply 4-bit quantization to T3 backbone (reduces size by ~53%%)",
+    )
+    parser.add_argument(
+        "--q-bits",
+        type=int,
+        default=4,
+        choices=[2, 3, 4, 8],
+        help="Quantization bits (default: 4)",
+    )
+    parser.add_argument(
+        "--q-group-size",
+        type=int,
+        default=64,
+        help="Quantization group size (default: 64)",
+    )
+    args = parser.parse_args()
+
+    # Determine precision suffix
+    precision_suffix = f"{args.q_bits}bit" if args.quantize else "fp16"
+
+    # Set default output dir based on precision
+    mlx_path = args.mlx_path or Path(f"./Chatterbox-TTS-{precision_suffix}")
+
+    # Determine if we should upload (--upload-repo was provided, even without value)
+    should_upload = args.upload_repo is not None
+
+    # Generate upload repo name (for README, and for upload if requested)
+    upload_repo = (
+        (args.upload_repo or f"mlx-community/Chatterbox-TTS-{precision_suffix}")
+        if args.upload_repo is not None
+        else f"mlx-community/Chatterbox-TTS-{precision_suffix}"
+    )
+
+    convert_all(
+        output_dir=mlx_path,
+        cache_dir=args.cache_dir,
+        upload_repo=upload_repo,
+        quantize=args.quantize,
+        bits=args.q_bits,
+        group_size=args.q_group_size,
+        dry_run=not should_upload,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_audio/tts/models/chatterbox/t3/__init__.py
+++ b/mlx_audio/tts/models/chatterbox/t3/__init__.py
@@ -1,0 +1,14 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from .cond_enc import T3CondEnc
+from .learned_pos_emb import LearnedPositionEmbeddings
+from .perceiver import Perceiver
+from .t3 import T3, T3Cond
+
+__all__ = [
+    "T3",
+    "T3Cond",
+    "LearnedPositionEmbeddings",
+    "Perceiver",
+    "T3CondEnc",
+]

--- a/mlx_audio/tts/models/chatterbox/t3/cond_enc.py
+++ b/mlx_audio/tts/models/chatterbox/t3/cond_enc.py
@@ -1,0 +1,132 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from dataclasses import dataclass
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..config import T3Config
+from .perceiver import Perceiver
+
+
+@dataclass
+class T3Cond:
+    """
+    Container for T3 conditioning information.
+
+    Attributes:
+        speaker_emb: Speaker embedding from voice encoder (B, speaker_dim)
+        clap_emb: Optional CLAP embedding for semantic conditioning
+        cond_prompt_speech_tokens: Optional speech token prompt (B, T)
+        cond_prompt_speech_emb: Optional embedded speech prompt (B, T, D)
+        emotion_adv: Emotion exaggeration factor, typically 0.3-0.7 (scalar or (B, 1))
+    """
+
+    speaker_emb: mx.array
+    clap_emb: Optional[mx.array] = None
+    cond_prompt_speech_tokens: Optional[mx.array] = None
+    cond_prompt_speech_emb: Optional[mx.array] = None
+    emotion_adv: Optional[mx.array] = None
+
+    def __post_init__(self):
+        """Set default emotion_adv if not provided."""
+        if self.emotion_adv is None:
+            self.emotion_adv = mx.array(0.5)
+
+
+class T3CondEnc(nn.Module):
+    """
+    Conditioning encoder for T3 model.
+    Handles speaker embeddings, emotion control, and prompt speech tokens.
+    """
+
+    def __init__(self, hp: T3Config):
+        super().__init__()
+        self.hp = hp
+
+        # Speaker embedding projection
+        if hp.encoder_type == "voice_encoder":
+            self.spkr_enc = nn.Linear(hp.speaker_embed_size, hp.n_channels)
+        else:
+            raise NotImplementedError(f"encoder_type '{hp.encoder_type}' not supported")
+
+        # Emotion control
+        self.emotion_adv_fc = None
+        if hp.emotion_adv:
+            self.emotion_adv_fc = nn.Linear(1, hp.n_channels, bias=False)
+
+        # Perceiver resampler for prompt speech tokens
+        self.perceiver = None
+        if hp.use_perceiver_resampler:
+            self.perceiver = Perceiver()
+
+    def __call__(self, cond: T3Cond) -> mx.array:
+        """
+        Process conditioning inputs into a single conditioning tensor.
+
+        Args:
+            cond: T3Cond dataclass with conditioning information
+
+        Returns:
+            Conditioning embeddings (B, cond_len, D)
+        """
+        # Validate
+        has_tokens = cond.cond_prompt_speech_tokens is not None
+        has_emb = cond.cond_prompt_speech_emb is not None
+        assert (
+            has_tokens == has_emb
+        ), "cond_prompt_speech_tokens and cond_prompt_speech_emb must both be provided or both be None"
+
+        # Speaker embedding projection (B, speaker_dim) -> (B, 1, D)
+        B = cond.speaker_emb.shape[0]
+        cond_spkr = self.spkr_enc(
+            mx.reshape(cond.speaker_emb, (B, self.hp.speaker_embed_size))
+        )
+        cond_spkr = mx.expand_dims(cond_spkr, 1)  # (B, 1, D)
+
+        # Empty placeholder for concatenation
+        empty = cond_spkr[:, :0, :]  # (B, 0, D)
+
+        # CLAP embedding (not implemented yet)
+        if cond.clap_emb is not None:
+            raise NotImplementedError("clap_emb not yet implemented")
+        cond_clap = empty  # (B, 0, D)
+
+        # Conditional prompt speech embeddings
+        cond_prompt_speech_emb = cond.cond_prompt_speech_emb
+        if cond_prompt_speech_emb is None:
+            cond_prompt_speech_emb = empty  # (B, 0, D)
+        elif self.hp.use_perceiver_resampler:
+            # Resample to fixed length using Perceiver
+            cond_prompt_speech_emb = self.perceiver(cond_prompt_speech_emb)
+
+        # Emotion exaggeration
+        cond_emotion_adv = empty  # (B, 0, D)
+        if self.hp.emotion_adv:
+            assert (
+                cond.emotion_adv is not None
+            ), "emotion_adv must be provided when hp.emotion_adv is True"
+            # Reshape to (B, 1, 1)
+            emotion_val = cond.emotion_adv
+            if emotion_val.ndim == 0:
+                emotion_val = mx.reshape(emotion_val, (1, 1, 1))
+            elif emotion_val.ndim == 1:
+                emotion_val = mx.reshape(emotion_val, (-1, 1, 1))
+            elif emotion_val.ndim == 2:
+                emotion_val = mx.expand_dims(emotion_val, -1)
+
+            cond_emotion_adv = self.emotion_adv_fc(emotion_val)
+
+        # Concatenate all conditioning signals
+        cond_embeds = mx.concatenate(
+            [
+                cond_spkr,
+                cond_clap,
+                cond_prompt_speech_emb,
+                cond_emotion_adv,
+            ],
+            axis=1,
+        )
+
+        return cond_embeds

--- a/mlx_audio/tts/models/chatterbox/t3/learned_pos_emb.py
+++ b/mlx_audio/tts/models/chatterbox/t3/learned_pos_emb.py
@@ -1,0 +1,47 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from typing import Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class LearnedPositionEmbeddings(nn.Module):
+    """Learned position embeddings for T3 model."""
+
+    def __init__(self, seq_len: int, model_dim: int, init: float = 0.02):
+        super().__init__()
+        self.emb = nn.Embedding(seq_len, model_dim)
+        # Initialize with normal distribution (GPT-2 style)
+        self.emb.weight = mx.random.normal(shape=(seq_len, model_dim), scale=init)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """
+        Returns positional embeddings for index 0 up to the length of x.
+
+        Args:
+            x: Input tensor of shape (B, T, ...)
+
+        Returns:
+            Positional embeddings of shape (T, model_dim)
+        """
+        sl = x.shape[1]
+        return self.emb(mx.arange(sl))
+
+    def get_fixed_embedding(self, idx: Union[int, mx.array]) -> mx.array:
+        """
+        Get positional embeddings for specific indices.
+
+        Args:
+            idx: Scalar int or integer array of shape (T,) or (B, T)
+
+        Returns:
+            Positional embeddings of shape (B, T, dim), or (1, 1, dim) for int input
+        """
+        if isinstance(idx, int):
+            idx = mx.array([[idx]])
+        elif idx.ndim == 1:
+            idx = mx.expand_dims(idx, 0)
+
+        assert idx.ndim == 2, f"Expected 2D array, got shape {idx.shape}"
+        return self.emb(idx)  # (B, T, dim)

--- a/mlx_audio/tts/models/chatterbox/t3/perceiver.py
+++ b/mlx_audio/tts/models/chatterbox/t3/perceiver.py
@@ -1,0 +1,184 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class AttentionQKV(nn.Module):
+    """Multi-head attention with separate Q, K, V projections."""
+
+    def __init__(
+        self,
+        n_heads: int,
+        head_dim: int,
+        dropout_rate: float = 0.1,
+        scale: float = None,
+    ):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = head_dim
+        self.scale = scale if scale is not None else head_dim**-0.5
+        self.dropout_rate = dropout_rate
+
+    def __call__(
+        self, q: mx.array, k: mx.array, v: mx.array, mask: mx.array = None
+    ) -> mx.array:
+        """
+        Args:
+            q: Query tensor (B, T_q, n_heads * head_dim)
+            k: Key tensor (B, T_k, n_heads * head_dim)
+            v: Value tensor (B, T_v, n_heads * head_dim)
+            mask: Optional attention mask (boolean, True=attend)
+
+        Returns:
+            Output tensor (B, T_q, n_heads * head_dim)
+        """
+        # Split heads: (B, T, D) -> (B, n_heads, T, head_dim)
+        q = self.split_heads(q)
+        k = self.split_heads(k)
+        v = self.split_heads(v)
+
+        # Use MLX fast attention (fused kernel)
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale, mask=mask)
+
+        return self.combine_heads(out)
+
+    def split_heads(self, x: mx.array) -> mx.array:
+        """(B, T, D) -> (B, n_heads, T, head_dim)"""
+        B, T, _ = x.shape
+        x = mx.reshape(x, (B, T, self.n_heads, self.head_dim))
+        return mx.transpose(x, (0, 2, 1, 3))
+
+    def combine_heads(self, x: mx.array) -> mx.array:
+        """(B, n_heads, T, head_dim) -> (B, T, D)"""
+        B, _, T, _ = x.shape
+        x = mx.transpose(x, (0, 2, 1, 3))
+        return mx.reshape(x, (B, T, -1))
+
+
+class AttentionBlock(nn.Module):
+    """
+    Cross-attention block with separate Q, K, V linear transformations.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        num_heads: int = 1,
+        dropout_rate: float = 0.2,
+        scale: float = None,
+    ):
+        super().__init__()
+        self.channels = channels
+        self.num_heads = num_heads
+
+        self.norm = nn.LayerNorm(channels)
+
+        # Separate linear layers for Q, K, V
+        self.to_q = nn.Linear(channels, channels)
+        self.to_k = nn.Linear(channels, channels)
+        self.to_v = nn.Linear(channels, channels)
+
+        self.attention = AttentionQKV(
+            num_heads, channels // num_heads, dropout_rate=dropout_rate, scale=scale
+        )
+
+        self.proj_out = nn.Linear(channels, channels)
+
+    def __call__(self, x1: mx.array, x2: mx.array, mask: mx.array = None) -> mx.array:
+        """
+        Cross-attention from x1 to x2.
+
+        Args:
+            x1: Query source (B, T1, C)
+            x2: Key/Value source (B, T2, C)
+            mask: Optional attention mask
+
+        Returns:
+            Output (B, T1, C)
+        """
+        x1_norm = self.norm(x1)
+        x2_norm = self.norm(x2)
+
+        q = self.to_q(x1_norm)
+        k = self.to_k(x2_norm)
+        v = self.to_v(x2_norm)
+
+        h = self.attention(q, k, v, mask=mask)
+        h = self.proj_out(h)
+
+        return x1 + h
+
+
+class Perceiver(nn.Module):
+    """
+    Perceiver-style resampler for conditioning embeddings.
+    Reduces variable-length input to fixed-length latent representation.
+
+    Note: Uses a single shared attention block for both cross-attention
+    and self-attention, matching the original PyTorch implementation.
+    """
+
+    def __init__(
+        self,
+        pre_attention_query_token: int = 32,
+        pre_attention_query_size: int = 1024,
+        embedding_dim: int = 1024,
+        num_attn_heads: int = 4,
+    ):
+        """
+        Args:
+            pre_attention_query_token: Number of query tokens (output length)
+            pre_attention_query_size: Size of each query token
+            embedding_dim: Dimension of the embedding space
+            num_attn_heads: Number of attention heads
+        """
+        super().__init__()
+
+        # Learnable query tokens - initialize with uniform distribution
+        # This is stored as a module attribute that will be tracked as a parameter
+        query_variance = math.sqrt(3.0) * math.sqrt(
+            2.0 / (pre_attention_query_token + pre_attention_query_token)
+        )
+        # Use a linear layer with no bias as a workaround to store learnable params
+        # We'll initialize with our custom values
+        self._query_shape = (1, pre_attention_query_token, pre_attention_query_size)
+        self.pre_attention_query = mx.random.uniform(
+            low=-query_variance, high=query_variance, shape=self._query_shape
+        )
+
+        # Single shared attention block (used for both cross and self attention)
+        # This matches the original PyTorch implementation
+        self.attn = AttentionBlock(embedding_dim, num_attn_heads)
+
+    def __call__(self, h: mx.array) -> mx.array:
+        """
+        Args:
+            h: Input embeddings (B, T, D) - variable length T
+
+        Returns:
+            Fixed-length output (B, query_tokens, D)
+        """
+        B = h.shape[0]
+
+        # Expand query to batch size
+        query = mx.broadcast_to(
+            self.pre_attention_query, (B,) + self.pre_attention_query.shape[1:]
+        )
+
+        # Cross-attention: query attends to input
+        pre_att = self.attn(query, h)
+
+        # Self-attention: query attends to itself
+        attn_out = self.attn(pre_att, pre_att)
+
+        return attn_out
+
+    def parameters(self):
+        """Return learnable parameters including the query tokens."""
+        params = super().parameters()
+        # Add pre_attention_query as a learnable parameter
+        params["pre_attention_query"] = self.pre_attention_query
+        return params

--- a/mlx_audio/tts/models/chatterbox/t3/t3.py
+++ b/mlx_audio/tts/models/chatterbox/t3/t3.py
@@ -1,0 +1,473 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from typing import Dict, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.cache import make_prompt_cache
+from mlx_lm.models.llama import Model as LlamaModel
+from mlx_lm.models.llama import ModelArgs as LlamaModelConfig
+from mlx_lm.sample_utils import make_logits_processors, make_sampler
+
+from ..config import LLAMA_CONFIGS, T3Config
+from .cond_enc import T3Cond, T3CondEnc
+from .learned_pos_emb import LearnedPositionEmbeddings
+
+
+class T3(nn.Module):
+    """
+    Token-To-Token (T3) TTS model using LLaMA as backbone.
+
+    Generates speech tokens from text tokens, conditioned on speaker embeddings
+    and optional emotion/prompt controls.
+    """
+
+    def __init__(self, hp: Optional[T3Config] = None):
+        super().__init__()
+
+        if hp is None:
+            hp = T3Config.english_only()
+
+        self.hp = hp
+
+        # Create LLaMA config from our T3 config
+        llama_config_dict = LLAMA_CONFIGS[hp.llama_config_name].copy()
+        self.cfg = LlamaModelConfig(**llama_config_dict)
+
+        # LLaMA transformer backbone
+        self.tfmr = LlamaModel(self.cfg)
+        self.dim = self.cfg.hidden_size
+
+        # Conditioning encoder
+        self.cond_enc = T3CondEnc(hp)
+
+        # Text and speech token embeddings
+        self.text_emb = nn.Embedding(hp.text_tokens_dict_size, self.dim)
+        self.speech_emb = nn.Embedding(hp.speech_tokens_dict_size, self.dim)
+
+        # Learned position embeddings (optional)
+        if hp.input_pos_emb == "learned":
+            max_text_seq_len = hp.max_text_tokens + 2
+            self.text_pos_emb = LearnedPositionEmbeddings(max_text_seq_len, self.dim)
+
+            max_mel_seq_len = hp.max_speech_tokens + 2 + 2
+            self.speech_pos_emb = LearnedPositionEmbeddings(max_mel_seq_len, self.dim)
+
+        # Output projection heads
+        self.text_head = nn.Linear(
+            self.cfg.hidden_size, hp.text_tokens_dict_size, bias=False
+        )
+        self.speech_head = nn.Linear(
+            self.cfg.hidden_size, hp.speech_tokens_dict_size, bias=False
+        )
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """
+        Sanitize PyTorch weights for MLX.
+
+        T3 uses a LLaMA backbone which mlx_lm already handles.
+        We need to handle:
+        - Mapping tfmr.* weights to the LLaMA model format (tfmr.X -> tfmr.model.X)
+        - Conv1d weight transposition in conditioning encoder
+
+        Note: Perceiver weights use the same naming convention (to_q, to_k, to_v, proj_out)
+        as the original PyTorch implementation, so no renaming is needed.
+
+        This method is idempotent - it checks shapes before transposing to support
+        both PyTorch-format and pre-converted MLX-format weights.
+        """
+        import re
+
+        from mlx.utils import tree_flatten
+
+        new_weights = {}
+
+        # Get expected shapes from model for idempotent transposition
+        curr_weights = dict(tree_flatten(self.parameters()))
+
+        for key, value in weights.items():
+            new_key = key
+
+            # === Transformer weight name mapping ===
+            # PyTorch uses: tfmr.layers.X, tfmr.embed_tokens, tfmr.norm
+            # mlx_lm LlamaModel uses: model.layers.X, model.embed_tokens, model.norm
+            # So we need: tfmr.layers.X -> tfmr.model.layers.X, etc.
+            # Check if already converted (idempotent)
+            if key.startswith("tfmr.") and not key.startswith("tfmr.model."):
+                # Map tfmr.X to tfmr.model.X for transformer internal components
+                # These are: layers, embed_tokens, norm
+                patterns_to_prefix = [
+                    r"^tfmr\.layers\.",
+                    r"^tfmr\.embed_tokens\.",
+                    r"^tfmr\.norm\.",
+                ]
+                for pattern in patterns_to_prefix:
+                    if re.match(pattern, key):
+                        new_key = re.sub(r"^tfmr\.", "tfmr.model.", key)
+                        break
+
+            # Conv1d weight transposition (idempotent)
+            # Only transpose if shape doesn't match expected MLX format
+            # PyTorch Conv1d: (out_channels, in_channels, kernel_size)
+            # MLX Conv1d: (out_channels, kernel_size, in_channels)
+            if "conv" in new_key.lower() and "weight" in new_key and value.ndim == 3:
+                if (
+                    new_key in curr_weights
+                    and value.shape != curr_weights[new_key].shape
+                ):
+                    value = value.swapaxes(1, 2)
+
+            new_weights[new_key] = value
+
+        # Delegate to LLaMA sanitizer for transformer weights if it has one
+        if hasattr(self.tfmr, "sanitize"):
+            tfmr_weights = {
+                k: v for k, v in new_weights.items() if k.startswith("tfmr.")
+            }
+            other_weights = {
+                k: v for k, v in new_weights.items() if not k.startswith("tfmr.")
+            }
+            tfmr_weights = self.tfmr.sanitize(tfmr_weights)
+            new_weights = {**other_weights, **tfmr_weights}
+
+        return new_weights
+
+    def prepare_conditioning(self, t3_cond: T3Cond) -> mx.array:
+        """
+        Prepare conditioning embeddings from T3Cond.
+
+        Args:
+            t3_cond: Conditioning information
+
+        Returns:
+            Conditioning embeddings (B, cond_len, dim)
+        """
+        # Embed speech prompt tokens if provided
+        if (
+            t3_cond.cond_prompt_speech_tokens is not None
+            and t3_cond.cond_prompt_speech_emb is None
+        ):
+            t3_cond.cond_prompt_speech_emb = self.speech_emb(
+                t3_cond.cond_prompt_speech_tokens
+            ) + self.speech_pos_emb(t3_cond.cond_prompt_speech_tokens)
+
+        return self.cond_enc(t3_cond)
+
+    def prepare_input_embeds(
+        self,
+        t3_cond: T3Cond,
+        text_tokens: mx.array,
+        speech_tokens: mx.array,
+        cfg_weight: float = 0.0,
+    ) -> Tuple[mx.array, int]:
+        """
+        Prepare input embeddings for the transformer.
+
+        Args:
+            t3_cond: Conditioning information
+            text_tokens: Text token IDs (B, text_len)
+            speech_tokens: Speech token IDs (B, speech_len)
+            cfg_weight: Classifier-free guidance weight
+
+        Returns:
+            Tuple of (embeddings, conditioning_length)
+        """
+        # Prepare conditioning embeddings
+        cond_emb = self.prepare_conditioning(t3_cond)  # (B, len_cond, dim)
+
+        # Text embeddings
+        text_emb = self.text_emb(text_tokens)  # (B, len_text, dim)
+
+        # CFG: zero out second batch item for unconditional
+        if cfg_weight > 0.0 and text_emb.shape[0] > 1:
+            text_emb = mx.concatenate(
+                [
+                    text_emb[:1],
+                    mx.zeros_like(text_emb[1:2]),
+                ],
+                axis=0,
+            )
+
+        # Speech embeddings
+        speech_emb = self.speech_emb(speech_tokens)  # (B, len_speech, dim)
+
+        # Add position embeddings if using learned positions
+        if self.hp.input_pos_emb == "learned":
+            text_emb = text_emb + self.text_pos_emb(text_tokens)
+            speech_emb = speech_emb + self.speech_pos_emb(speech_tokens)
+
+        len_cond = cond_emb.shape[1]
+
+        # Broadcast conditioning if batch sizes don't match
+        if cond_emb.shape[0] != text_emb.shape[0]:
+            cond_emb = mx.broadcast_to(
+                cond_emb, (text_emb.shape[0],) + cond_emb.shape[1:]
+            )
+
+        # Broadcast speech embeddings if batch sizes don't match (e.g., CFG)
+        if speech_emb.shape[0] != text_emb.shape[0]:
+            speech_emb = mx.broadcast_to(
+                speech_emb, (text_emb.shape[0],) + speech_emb.shape[1:]
+            )
+
+        # Concatenate: [conditioning | text | speech]
+        embeds = mx.concatenate([cond_emb, text_emb, speech_emb], axis=1)
+
+        return embeds, len_cond
+
+    def __call__(
+        self,
+        t3_cond: T3Cond,
+        text_tokens: mx.array,
+        text_token_lens: mx.array,
+        speech_tokens: mx.array,
+        speech_token_lens: mx.array,
+        cache=None,
+    ) -> dict:
+        """
+        Forward pass through T3 model.
+
+        Args:
+            t3_cond: Conditioning information
+            text_tokens: Text token IDs (B, text_len)
+            text_token_lens: Valid lengths for each text sequence (B,)
+            speech_tokens: Speech token IDs (B, speech_len)
+            speech_token_lens: Valid lengths for each speech sequence (B,)
+            cache: Optional KV cache for inference
+
+        Returns:
+            Dictionary with text_logits, speech_logits, and hidden_states
+        """
+        # Prepare input embeddings
+        embeds, len_cond = self.prepare_input_embeds(
+            t3_cond=t3_cond,
+            text_tokens=text_tokens,
+            speech_tokens=speech_tokens,
+        )
+
+        # Forward through LLaMA backbone
+        # Note: mlx_lm's LlamaModel takes input_embeddings differently
+        hidden_states = self.tfmr.model(
+            inputs=None,
+            cache=cache,
+            input_embeddings=embeds,
+        )
+
+        # Extract text and speech portions of hidden states
+        B = text_tokens.shape[0]
+        len_text = text_tokens.shape[1]
+        len_speech = speech_tokens.shape[1]
+        dim = hidden_states.shape[-1]
+
+        # Allocate output tensors
+        text_latents = mx.zeros((B, len_text, dim))
+        speech_latents = mx.zeros((B, len_speech, dim))
+
+        # Split hidden states by sequence position
+        for i in range(B):
+            ttl = int(text_token_lens[i])
+            stl = int(speech_token_lens[i])
+
+            text_start = len_cond
+            text_end = len_cond + ttl
+
+            speech_start = len_cond + len_text
+            speech_end = speech_start + stl
+
+            text_latents = (
+                mx.concatenate(
+                    [
+                        text_latents[:i],
+                        hidden_states[i : i + 1, text_start:text_end, :],
+                        text_latents[i + 1 :],
+                    ],
+                    axis=0,
+                )
+                if i < B
+                else text_latents
+            )
+
+            speech_latents = (
+                mx.concatenate(
+                    [
+                        speech_latents[:i],
+                        hidden_states[i : i + 1, speech_start:speech_end, :],
+                        speech_latents[i + 1 :],
+                    ],
+                    axis=0,
+                )
+                if i < B
+                else speech_latents
+            )
+
+        # Project to vocabulary
+        text_logits = self.text_head(text_latents)
+        speech_logits = self.speech_head(speech_latents)
+
+        return {
+            "text_logits": text_logits,
+            "text_latents": text_latents,
+            "speech_logits": speech_logits,
+            "speech_latents": speech_latents,
+            "hidden_states": hidden_states,
+        }
+
+    def inference(
+        self,
+        t3_cond: T3Cond,
+        text_tokens: mx.array,
+        initial_speech_tokens: Optional[mx.array] = None,
+        max_new_tokens: int = 1024,
+        temperature: float = 0.8,
+        top_p: float = 0.95,
+        min_p: float = 0.05,
+        repetition_penalty: float = 1.2,
+        cfg_weight: float = 0.5,
+    ) -> mx.array:
+        """
+        Generate speech tokens from text tokens.
+
+        This matches the original PyTorch implementation which uses:
+        - KV caching for efficient generation
+        - Position embeddings for each generated token
+        - Repetition penalty, min_p, and top_p filtering
+        - Classifier-free guidance (CFG)
+
+        Args:
+            t3_cond: Conditioning information
+            text_tokens: Text token IDs (1D or 2D)
+            initial_speech_tokens: Optional initial speech tokens
+            max_new_tokens: Maximum tokens to generate
+            temperature: Sampling temperature
+            top_p: Top-p sampling threshold
+            min_p: Minimum probability threshold
+            repetition_penalty: Repetition penalty factor
+            cfg_weight: Classifier-free guidance weight
+
+        Returns:
+            Generated speech tokens (B, T)
+        """
+        # Ensure text_tokens is 2D
+        if text_tokens.ndim == 1:
+            text_tokens = mx.expand_dims(text_tokens, 0)
+
+        # Default initial speech token (BOS)
+        bos_token = mx.array([[self.hp.start_speech_token]], dtype=mx.int32)
+
+        # Prepare conditioning and text embeddings
+        embeds, len_cond = self.prepare_input_embeds(
+            t3_cond=t3_cond,
+            text_tokens=text_tokens,
+            speech_tokens=bos_token,
+            cfg_weight=cfg_weight,
+        )
+
+        # Create BOS embedding with position embedding at position 0
+        bos_embed = self.speech_emb(bos_token)  # (1, 1, dim)
+        bos_embed = bos_embed + self.speech_pos_emb.get_fixed_embedding(0)
+
+        # For CFG, duplicate BOS embed
+        if cfg_weight > 0.0:
+            bos_embed = mx.concatenate([bos_embed, bos_embed], axis=0)
+
+        # Combine conditioning+text embeddings with BOS token
+        # embeds already has [cond | text | bos] structure from prepare_input_embeds
+        # We need to replace the speech part with our position-embedded BOS
+        # Actually, let's rebuild the input properly
+        cond_emb = self.prepare_conditioning(t3_cond)  # (1, len_cond, dim)
+        text_emb = self.text_emb(text_tokens)  # (B, len_text, dim)
+
+        if cfg_weight > 0.0:
+            # Zero out second batch for unconditional
+            text_emb = mx.concatenate(
+                [
+                    text_emb[:1],
+                    mx.zeros_like(text_emb[:1]),
+                ],
+                axis=0,
+            )
+
+        if self.hp.input_pos_emb == "learned":
+            text_emb = text_emb + self.text_pos_emb(text_tokens)
+
+        # Broadcast conditioning if needed
+        if cond_emb.shape[0] != text_emb.shape[0]:
+            cond_emb = mx.broadcast_to(
+                cond_emb, (text_emb.shape[0],) + cond_emb.shape[1:]
+            )
+
+        # Build initial input: [cond | text | bos]
+        input_embeddings = mx.concatenate([cond_emb, text_emb, bos_embed], axis=1)
+
+        # Create KV cache
+        cache = make_prompt_cache(self.tfmr)
+
+        # Create sampler and logits processors
+        sampler = make_sampler(temp=temperature, top_p=top_p, min_p=min_p)
+        logits_processors = make_logits_processors(
+            logit_bias=None,
+            repetition_penalty=repetition_penalty,
+            repetition_context_size=max_new_tokens,  # Use all generated tokens for repetition
+        )
+
+        # Track generated tokens (Python list for efficiency - avoid growing mx.array each step)
+        generated_ids = [self.hp.start_speech_token]
+
+        # Initial forward pass to fill cache
+        hidden = self.tfmr.model(
+            inputs=None, input_embeddings=input_embeddings, cache=cache
+        )
+
+        # Generation loop
+        for step in range(max_new_tokens):
+            # Get logits for last position
+            logits = self.speech_head(hidden[:, -1:, :])  # (B, 1, vocab)
+            logits = logits.squeeze(1)  # (B, vocab)
+
+            # Apply CFG
+            if cfg_weight > 0.0 and logits.shape[0] > 1:
+                cond_logits = logits[0:1, :]
+                uncond_logits = logits[1:2, :]
+                logits = cond_logits + cfg_weight * (cond_logits - uncond_logits)
+            else:
+                logits = logits[0:1, :]
+
+            # Apply logits processors (repetition penalty)
+            # Lazily convert Python list to array - processor only uses last N tokens anyway
+            for processor in logits_processors:
+                tokens_for_penalty = mx.array([generated_ids], dtype=mx.int32)
+                logits = processor(tokens_for_penalty, logits)
+
+            # Sample next token using the sampler (handles temperature, top_p, min_p)
+            next_token = sampler(logits)
+            # Sampler returns 1D array (B,) for each batch item
+            next_token_id = int(next_token[0])
+
+            # Check for EOS
+            if next_token_id == self.hp.stop_speech_token:
+                generated_ids.append(next_token_id)
+                break
+
+            generated_ids.append(next_token_id)
+
+            # Create embedding for next token with position embedding
+            next_token_embed = self.speech_emb(mx.array([[next_token_id]]))
+            next_token_embed = (
+                next_token_embed + self.speech_pos_emb.get_fixed_embedding(step + 1)
+            )
+
+            # For CFG, duplicate
+            if cfg_weight > 0.0:
+                next_token_embed = mx.concatenate(
+                    [next_token_embed, next_token_embed], axis=0
+                )
+
+            # Forward pass with cache (only new token)
+            hidden = self.tfmr.model(
+                inputs=None, input_embeddings=next_token_embed, cache=cache
+            )
+
+            # Pipeline: start computing next step while current finishes
+            mx.async_eval(hidden)
+
+        return mx.array([generated_ids])

--- a/mlx_audio/tts/models/chatterbox/tokenizer.py
+++ b/mlx_audio/tts/models/chatterbox/tokenizer.py
@@ -1,0 +1,110 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from pathlib import Path
+from typing import List, Union
+
+import mlx.core as mx
+
+try:
+    from tokenizers import Tokenizer
+except ImportError:
+    Tokenizer = None
+
+# Special tokens
+SOT = "[START]"
+EOT = "[STOP]"
+UNK = "[UNK]"
+SPACE = "[SPACE]"
+SPECIAL_TOKENS = [SOT, EOT, UNK, SPACE, "[PAD]", "[SEP]", "[CLS]", "[MASK]"]
+
+
+class EnTokenizer:
+    """
+    English text tokenizer for Chatterbox TTS.
+
+    Uses Hugging Face tokenizers library to load vocab from tokenizer.json.
+    """
+
+    def __init__(self, vocab_file_path: Union[str, Path]):
+        if Tokenizer is None:
+            raise ImportError(
+                "tokenizers library required for Chatterbox text tokenization. "
+                "Install with: pip install tokenizers"
+            )
+        self.tokenizer = Tokenizer.from_file(str(vocab_file_path))
+        self._check_vocab()
+
+    def _check_vocab(self):
+        """Verify required special tokens exist in vocabulary."""
+        vocab = self.tokenizer.get_vocab()
+        if SOT not in vocab:
+            raise ValueError(f"Tokenizer missing required token: {SOT}")
+        if EOT not in vocab:
+            raise ValueError(f"Tokenizer missing required token: {EOT}")
+
+    def text_to_tokens(self, text: str) -> mx.array:
+        """
+        Convert text to token IDs.
+
+        Args:
+            text: Input text string
+
+        Returns:
+            Token IDs as MLX array with shape (1, seq_len)
+        """
+        token_ids = self.encode(text)
+        return mx.array([token_ids], dtype=mx.int32)
+
+    def encode(self, text: str) -> List[int]:
+        """
+        Encode text to token IDs.
+
+        Replaces spaces with SPACE token before encoding.
+
+        Args:
+            text: Input text string
+
+        Returns:
+            List of token IDs
+        """
+        text = text.replace(" ", SPACE)
+        encoding = self.tokenizer.encode(text)
+        return encoding.ids
+
+    def decode(self, token_ids: Union[mx.array, List[int]]) -> str:
+        """
+        Decode token IDs back to text.
+
+        Args:
+            token_ids: Token IDs as MLX array or list
+
+        Returns:
+            Decoded text string
+        """
+        if isinstance(token_ids, mx.array):
+            token_ids = token_ids.tolist()
+
+        # Flatten if 2D
+        if isinstance(token_ids[0], list):
+            token_ids = token_ids[0]
+
+        text = self.tokenizer.decode(token_ids, skip_special_tokens=False)
+        # Clean up special tokens
+        text = text.replace(" ", "")
+        text = text.replace(SPACE, " ")
+        text = text.replace(EOT, "")
+        text = text.replace(UNK, "")
+        return text
+
+    @property
+    def vocab_size(self) -> int:
+        """Get vocabulary size."""
+        return self.tokenizer.get_vocab_size()
+
+    def get_sot_token_id(self) -> int:
+        """Get start-of-text token ID."""
+        return self.tokenizer.token_to_id(SOT)
+
+    def get_eot_token_id(self) -> int:
+        """Get end-of-text token ID."""
+        return self.tokenizer.token_to_id(EOT)

--- a/mlx_audio/tts/models/chatterbox/voice_encoder/__init__.py
+++ b/mlx_audio/tts/models/chatterbox/voice_encoder/__init__.py
@@ -1,0 +1,7 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from .config import VoiceEncConfig
+from .melspec import melspectrogram
+from .voice_encoder import VoiceEncoder
+
+__all__ = ["VoiceEncoder", "VoiceEncConfig", "melspectrogram"]

--- a/mlx_audio/tts/models/chatterbox/voice_encoder/config.py
+++ b/mlx_audio/tts/models/chatterbox/voice_encoder/config.py
@@ -1,0 +1,25 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+from dataclasses import dataclass
+
+
+@dataclass
+class VoiceEncConfig:
+    """Voice encoder configuration."""
+
+    num_mels: int = 40
+    sample_rate: int = 16000
+    speaker_embed_size: int = 256
+    ve_hidden_size: int = 256
+    n_fft: int = 400
+    hop_size: int = 160
+    win_size: int = 400
+    fmax: int = 8000
+    fmin: int = 0
+    preemphasis: float = 0.0
+    mel_power: float = 2.0
+    mel_type: str = "amp"
+    normalized_mels: bool = False
+    ve_partial_frames: int = 160
+    ve_final_relu: bool = True
+    stft_magnitude_min: float = 1e-4

--- a/mlx_audio/tts/models/chatterbox/voice_encoder/melspec.py
+++ b/mlx_audio/tts/models/chatterbox/voice_encoder/melspec.py
@@ -1,0 +1,76 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import math
+
+import mlx.core as mx
+
+from mlx_audio.utils import mel_filters, stft
+
+from .config import VoiceEncConfig
+
+
+def melspectrogram(wav: mx.array, hp: VoiceEncConfig, pad: bool = True) -> mx.array:
+    """
+    Compute mel spectrogram from waveform.
+
+    Args:
+        wav: Waveform (T,) or (B, T)
+        hp: Voice encoder config
+        pad: Whether to pad the STFT
+
+    Returns:
+        Mel spectrogram (M, T') or (B, M, T')
+    """
+    was_1d = len(wav.shape) == 1
+    if was_1d:
+        wav = mx.expand_dims(wav, 0)  # (1, T)
+
+    # STFT - process each batch item separately since stft expects 1D input
+    specs = []
+    for i in range(wav.shape[0]):
+        spec = stft(
+            wav[i],  # 1D input (T,)
+            window="hann",
+            n_fft=hp.n_fft,
+            hop_length=hp.hop_size,
+            win_length=hp.win_size,
+        )
+        specs.append(spec)
+
+    # Stack: each spec is (T', F) -> stack to (B, T', F)
+    spec = mx.stack(specs, axis=0)
+
+    # Get magnitudes
+    spec_magnitudes = mx.abs(spec)  # (B, T', F)
+
+    # Apply power
+    if hp.mel_power != 1.0:
+        spec_magnitudes = spec_magnitudes**hp.mel_power
+
+    # Create mel filterbank
+    # Use librosa defaults: norm='slaney', mel_scale='slaney' (htk=False)
+    filters = mel_filters(
+        sample_rate=hp.sample_rate,
+        n_fft=hp.n_fft,
+        n_mels=hp.num_mels,
+        f_min=hp.fmin,
+        f_max=hp.fmax,
+        norm="slaney",
+        mel_scale="slaney",
+    )
+
+    # Apply mel filterbank: (B, T', F) @ (F, M) -> (B, T', M)
+    mel = spec_magnitudes @ filters.T  # (B, T', M)
+    mel = mx.transpose(mel, [0, 2, 1])  # (B, M, T')
+
+    # Convert to dB if needed
+    if hp.mel_type == "db":
+        mel = 20 * mx.log10(mx.maximum(mel, hp.stft_magnitude_min))
+
+    # Normalize if needed
+    if hp.normalized_mels:
+        min_level_db = 20 * math.log10(hp.stft_magnitude_min)
+        headroom_db = 15
+        mel = (mel - min_level_db) / (-min_level_db + headroom_db)
+
+    return mel.squeeze(0) if was_1d else mel  # (M, T') or (B, M, T')

--- a/mlx_audio/tts/models/chatterbox/voice_encoder/voice_encoder.py
+++ b/mlx_audio/tts/models/chatterbox/voice_encoder/voice_encoder.py
@@ -1,0 +1,478 @@
+# Ported from https://github.com/resemble-ai/chatterbox
+
+import math
+from typing import Dict, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import VoiceEncConfig
+from .melspec import melspectrogram
+
+
+def get_num_wins(
+    n_frames: int,
+    step: int,
+    min_coverage: float,
+    hp: VoiceEncConfig,
+):
+    """Calculate number of windows and target length for partial utterance splitting."""
+    assert n_frames > 0
+    win_size = hp.ve_partial_frames
+    n_wins, remainder = divmod(max(n_frames - win_size + step, 0), step)
+    if n_wins == 0 or (remainder + (win_size - step)) / win_size >= min_coverage:
+        n_wins += 1
+    target_n = win_size + step * (n_wins - 1)
+    return n_wins, target_n
+
+
+def get_frame_step(
+    overlap: float,
+    rate: Optional[float],
+    hp: VoiceEncConfig,
+):
+    """Compute how many frames separate two partial utterances."""
+    assert 0 <= overlap < 1
+    if rate is None:
+        frame_step = int(round(hp.ve_partial_frames * (1 - overlap)))
+    else:
+        frame_step = int(round((hp.sample_rate / rate) / hp.ve_partial_frames))
+    assert 0 < frame_step <= hp.ve_partial_frames
+    return frame_step
+
+
+def sanitize_lstm_weights(
+    key: str, value: mx.array, num_layers: int = 3
+) -> Dict[str, mx.array]:
+    """
+    Convert PyTorch LSTM weight keys to MLX LSTM weight keys.
+
+    PyTorch LSTM weight format:
+        lstm.weight_ih_l{layer} -> input-hidden weights for layer
+        lstm.weight_hh_l{layer} -> hidden-hidden weights for layer
+        lstm.bias_ih_l{layer} -> input-hidden bias for layer
+        lstm.bias_hh_l{layer} -> hidden-hidden bias for layer
+
+    MLX LSTM weight format (for list of LSTM layers):
+        lstm.{layer}.Wx -> input weights
+        lstm.{layer}.Wh -> hidden weights
+        lstm.{layer}.bias -> combined bias (ih + hh)
+    """
+    result = {}
+
+    # Extract layer number from key like "lstm.weight_ih_l0"
+    import re
+
+    match = re.search(r"lstm\.(weight_ih|weight_hh|bias_ih|bias_hh)_l(\d+)", key)
+    if not match:
+        result[key] = value
+        return result
+
+    weight_type = match.group(1)
+    layer_idx = int(match.group(2))
+
+    if weight_type == "weight_ih":
+        result[f"lstm.layers.{layer_idx}.Wx"] = value
+    elif weight_type == "weight_hh":
+        result[f"lstm.layers.{layer_idx}.Wh"] = value
+    elif weight_type == "bias_ih":
+        # MLX combines biases, so we need special handling
+        result[f"lstm.layers.{layer_idx}.bias_ih"] = value
+    elif weight_type == "bias_hh":
+        result[f"lstm.layers.{layer_idx}.bias_hh"] = value
+
+    return result
+
+
+class StackedLSTM(nn.Module):
+    """Multi-layer LSTM that matches PyTorch's nn.LSTM(num_layers=N)."""
+
+    def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1):
+        super().__init__()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+
+        # Create stacked LSTM layers
+        self.layers = [
+            nn.LSTM(input_size if i == 0 else hidden_size, hidden_size)
+            for i in range(num_layers)
+        ]
+
+    def __call__(self, x: mx.array, hidden=None):
+        """
+        Args:
+            x: Input tensor (seq_len, batch, input_size) or (batch, seq_len, input_size)
+            hidden: Tuple of (h_0, c_0), each of shape (num_layers, batch, hidden_size)
+
+        Returns:
+            output: Output tensor
+            (h_n, c_n): Final hidden and cell states
+        """
+        if hidden is None:
+            h_list = [None] * self.num_layers
+            c_list = [None] * self.num_layers
+        else:
+            h_0, c_0 = hidden
+            h_list = [h_0[i] for i in range(self.num_layers)]
+            c_list = [c_0[i] for i in range(self.num_layers)]
+
+        output = x
+        new_h = []
+        new_c = []
+
+        for i, layer in enumerate(self.layers):
+            all_h, all_c = layer(output, hidden=h_list[i], cell=c_list[i])
+            output = all_h
+            # Extract final timestep: all_h has shape (batch, seq_len, hidden_size)
+            # Use [:, -1, :] to get (batch, hidden_size) for the last timestep
+            new_h.append(all_h[:, -1, :] if all_h.ndim == 3 else all_h)
+            new_c.append(all_c[:, -1, :] if all_c.ndim == 3 else all_c)
+
+        h_n = mx.stack(new_h, axis=0)
+        c_n = mx.stack(new_c, axis=0)
+
+        return output, (h_n, c_n)
+
+
+class VoiceEncoder(nn.Module):
+    """LSTM-based voice encoder for speaker embeddings."""
+
+    def __init__(self, hp: VoiceEncConfig = None):
+        super().__init__()
+        self.hp = hp or VoiceEncConfig()
+
+        # Network definition: 3-layer stacked LSTM
+        self.lstm = StackedLSTM(self.hp.num_mels, self.hp.ve_hidden_size, num_layers=3)
+        self.proj = nn.Linear(self.hp.ve_hidden_size, self.hp.speaker_embed_size)
+
+        # Cosine similarity scaling (fixed initial parameter values)
+        self.similarity_weight = mx.array([10.0])
+        self.similarity_bias = mx.array([-5.0])
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """
+        Sanitize PyTorch weights for MLX.
+
+        Handles:
+        - LSTM weight renaming (weight_ih_l0 -> layers.0.Wx, etc.)
+        - Bias combining (PyTorch has separate ih/hh biases)
+
+        This method is idempotent - key renaming only affects PyTorch-format keys,
+        MLX-format keys pass through unchanged on subsequent runs.
+        """
+        new_weights = {}
+        bias_ih = {}
+        bias_hh = {}
+
+        for key, value in weights.items():
+            # Handle LSTM weights
+            if "lstm." in key and any(
+                x in key for x in ["weight_ih", "weight_hh", "bias_ih", "bias_hh"]
+            ):
+                import re
+
+                match = re.search(
+                    r"lstm\.(weight_ih|weight_hh|bias_ih|bias_hh)_l(\d+)", key
+                )
+                if match:
+                    weight_type = match.group(1)
+                    layer_idx = int(match.group(2))
+
+                    if weight_type == "weight_ih":
+                        new_weights[f"lstm.layers.{layer_idx}.Wx"] = value
+                    elif weight_type == "weight_hh":
+                        new_weights[f"lstm.layers.{layer_idx}.Wh"] = value
+                    elif weight_type == "bias_ih":
+                        bias_ih[layer_idx] = value
+                    elif weight_type == "bias_hh":
+                        bias_hh[layer_idx] = value
+            else:
+                new_weights[key] = value
+
+        # Combine ih and hh biases (MLX LSTM uses combined bias)
+        for layer_idx in bias_ih:
+            if layer_idx in bias_hh:
+                combined_bias = bias_ih[layer_idx] + bias_hh[layer_idx]
+                new_weights[f"lstm.layers.{layer_idx}.bias"] = combined_bias
+
+        return new_weights
+
+    def __call__(self, mels: mx.array) -> mx.array:
+        """
+        Computes the embeddings of a batch of partial utterances.
+
+        Args:
+            mels: Batch of unscaled mel spectrograms (B, T, M)
+                  where T is hp.ve_partial_frames
+
+        Returns:
+            Embeddings as (B, E) where E is hp.speaker_embed_size.
+            Embeddings are L2-normed.
+        """
+        if self.hp.normalized_mels:
+            min_val = mx.min(mels)
+            max_val = mx.max(mels)
+            if float(min_val) < 0 or float(max_val) > 1:
+                raise Exception(f"Mels outside [0, 1]. Min={min_val}, Max={max_val}")
+
+        # Pass full sequence through LSTM layers (vectorized, no per-timestep loop)
+        _, (h_n, _) = self.lstm(mels)
+
+        # Get final hidden state from last layer
+        final_hidden = h_n[-1]  # (B, H)
+
+        # Project
+        raw_embeds = self.proj(final_hidden)
+
+        # Apply ReLU if configured
+        if self.hp.ve_final_relu:
+            raw_embeds = nn.relu(raw_embeds)
+
+        # L2 normalize
+        embeds = raw_embeds / mx.linalg.norm(raw_embeds, axis=1, keepdims=True)
+
+        return embeds
+
+    def inference(
+        self,
+        mels: mx.array,
+        mel_lens: List[int],
+        overlap: float = 0.5,
+        rate: Optional[float] = None,
+        min_coverage: float = 0.8,
+        batch_size: Optional[int] = None,
+    ) -> mx.array:
+        """
+        Computes embeddings of a batch of full utterances.
+
+        Args:
+            mels: (B, T, M) unscaled mels
+            mel_lens: List of mel lengths for each batch item
+            overlap: Overlap between partial windows
+            rate: Rate for frame step calculation
+            min_coverage: Minimum coverage for partial windows
+            batch_size: Batch size for processing partials
+
+        Returns:
+            (B, E) embeddings
+        """
+        # Compute where to split the utterances into partials
+        frame_step = get_frame_step(overlap, rate, self.hp)
+        n_partials_list = []
+        target_lens = []
+        for l in mel_lens:
+            n_p, t_l = get_num_wins(l, frame_step, min_coverage, self.hp)
+            n_partials_list.append(n_p)
+            target_lens.append(t_l)
+
+        # Possibly pad the mels to reach the target lengths
+        len_diff = max(target_lens) - mels.shape[1]
+        if len_diff > 0:
+            pad = mx.zeros((mels.shape[0], len_diff, self.hp.num_mels))
+            mels = mx.concatenate([mels, pad], axis=1)
+
+        # Group all partials together (vectorized extraction)
+        # For each mel, extract all partials at once using mx.take
+        partial_list = []
+        for mel, n_partial in zip(mels, n_partials_list):
+            if n_partial > 0:
+                # Create indices for all partials at once: (n_partial, ve_partial_frames)
+                partial_starts = mx.arange(n_partial) * frame_step  # (n_partial,)
+                frame_offsets = mx.arange(
+                    self.hp.ve_partial_frames
+                )  # (ve_partial_frames,)
+                # Broadcast to get all indices: (n_partial, ve_partial_frames)
+                indices = partial_starts[:, None] + frame_offsets[None, :]
+
+                # Extract all partials at once for each mel dimension
+                # mel is (T, M), we need (n_partial, ve_partial_frames, M)
+                mel_partials = mx.take(mel, indices.flatten(), axis=0).reshape(
+                    n_partial, self.hp.ve_partial_frames, mel.shape[1]
+                )
+                partial_list.append(mel_partials)
+
+        partials = mx.concatenate(partial_list, axis=0)  # (total_partials, T, M)
+
+        # Forward the partials (in batches if needed)
+        if batch_size is None or batch_size >= len(partials):
+            partial_embeds = self(partials)
+        else:
+            embed_chunks = []
+            for i in range(0, len(partials), batch_size):
+                chunk = partials[i : i + batch_size]
+                embed_chunks.append(self(chunk))
+            partial_embeds = mx.concatenate(embed_chunks, axis=0)
+
+        # Reduce the partial embeds into full embeds
+        # Compute slice indices without numpy
+        slices = [0]
+        for n in n_partials_list:
+            slices.append(slices[-1] + n)
+        raw_embeds = []
+        for start, end in zip(slices[:-1], slices[1:]):
+            raw_embeds.append(mx.mean(partial_embeds[start:end], axis=0))
+        raw_embeds = mx.stack(raw_embeds)
+
+        # L2-normalize the final embeds
+        embeds = raw_embeds / mx.linalg.norm(raw_embeds, axis=1, keepdims=True)
+
+        return embeds
+
+    @staticmethod
+    def utt_to_spk_embed(utt_embeds: mx.array) -> mx.array:
+        """
+        Takes L2-normalized utterance embeddings, computes mean and L2-normalizes
+        to get a speaker embedding.
+        """
+        assert len(utt_embeds.shape) == 2
+        utt_embeds = mx.mean(utt_embeds, axis=0)
+        return utt_embeds / mx.linalg.norm(utt_embeds)
+
+    @staticmethod
+    def voice_similarity(embeds_x: mx.array, embeds_y: mx.array) -> float:
+        """Cosine similarity for L2-normalized embeddings."""
+        if len(embeds_x.shape) != 1:
+            embeds_x = VoiceEncoder.utt_to_spk_embed(embeds_x)
+        if len(embeds_y.shape) != 1:
+            embeds_y = VoiceEncoder.utt_to_spk_embed(embeds_y)
+        return float(embeds_x @ embeds_y)
+
+    def embeds_from_mels(
+        self,
+        mels: List[mx.array],
+        mel_lens: Optional[List[int]] = None,
+        as_spk: bool = False,
+        batch_size: int = 32,
+        **kwargs,
+    ) -> mx.array:
+        """
+        Convenience function for deriving utterance or speaker embeddings from mel spectrograms.
+
+        Args:
+            mels: List of (Ti, M) arrays or stacked (B, T, M) array
+            mel_lens: Individual mel lengths if mels is stacked
+            as_spk: Whether to return speaker embedding (single) or utterance embeddings (per-utt)
+            batch_size: Batch size for processing
+            **kwargs: Additional args for inference()
+
+        Returns:
+            (B, E) embeddings if as_spk is False, else (E,) speaker embedding
+        """
+        # Handle list of mels
+        if isinstance(mels, list):
+            mel_lens = [mel.shape[0] for mel in mels]
+            max_len = max(mel_lens)
+            # Pad and stack
+            padded = []
+            for mel in mels:
+                if mel.shape[0] < max_len:
+                    pad = mx.zeros((max_len - mel.shape[0], mel.shape[1]))
+                    mel = mx.concatenate([mel, pad], axis=0)
+                padded.append(mel)
+            mels = mx.stack(padded)
+
+        # Embed them
+        utt_embeds = self.inference(mels, mel_lens, batch_size=batch_size, **kwargs)
+
+        return self.utt_to_spk_embed(utt_embeds) if as_spk else utt_embeds
+
+    def embeds_from_wavs(
+        self,
+        wavs: List[mx.array],
+        sample_rate: int,
+        as_spk: bool = False,
+        batch_size: int = 32,
+        trim_top_db: Optional[float] = 20,
+        **kwargs,
+    ) -> mx.array:
+        """
+        Wrapper around embeds_from_mels that first converts waveforms to mel spectrograms.
+
+        Args:
+            wavs: List of waveform arrays
+            sample_rate: Sample rate of the waveforms
+            as_spk: Whether to return speaker embedding
+            batch_size: Batch size for processing
+            trim_top_db: Trim silence below this threshold (None to disable)
+            **kwargs: Additional args for inference()
+
+        Returns:
+            Embeddings
+        """
+        import scipy.signal
+
+        # Resample if needed
+        if sample_rate != self.hp.sample_rate:
+            import numpy as np
+
+            resampled_wavs = []
+            for wav in wavs:
+                # Convert to numpy for resampling
+                wav_np = np.array(wav)
+                # Calculate resampling ratio
+                gcd = math.gcd(sample_rate, self.hp.sample_rate)
+                up = self.hp.sample_rate // gcd
+                down = sample_rate // gcd
+                wav_resampled = scipy.signal.resample_poly(wav_np, up, down)
+                resampled_wavs.append(mx.array(wav_resampled))
+            wavs = resampled_wavs
+
+        # Trim silence if requested
+        if trim_top_db is not None:
+            import numpy as np
+
+            trimmed_wavs = []
+            for wav in wavs:
+                wav_np = np.array(wav)
+                # Simple energy-based trimming
+                # Calculate frame energy
+                frame_length = 2048
+                hop_length = 512
+                # Compute RMS energy per frame
+                n_frames = 1 + (len(wav_np) - frame_length) // hop_length
+                if n_frames > 0:
+                    rms = np.array(
+                        [
+                            math.sqrt(
+                                np.mean(
+                                    wav_np[
+                                        i * hop_length : i * hop_length + frame_length
+                                    ]
+                                    ** 2
+                                )
+                            )
+                            for i in range(n_frames)
+                        ]
+                    )
+                    # Convert to dB
+                    rms_db = 20 * np.log10(np.maximum(rms, 1e-10))
+                    threshold = np.max(rms_db) - trim_top_db
+                    # Find non-silent frames
+                    non_silent = np.where(rms_db >= threshold)[0]
+                    if len(non_silent) > 0:
+                        start_frame = non_silent[0]
+                        end_frame = non_silent[-1] + 1
+                        start_sample = start_frame * hop_length
+                        end_sample = min(
+                            end_frame * hop_length + frame_length, len(wav_np)
+                        )
+                        wav_np = wav_np[start_sample:end_sample]
+                trimmed_wavs.append(mx.array(wav_np))
+            wavs = trimmed_wavs
+
+        # Set default rate if not provided
+        if "rate" not in kwargs:
+            kwargs["rate"] = 1.3  # Resemble's default value
+
+        # Convert waveforms to mel spectrograms
+        mels = []
+        for wav in wavs:
+            mel = melspectrogram(wav, self.hp)
+            # Transpose from (M, T) to (T, M)
+            mel = mx.transpose(mel)
+            mels.append(mel)
+
+        return self.embeds_from_mels(
+            mels, as_spk=as_spk, batch_size=batch_size, **kwargs
+        )

--- a/mlx_audio/tts/tests/test_chatterbox.py
+++ b/mlx_audio/tts/tests/test_chatterbox.py
@@ -1,0 +1,110 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import numpy as np
+
+
+class TestChatterboxConfig(unittest.TestCase):
+    def test_t3_config_defaults(self):
+        """Test T3Config default values and factory methods."""
+        from mlx_audio.tts.models.chatterbox.config import T3Config
+
+        # Test defaults
+        config = T3Config()
+        self.assertEqual(config.text_tokens_dict_size, 704)
+        self.assertEqual(config.speech_tokens_dict_size, 8194)
+        self.assertEqual(config.llama_config_name, "Llama_520M")
+        self.assertEqual(config.n_channels, 1024)
+        self.assertFalse(config.is_multilingual)
+
+        # Test factory methods
+        self.assertFalse(T3Config.english_only().is_multilingual)
+        self.assertTrue(T3Config.multilingual().is_multilingual)
+
+    def test_model_config_defaults(self):
+        """Test ModelConfig default values."""
+        from mlx_audio.tts.models.chatterbox.config import ModelConfig
+
+        config = ModelConfig()
+
+        self.assertEqual(config.model_type, "chatterbox")
+        self.assertEqual(config.s3_sr, 16000)
+        self.assertEqual(config.s3gen_sr, 24000)
+        self.assertEqual(config.sample_rate, 24000)
+        self.assertIsNotNone(config.t3_config)
+
+    def test_model_config_from_dict(self):
+        """Test ModelConfig.from_dict method."""
+        from mlx_audio.tts.models.chatterbox.config import ModelConfig
+
+        config_dict = {
+            "model_type": "chatterbox",
+            "t3_config": {
+                "text_tokens_dict_size": 2454,
+            },
+        }
+
+        config = ModelConfig.from_dict(config_dict)
+
+        self.assertEqual(config.model_type, "chatterbox")
+        self.assertTrue(config.t3_config.is_multilingual)
+
+
+class TestChatterboxModel(unittest.TestCase):
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.T3")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.S3Token2Wav")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.VoiceEncoder")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.S3TokenizerV2")
+    def test_init(self, mock_s3_tokenizer, mock_ve, mock_s3gen, mock_t3):
+        """Test Model initialization with config."""
+        from mlx_audio.tts.models.chatterbox.chatterbox import Model
+        from mlx_audio.tts.models.chatterbox.config import ModelConfig
+
+        config = ModelConfig()
+        model = Model(config)
+
+        self.assertIsNotNone(model.t3)
+        self.assertIsNotNone(model.s3gen)
+        self.assertIsNotNone(model.ve)
+        self.assertEqual(model.sr, 24000)
+        self.assertEqual(model.sample_rate, 24000)
+
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.T3")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.S3Token2Wav")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.VoiceEncoder")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.S3TokenizerV2")
+    def test_sanitize(
+        self, mock_s3_tokenizer, mock_ve_class, mock_s3gen_class, mock_t3_class
+    ):
+        """Test weight sanitization routes to correct components."""
+        from mlx_audio.tts.models.chatterbox.chatterbox import Model
+
+        # Mock components to have sanitize methods that pass through weights
+        for mock_class in [
+            mock_ve_class,
+            mock_t3_class,
+            mock_s3gen_class,
+            mock_s3_tokenizer,
+        ]:
+            mock_class.return_value.sanitize.side_effect = lambda w: w
+
+        model = Model()
+
+        # Test that prefixed weights are routed and re-prefixed
+        weights = {
+            "ve.lstm.weight": mx.zeros((10, 10)),
+            "t3.tfmr.weight": mx.zeros((10, 10)),
+            "s3gen.flow.weight": mx.zeros((10, 10)),
+        }
+
+        result = model.sanitize(weights)
+
+        # Verify weights keep their prefixes
+        self.assertIn("ve.lstm.weight", result)
+        self.assertIn("t3.tfmr.weight", result)
+        self.assertIn("s3gen.flow.weight", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I've ported [Chatterbox](https://github.com/resemble-ai/chatterbox) to MLX in Python, and it's working well. I haven't uploaded the weights to Hugging Face yet, in case any adjustments need to be made.

The 4-bit quantized model is about half as large and produces good results.

I was able to reuse and extend the existing S3 tokenizer.

You'll need to provide a short (5- to 10-second) sample recording of a voice to generate speech.

### Convert weights and save locally

```bash
# Full precision (~3GB)
python mlx_audio/tts/models/chatterbox/scripts/convert_chatterbox.py -o ./Chatterbox-TTS-fp16

# 4-bit quantized (~1.6GB, quantizes T3 backbone only)
python mlx_audio/tts/models/chatterbox/scripts/convert_chatterbox.py -o ./Chatterbox-TTS-4bit --quantize
```

### Generate speech with reference audio (voice cloning)

```bash
python -m mlx_audio.tts.generate \
  --model ./Chatterbox-TTS-4bit \
  --text "Hello, this is my cloned voice." \
  --ref_audio sample.wav \
  --play
```