### PR TITLE
fix(server): use lowercase for default response_format

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -163,7 +163,7 @@ class SpeechRequest(BaseModel):
     top_p: float | None = 0.95
     top_k: int | None = 40
     repetition_penalty: float | None = 1.0
-    response_format: str | None = "WAV"
+    response_format: str | None = "wav"
 
 
 # Initialize the ModelProvider


### PR DESCRIPTION
## Summary
Change default `response_format` from `"WAV"` to `"wav"`.

## Problem
The server returns `Content-Type: audio/WAV` and `Content-Disposition: attachment; filename=speech.WAV` with uppercase extension.

## RFC Standards

**RFC 6838 (Media Type Specifications)** and **RFC 7231 (HTTP Semantics)**:
- Media types are **case-insensitive** (`audio/wav` == `audio/WAV`)
- However, **IANA registers all media types in lowercase**
- Industry convention is to use **lowercase**

## Changes
- `response_format: str | None = "WAV"` → `"wav"`

## Impact
- `Content-Type: audio/wav` (was `audio/WAV`)
- `Content-Disposition: attachment; filename=speech.wav` (was `speech.WAV`)

This improves interoperability and follows established conventions.