### PR TITLE
Set max tokens to a more reasonable value by default for STT

### DIFF
--- a/mlx_audio/stt/generate.py
+++ b/mlx_audio/stt/generate.py
@@ -42,7 +42,7 @@ def parse_args():
     parser.add_argument(
         "--max-tokens",
         type=int,
-        default=128,
+        default=8192,
         help="Maximum number of new tokens to generate",
     )
     parser.add_argument(


### PR DESCRIPTION
I think this is a pretty sharp edge where it's hard to understand what's happening from the defaults. Fixes https://github.com/Blaizzy/mlx-audio/issues/459