### PR TITLE
stt: Keep uploaded file extension to avoid unnecessary conversions.

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -401,7 +401,8 @@ async def stt_transcriptions(
     tmp = io.BytesIO(data)
     audio, sr = audio_read(tmp, always_2d=False)
     tmp.close()
-    tmp_path = f"/tmp/{time.time()}.mp3"
+    _, ext = os.path.splitext(file.filename)
+    tmp_path = f"/tmp/{time.time()}.{ext if ext else 'mp3'}"
     audio_write(tmp_path, audio, sr)
 
     stt_model = model_provider.load_model(payload.model)


### PR DESCRIPTION
When uploading a file for the /v1/audio/transcriptions endpoint, it either assumes it is in mp3 format, or it converts the bytes into mp3 for processing. If the user does not have ffmpeg on their machine, this will fail.

The PR preserves the uploaded file's extension (e.g. ".wav") to avoid issues.