### PR TITLE
Fix: Use single quotes in README examples to avoid Bash history expansion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ pip install -e ".[dev]"
 
 ```bash
 # Basic TTS generation
-mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text "Hello, world!" --lang_code a
+mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text 'Hello, world!' --lang_code a
 
 # With voice selection and speed adjustment
-mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text "Hello!" --voice af_heart --speed 1.2 --lang_code a
+mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text 'Hello!' --voice af_heart --speed 1.2 --lang_code a
 
 # Play audio immediately
-mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text "Hello!" --play  --lang_code a
+mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text 'Hello!' --play  --lang_code a
 
 # Save to a specific directory
-mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text "Hello!" --output_path ./my_audio  --lang_code a
+mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text 'Hello!' --output_path ./my_audio  --lang_code a
 ```
 
 ### Python API


### PR DESCRIPTION
## Context
The terminal returns dquote> because Bash interprets the ! inside double quotes as a history expansion character. 

Ex.
`ls /root  # Permission denied`
`sudo !!   # Runs: sudo ls /root`

## Description
I tried to start the project using the command from the documentation, but encountered an issue: 

`Mac mlx-audio % mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text "Hello, world!" --lang_code a`

`dquote>`

## Same for other commands:

- Basic TTS generation
`mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text "Hello, world!" --lang_code a`

- With voice selection and speed adjustment
`mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text "Hello!" --voice af_heart --speed 1.2 --lang_code a`

- Play audio immediately
`mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text "Hello!" --play  --lang_code a`

- Save to a specific directory
`mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text "Hello!" --output_path ./my_audio  --lang_code a`


For ordinary users or beginners who use a classic terminal without replacing this command with a hotkey (there are some), it will be difficult to understand what is going on, and their opinion of the repo will be “it doesn't work.”

Changes in the codebase
I have replaced double quotes with single quotes in the documentation. Alternatively, we could use an escaped exclamation mark **`"Hello, world\!"`**, but single quotes are cleaner.

## Changes outside the codebase
No :)

## Additional information
https://www.gnu.org/software/bash/manual/html_node/History-Interaction.html

<!-- Optional: Add a checklist for contributors -->
## Checklist
- [x] Documentation updated
- [x] Issue referenced (e.g., "Closes #...")
