### PR TITLE
fix: replace 4 bare excepts with except Exception

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -634,7 +634,7 @@ async def stt_realtime_transcriptions(websocket: WebSocket):
             # Receive message
             try:
                 message = await websocket.receive()
-            except:
+            except Exception:
                 break
 
             if "bytes" in message:
@@ -795,7 +795,7 @@ async def stt_realtime_transcriptions(websocket: WebSocket):
                     data = json.loads(message["text"])
                     if data.get("action") == "stop":
                         break
-                except:
+                except Exception:
                     pass
 
     except WebSocketDisconnect:
@@ -803,12 +803,12 @@ async def stt_realtime_transcriptions(websocket: WebSocket):
     except Exception as e:
         try:
             await websocket.send_json({"error": str(e), "status": "error"})
-        except:
+        except Exception:
             pass
     finally:
         try:
             await websocket.close()
-        except:
+        except Exception:
             pass
 
 


### PR DESCRIPTION
Replace 4 bare `except:` with `except Exception:`. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.