### PR TITLE
Remove loguru reconfiguration on Kokoro import

### DIFF
--- a/mlx_audio/tts/models/kokoro/kokoro.py
+++ b/mlx_audio/tts/models/kokoro/kokoro.py
@@ -1,5 +1,4 @@
 import json
-import sys
 import time
 from dataclasses import dataclass
 from numbers import Number
@@ -13,12 +12,6 @@ from ..base import BaseModelArgs, GenerationResult, check_array_shape
 from .istftnet import Decoder
 from .modules import AlbertModelArgs, CustomAlbert, ProsodyPredictor, TextEncoder
 from .pipeline import KokoroPipeline
-
-# Force reset logger configuration at the top of your file
-logger.remove()  # Remove all handlers
-logger.configure(
-    handlers=[{"sink": sys.stderr, "level": "DEBUG"}]
-)  # Add back with explicit level
 
 
 def sanitize_lstm_weights(key: str, state_dict: mx.array) -> dict:


### PR DESCRIPTION
## Summary
- Remove loguru reconfiguration at Kokoro model import time
- Prevent library code from wiping application log handlers

## Motivation
Import-time logger.remove()/logger.configure() clears all loguru sinks registered by host apps, breaking downstream logging-dependent features when Kokoro runs in-process. Libraries should not mutate global logging configuration on import.

Tracking this down took ~4 hours because it so subtly broke downstream logging hooks when Kokoro ran in-process. Sharing in case it saves others time.