### PR TITLE
fix(docs): update outdated model links

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ for result in model.generate("Hello from MLX-Audio!", voice="af_heart"):
 | **Qwen3-ForcedAligner** | Word-level audio alignment | ZH, EN, JA, KO, + more | [mlx-community/Qwen3-ForcedAligner-0.6B-8bit](https://huggingface.co/mlx-community/Qwen3-ForcedAligner-0.6B-8bit) |
 | **Parakeet** | NVIDIA's accurate STT | EN (v2), 25 EU languages (v3) | [mlx-community/parakeet-tdt-0.6b-v3](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3) |
 | **Voxtral** | Mistral's speech model | Multiple | [mlx-community/Voxtral-Mini-3B-2507-bf16](https://huggingface.co/mlx-community/Voxtral-Mini-3B-2507-bf16) |
-| **Voxtral Realtime** | Mistral's 4B streaming STT | Multiple | [int4](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-int4), [fp16](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16) |
+| **Voxtral Realtime** | Mistral's 4B streaming STT | Multiple | [4bit](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit), [fp16](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16) |
 | **VibeVoice-ASR** | Microsoft's 9B ASR with diarization & timestamps | Multiple | [mlx-community/VibeVoice-ASR-bf16](https://huggingface.co/mlx-community/VibeVoice-ASR-bf16) |
 
 
@@ -315,12 +315,12 @@ python -m mlx_audio.stt.generate \
 
 Mistral's 4B parameter streaming speech-to-text model, optimized for low-latency transcription.
 
-Available variants: [int4](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit) (smaller/faster) | [fp16](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16) (full precision)
+Available variants: [4bit](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit) (smaller/faster) | [fp16](https://huggingface.co/mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16) (full precision)
 
 ```python
 from mlx_audio.stt.utils import load
 
-# Use int4 for faster inference, fp16 for full precision
+# Use 4bit for faster inference, fp16 for full precision
 model = load("mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit")
 
 # Transcribe audio


### PR DESCRIPTION
## Context

I was trying out some models and noticed that the links for some of them in the README are outdated.

## Description

This PR is for updating model links that aren't working or are outdated. I tried to choose the model that seemed consistent with the previous link. Please let me know your feedback.