### PR TITLE
Optimize ACE-Step: NLC VAE, compiled decode, LoRA support

### DIFF
--- a/mlx_audio/tts/models/ace_step/lm.py
+++ b/mlx_audio/tts/models/ace_step/lm.py
@@ -20,26 +20,25 @@ class LMConfig:
     """Configuration for the 5Hz Language Model.
 
     Available models:
-        - "0.6B": Smallest, fastest (default, recommended for most use cases)
+        - "0.6B": Full precision (default)
+        - "0.6B-8bit": 8-bit quantized, ~704 MB
+        - "0.6B-4bit": 4-bit quantized, ~373 MB
         - "4B": Largest, highest quality but slower
-
-    Note: The 1.7B bundled model requires manual weight conversion and is not
-    currently supported. Use 0.6B or 4B instead.
     """
 
-    model_size: str = "0.6B"  # "0.6B" or "4B"
+    model_size: str = "0.6B"
     max_new_tokens: int = 3000
     temperature: float = 0.8
     top_k: int = 200
     top_p: float = 0.95
     repetition_penalty: float = 1.05
 
-    # Base model path (set when loading from ACE-Step1.5)
     base_model_path: Optional[str] = None
 
-    # Model ID mapping for standalone models (HuggingFace repos)
     _STANDALONE_MODEL_IDS = {
         "0.6B": "ACE-Step/acestep-5Hz-lm-0.6B",
+        "0.6B-8bit": "WaveCut/acestep-5Hz-lm-0.6B-mlx_8bit",
+        "0.6B-4bit": "WaveCut/acestep-5Hz-lm-0.6B-mlx_4bit",
         "4B": "ACE-Step/acestep-5Hz-lm-4B",
     }
 

--- a/mlx_audio/tts/utils.py
+++ b/mlx_audio/tts/utils.py
@@ -17,6 +17,7 @@ from mlx_audio.utils import (
 )
 
 MODEL_REMAPPING = {
+    "acestep": "ace_step",
     "qwen3_tts": "qwen3_tts",
     "outetts": "outetts",
     "spark": "spark",

--- a/mlx_audio/utils.py
+++ b/mlx_audio/utils.py
@@ -284,15 +284,15 @@ def get_model_class(
             if item.is_dir() and not item.name.startswith("__"):
                 available_models.append(item.name)
 
-    if model_name is not None and model_type_mapped != model_type:
+    if model_type_mapped is not None:
+        model_type = model_type_mapped
+    elif model_name is not None:
         for part in model_name:
             if part in available_models:
                 model_type = part
             if part in model_remapping:
                 model_type = model_remapping[part]
                 break
-    elif model_type_mapped is not None:
-        model_type = model_type_mapped
 
     try:
         module_path = f"mlx_audio.{category}.models.{model_type}"
@@ -370,6 +370,10 @@ def base_load_model(
         category=category,
         model_remapping=model_remapping,
     )
+
+    # Models with custom_loading delegate entirely to from_pretrained
+    if getattr(model_class.Model, "custom_loading", False):
+        return model_class.Model.from_pretrained(str(model_path))
 
     # Get model config from model class if it exists, otherwise use the config
     model_config = (


### PR DESCRIPTION
## Summary

- **VAE rewrite to NLC format**: Replace `WeightNormConv1d`/`WeightNormConvTranspose1d` with `nn.Conv1d` and `FastConvTranspose1d`. Weight-norm parameters (`weight_g`, `weight_v`) are fused into regular weights at load time via `sanitize()`, eliminating per-forward-pass normalization overhead.
- **Compiled VAE decode**: `mx.compile(model.vae.decode)` with auto-conversion to `mlx_weights.safetensors` on first load (skips PT→MLX conversion on subsequent runs).
- **`mx.fast.scaled_dot_product_attention`**: Replaces manual attention (matmul → mask → softmax → matmul) with MLX's fused kernel.
- **Simplified turbo diffusion**: Single-pass inference without CFG/APG (turbo model was distilled without guidance). Removes ~80 lines of unused guidance code.
- **LoRA adapter support**: `load_lora()` / `unload_lora()` with weight fusion (`W + scale * (alpha/r) * B @ A`), base weight backup/restore for hot-swapping adapters.
- **Quantized 5Hz LM variants**: Added `0.6B-8bit` and `0.6B-4bit` model IDs for lower-memory language model inference.
- **Music metadata**: `bpm`, `keyscale`, `timesignature` parameters forwarded to prompt formatting.
- **Model loading**: `custom_loading` class attribute + `acestep` remapping for clean integration with `mlx_audio.utils.base_load_model`.

## Test plan

- [x] Generate 30s instrumental with `--model ACE-Step/ACE-Step1.5` — verified output WAV
- [x] Generate 30s track with lyrics and vocal_language param
- [x] Generate with bpm/keyscale/timesignature metadata params
- [x] Verify `mlx_audio.tts.load()` API path works with custom_loading
- [x] Generate 60s track — verified correct duration and stereo output
- [x] Verify other TTS models (Kokoro, Spark) unaffected by utils changes
- [ ] Test with LoRA adapter loading/unloading
- [ ] Test quantized LM variants (0.6B-8bit, 0.6B-4bit)
- [ ] Test audio-to-audio tasks (cover, extract, complete)