### PR TITLE
Fix source separation issue with shape mismatch: noise shape for separate_long

### DIFF
--- a/mlx_audio/sts/models/sam_audio/model.py
+++ b/mlx_audio/sts/models/sam_audio/model.py
@@ -639,10 +639,13 @@ class SAMAudio(nn.Module):
         if total_samples <= chunk_samples:
             if verbose:
                 print(f"Audio is {total_duration:.1f}s, processing in single pass...")
-            sizes = mx.array([total_samples // self.audio_codec.config.hop_length])
+            feature_len = self.audio_codec.wav_idx_to_feature_idx(total_samples)
+            sizes = mx.array([feature_len])
+            noise_channels = 2 * self.audio_codec.config.codebook_dim
             noise = mx.random.normal(
-                (1, total_samples // self.audio_codec.config.hop_length, 256),
+                (1, feature_len, noise_channels),
                 key=mx.random.key(seed),
+                dtype=self.dtype,
             )
             return self.separate(
                 audios,


### PR DESCRIPTION
## Context
Running source separation with sam_audio currently fails because of a shape mismatch between the noise and the audio shape. 

## Description
  - Fix noise length calculation in the short-audio path of separate_long.
  - Generate noise with correct feature length and channels.


## Changes in the codebase
  - Use `wav_idx_to_feature_idx(total_samples)` instead of floor division by hop length (this correctly does ceiling)
  - Derive noise channel count from codebook_dim and match dtype.

## Additional information
Tested manually and sam_audio_small and it works now
