### PR TITLE
Ensure TTS audio player plays a trailing, partially-filled audio frame.

### DIFF
--- a/mlx_audio/tts/audio_player.py
+++ b/mlx_audio/tts/audio_player.py
@@ -41,7 +41,10 @@ class AudioPlayer:
                 else:
                     self.audio_buffer[0] = buf[to_copy:]
 
-            if not self.audio_buffer and filled < frames:
+            if filled < frames:
+                outdata[filled:] = 0  # fill with silence
+
+            if not self.audio_buffer and filled == 0:
                 self.drain_event.set()
                 self.playing = False
                 raise sd.CallbackStop()


### PR DESCRIPTION
The TTS audio player fills audio frames for playback. At the end of the audio stream, the output data buffer may have a partially filled frame. This was silently being discarded, and audio playback stopped, often abruptly cutting off speech.

This PR ensures any trailing, partially-filled audio frames are played.