### PR TITLE
feat(qwen3_asr): add auto language detection support

### DIFF
--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from mlx_audio.stt.models.base import STTOutput
 
 from .config import AudioEncoderConfig, ModelConfig, TextConfig
+from .utils import merge_languages, parse_asr_output
 
 
 @dataclass
@@ -852,22 +853,27 @@ class Qwen3ASRModel(nn.Module):
     def _build_prompt(
         self,
         num_audio_tokens: int,
-        language: str = "English",
+        language: Optional[str] = None,
         system_prompt: str | None = None,
     ) -> mx.array:
         """Build prompt with audio tokens."""
-        supported = self.config.support_languages or []
-        supported_lower = {lang.lower(): lang for lang in supported}
-
-        # Match language (case-insensitive) against supported languages
-        lang_name = supported_lower.get(language.lower(), language)
-
         system_content = f"{system_prompt}\n" if system_prompt else ""
-        prompt = (
-            f"<|im_start|>system\n{system_content}<|im_end|>\n"
-            f"<|im_start|>user\n<|audio_start|>{'<|audio_pad|>' * num_audio_tokens}<|audio_end|><|im_end|>\n"
-            f"<|im_start|>assistant\nlanguage {lang_name}<asr_text>"
-        )
+
+        if language is None:
+            prompt = (
+                f"<|im_start|>system\n{system_content}<|im_end|>\n"
+                f"<|im_start|>user\n<|audio_start|>{'<|audio_pad|>' * num_audio_tokens}<|audio_end|><|im_end|>\n"
+                f"<|im_start|>assistant\n"
+            )
+        else:
+            supported = self.config.support_languages or []
+            supported_lower = {lang.lower(): lang for lang in supported}
+            lang_name = supported_lower.get(language.lower(), language)
+            prompt = (
+                f"<|im_start|>system\n{system_content}<|im_end|>\n"
+                f"<|im_start|>user\n<|audio_start|>{'<|audio_pad|>' * num_audio_tokens}<|audio_end|><|im_end|>\n"
+                f"<|im_start|>assistant\nlanguage {lang_name}<asr_text>"
+            )
 
         input_ids = self._tokenizer.encode(prompt, return_tensors="np")
         return mx.array(input_ids)
@@ -879,7 +885,7 @@ class Qwen3ASRModel(nn.Module):
         max_tokens: int = 8192,
         sampler: Optional[Callable[[mx.array], mx.array]] = None,
         logits_processors: Optional[List[Callable]] = None,
-        language: str = "English",
+        language: Optional[str] = None,
         prefill_step_size: int = 2048,
         verbose: bool = False,
         system_prompt: str | None = None,
@@ -983,7 +989,7 @@ class Qwen3ASRModel(nn.Module):
         max_tokens: int = 8192,
         sampler: Optional[Callable] = None,
         logits_processors: Optional[List[Callable]] = None,
-        language: str = "English",
+        language: Optional[str] = None,
         prefill_step_size: int = 2048,
         verbose: bool = False,
         system_prompt: str | None = None,
@@ -1030,7 +1036,7 @@ class Qwen3ASRModel(nn.Module):
         min_tokens_to_keep: int = 1,
         repetition_penalty: Optional[float] = None,
         repetition_context_size: int = 100,
-        language: str = "English",
+        language: Optional[str] = None,
         prefill_step_size: int = 2048,
         chunk_duration: float = 1200.0,
         min_chunk_duration: float = 1.0,
@@ -1120,6 +1126,7 @@ class Qwen3ASRModel(nn.Module):
         total_prompt_tokens = 0
         total_generation_tokens = 0
         remaining_tokens = max_tokens
+        detected_languages = []
 
         chunk_iter = tqdm(
             chunks, desc="Processing chunks", disable=not verbose or len(chunks) == 1
@@ -1142,6 +1149,14 @@ class Qwen3ASRModel(nn.Module):
                 and len(chunks) == 1,  # Only show inner progress for single chunk
                 system_prompt=system_prompt,
             )
+
+            chunk_lang, parsed_text = parse_asr_output(text, user_language=language)
+            text = parsed_text
+
+            # Parse output for detected language from first chunk only
+            if chunk_lang and language is None:
+                detected_languages.append(chunk_lang)
+
             all_texts.append(text)
             total_prompt_tokens += prompt_toks
             total_generation_tokens += gen_toks
@@ -1163,10 +1178,12 @@ class Qwen3ASRModel(nn.Module):
 
         # Combine transcriptions
         full_text = " ".join(all_texts)
