### PR TITLE
Improve convert dtype/.pt/model-type

### DIFF
--- a/mlx_audio/tts/tests/test_convert.py
+++ b/mlx_audio/tts/tests/test_convert.py
@@ -42,6 +42,7 @@ class TestConvert(unittest.TestCase):
             revision=None,
             dequantize=False,
             model_domain=None,
+            model_type=None,
         )
 
     def test_quantized_conversion(self):
@@ -70,6 +71,7 @@ class TestConvert(unittest.TestCase):
             revision=None,
             dequantize=False,
             model_domain=None,
+            model_type=None,
         )
 
     def test_quantized_conversion_invalid_group_size_raises_error(self):
@@ -114,6 +116,7 @@ class TestConvert(unittest.TestCase):
             revision=None,
             dequantize=False,
             model_domain=None,
+            model_type=None,
         )
 
     def test_quantization_recipes(self):
@@ -137,6 +140,7 @@ class TestConvert(unittest.TestCase):
                     revision=None,
                     dequantize=False,  # Default dequantize
                     model_domain=None,
+                    model_type=None,
                 )
                 # No need to reset mock here, it's handled at the start of the loop
 
@@ -158,6 +162,7 @@ class TestConvert(unittest.TestCase):
             revision=None,
             dequantize=True,
             model_domain=None,
+            model_type=None,
         )
 
     def test_upload_repo_argument(self):
@@ -178,6 +183,34 @@ class TestConvert(unittest.TestCase):
             revision=None,
             dequantize=False,
             model_domain=None,
+            model_type=None,
+        )
+
+    def test_model_type_argument(self):
+        test_args = [
+            "--hf-path",
+            "dummy_hf",
+            "--model-domain",
+            "sts",
+            "--model-type",
+            "sam_audio",
+        ]
+        with patch.object(sys, "argv", ["convert.py"] + test_args):
+            main()
+
+        self.convert_mock.assert_called_once_with(
+            hf_path="dummy_hf",
+            mlx_path="mlx_model",
+            quantize=False,
+            q_group_size=64,
+            q_bits=4,
+            quant_predicate=None,
+            dtype=None,
+            upload_repo=None,
+            revision=None,
+            dequantize=False,
+            model_domain="sts",
+            model_type="sam_audio",
         )
 
 


### PR DESCRIPTION
## Summary
- fix dtype conversion persistence in `mlx_audio/convert.py` by loading casted weights back into the model before saving
- add `.pt` / `.pth` checkpoint support in converter weight loading as a fallback when `.safetensors` is not present
- refactor converter to use shared `get_model_path` from `mlx_audio.utils`
- add `--model-type` CLI/API override with validation and help example (`--model-domain sts --model-type sam_audio`)

## Details
- `--dtype` now affects the serialized model in non-quantized conversions
- loader supports common PyTorch checkpoint structures: `state_dict`, `model_state_dict`, `model`, `weights`
- optional `module.` prefixes in checkpoint keys are stripped
- `.safetensors` remains preferred and is attempted first
- `--model-type` can override auto-detection and errors clearly if incompatible with the selected domain

## Validation
- `python -m py_compile mlx_audio/convert.py mlx_audio/tts/tests/test_convert.py`
- updated CLI parser tests in `mlx_audio/tts/tests/test_convert.py`
