### PR TITLE
Remove actual issue ID reference from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,4 @@
 ## Checklist
 - [ ] Tests added/updated
 - [ ] Documentation updated
-- [ ] Issue referenced (e.g., Closes #123)
+- [ ] Issue referenced (e.g., "Closes #...")


### PR DESCRIPTION
Resolves #333

## Description

Replaces the existing issue ID in the pull request template with a placeholder to avoid creating unwanted references. Also adds quotes to make the example snippet more distinct.
