### PR TITLE
Restore Qwen3-TTS encoder_config to preserve accents in voice clones.

### DIFF
--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -1767,6 +1767,12 @@ class Model(nn.Module):
                         tokenizer_config_dict["decoder_config"],
                     )
                     decoder_config = Qwen3TTSTokenizerDecoderConfig(**filtered)
+                if "encoder_config" in tokenizer_config_dict:
+                    filtered = filter_dict_for_dataclass(
+                        Qwen3TTSTokenizerEncoderConfig,
+                        tokenizer_config_dict["encoder_config"],
+                    )
+                    encoder_config = Qwen3TTSTokenizerEncoderConfig(**filtered)
 
                 tokenizer_config = Qwen3TTSTokenizerConfig(
                     encoder_config=encoder_config,


### PR DESCRIPTION
Fixes #439.

This bumps the resource usage back up a bit though.