### PR TITLE
Feat: add response format option to SpeechRequest

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -262,8 +262,10 @@ async def tts_speech(payload: SpeechRequest):
     model = model_provider.load_model(payload.model)
     return StreamingResponse(
         generate_audio(model, payload),
-        media_type="audio/wav",
-        headers={"Content-Disposition": "attachment; filename=speech.wav"},
+        media_type=f"audio/{payload.response_format}",
+        headers={
+            "Content-Disposition": f"attachment; filename=speech.{payload.response_format}"
+        },
     )
 
 


### PR DESCRIPTION
Add response_format parameter to TTS API

Closes #288 

# Summary
Adds response_format parameter to the `/v1/audio/speech` endpoint
Allows users to specify the output audio formats supported such as:

- WAV (default)
- FLAC
- OGG
- MP3 (if libsndfile was compiled with MP3 support)

# Usage

## Start server
> mlx_audio.server

## CURL

```curl
curl http://localhost:8000/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mlx-community/Spark-TTS-0.5B-bf16",
    "input": "The quick brown fox jumped over the lazy dog.",
    "voice": "male",
    "response_format": "mp3"
  }' \
  --output speech.mp3
```

## Script
```pytthon
import requests

response = requests.post(
    "http://localhost:8000/v1/audio/speech",
    json={
        "model": "mlx-community/Spark-TTS-0.5B-bf16",
        "input": "Hello, this is a test of text to speech.",
        "voice": "male",
        "response_format": "mp3"
    }
)

# Check the response format
print(f"Status Code: {response.status_code}")
print(f"Content-Type: {response.headers.get('Content-Type')}")
print(f"Content-Disposition: {response.headers.get('Content-Disposition')}")


with open("speech.mp3", "wb") as f:
    f.write(response.content)
```