+        final_language = language if language else merge_languages(detected_languages)
 
         return STTOutput(
             text=full_text,
             segments=segments,
+            language=final_language,
             prompt_tokens=total_prompt_tokens,
             generation_tokens=total_generation_tokens,
             total_tokens=total_prompt_tokens + total_generation_tokens,
@@ -1195,7 +1212,7 @@ class Qwen3ASRModel(nn.Module):
         min_tokens_to_keep: int = 1,
         repetition_penalty: Optional[float] = None,
         repetition_context_size: int = 100,
-        language: str = "English",
+        language: Optional[str] = None,
         prefill_step_size: int = 2048,
         chunk_duration: float = 1200.0,
         min_chunk_duration: float = 1.0,

--- a/mlx_audio/stt/models/qwen3_asr/utils.py
+++ b/mlx_audio/stt/models/qwen3_asr/utils.py
@@ -1,0 +1,193 @@
+from typing import List, Optional, Tuple
+
+_ASR_TEXT_TAG = "<asr_text>"
+_LANG_PREFIX = "language "
+
+
+def detect_and_fix_repetitions(text, threshold=20):
+    def fix_char_repeats(s, thresh):
+        res = []
+        i = 0
+        n = len(s)
+        while i < n:
+            count = 1
+            while i + count < n and s[i + count] == s[i]:
+                count += 1
+
+            if count > thresh:
+                res.append(s[i])
+                i += count
+            else:
+                res.append(s[i : i + count])
+                i += count
+        return "".join(res)
+
+    def fix_pattern_repeats(s, thresh, max_len=20):
+        n = len(s)
+        min_repeat_chars = thresh * 2
+        if n < min_repeat_chars:
+            return s
+
+        i = 0
+        result = []
+        while i <= n - min_repeat_chars:
+            found = False
+            for k in range(1, max_len + 1):
+                if i + k * thresh > n:
+                    break
+
+                pattern = s[i : i + k]
+                valid = True
+                for rep in range(1, thresh):
+                    start_idx = i + rep * k
+                    if s[start_idx : start_idx + k] != pattern:
+                        valid = False
+                        break
+
+                if valid:
+                    total_rep = thresh
+                    end_index = i + thresh * k
+                    while (
+                        end_index + k <= n and s[end_index : end_index + k] == pattern
+                    ):
+                        total_rep += 1
+                        end_index += k
+                    result.append(pattern)
+                    result.append(fix_pattern_repeats(s[end_index:], thresh, max_len))
+                    i = n
+                    found = True
+                    break
+
+            if found:
+                break
+            else:
+                result.append(s[i])
+                i += 1
+
+        if not found:
+            result.append(s[i:])
+        return "".join(result)
+
+    text_raw = text
+    text = fix_char_repeats(text_raw, threshold)
+    text = fix_pattern_repeats(text, threshold)
+    return text
+
+
+def normalize_language_name(language: str) -> str:
+    """
+    Normalize language name to the canonical format used by Qwen3-ASR:
+    first letter uppercase, the rest lowercase (e.g., 'cHINese' -> 'Chinese').
+
+    Args:
+        language (str): Input language name.
+
+    Returns:
+        str: Normalized language name.
+
+    Raises:
+        ValueError: If language is empty.
+    """
+    if language is None:
+        raise ValueError("language is None")
+    s = str(language).strip()
+    if not s:
+        raise ValueError("language is empty")
+    return s[:1].upper() + s[1:].lower()
+
+
+def parse_asr_output(
+    raw: str,
+    user_language: Optional[str] = None,
+) -> Tuple[str, str]:
+    """
+    Parse Qwen3-ASR raw output into (language, text).
+
+    Cases:
+      - With tag: "language Chinese<asr_text>...."
+      - With newlines: "language Chinese\\n...\\n<asr_text>...."
+      - No tag: treat whole string as text.
+      - "language None<asr_text>": treat as empty audio -> ("", "")
+
+    If user_language is provided, language is forced to user_language and raw is treated as text-only
+    (the model is expected to output plain transcription without metadata).
+
+    Args:
+        raw: Raw decoded string.
+        user_language: Canonical language name if user forced language.
+
+    Returns:
+        Tuple[str, str]: (language, text)
+    """
+    if raw is None:
+        return "", ""
+    s = str(raw).strip()
+    if not s:
+        return "", ""
+
+    s = detect_and_fix_repetitions(s)
+
+    if user_language:
+        # user explicitly forced language => model output is treated as pure text
+        return user_language, s
+
+    meta_part = s
+    text_part = ""
+    has_tag = _ASR_TEXT_TAG in s
+    if has_tag:
+        meta_part, text_part = s.split(_ASR_TEXT_TAG, 1)
+    else:
+        # no tag => pure text
+        return "", s.strip()
+
+    meta_lower = meta_part.lower()
+
+    # empty audio heuristic
+    if "language none" in meta_lower:
+        t = text_part.strip()
+        if not t:
+            return "", ""
+        # if model still returned something, keep it but language unknown
+        return "", t
+
+    # extract "language xxx" from meta
+    lang = ""
+    for line in meta_part.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        low = line.lower()
+        if low.startswith(_LANG_PREFIX):
+            val = line[len(_LANG_PREFIX) :].strip()
+            if val:
+                lang = normalize_language_name(val)
+            break
+
+    return lang, text_part.strip()
+
+
+def merge_languages(langs: List[str]) -> str:
+    """
+    Merge per-chunk languages into a compact comma-separated string,
+    keeping order and removing consecutive duplicates and empty entries.
+
+    Example:
+      ["Chinese", "English", "English"] -> "Chinese,English"
+
+    Args:
+        langs: List of canonical language names.
+
+    Returns:
+        str: Merged language string.
+    """
+    out: List[str] = []
+    prev = None
+    for x in langs:
+        x = (x or "").strip()
+        if not x:
+            continue
+        if x == prev:
+            continue
+        out.append(x)
+        prev = x
+    return ",".join(out)


### PR DESCRIPTION
## Summary

This PR adds automatic language detection support to Qwen3-ASR, ported from the original Qwen-ASR repository.

### Changes
- Allow `language` parameter to be optional (`None`) for auto-detection
- Add `utils.py` with `merge_languages` and `parse_asr_output` helpers
- Parse ASR output to detect language from model response
- Return detected language in `STTOutput`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Additional Context

Ported from original Qwen-ASR implementation for auto language detection feature.