### PR TITLE
fix: avoid passing language=None to STT model generate()

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -531,10 +531,14 @@ async def _stream_transcription(
     """
     supports_stream = "stream" in inspect.signature(stt_model.generate).parameters
     lang_arg = language if language and language != "Detect" else None
+    # Only pass language kwarg when explicitly set — otherwise let the model
+    # use its own default (e.g. Qwen3-ASR defaults to "English").  Passing
+    # None explicitly overrides the default and crashes models that expect a str.
+    lang_kwargs = {"language": lang_arg} if lang_arg is not None else {}
 
     if supports_stream and streaming:
         result_iter = stt_model.generate(
-            audio_array, stream=True, language=lang_arg, verbose=False
+            audio_array, stream=True, **lang_kwargs, verbose=False
         )
         accumulated = ""
         for chunk in result_iter:
@@ -557,7 +561,7 @@ async def _stream_transcription(
         tmp_path = f"/tmp/realtime_{time.time()}.mp3"
         audio_write(tmp_path, audio_array, sample_rate)
         try:
-            result = stt_model.generate(tmp_path, language=lang_arg, verbose=False)
+            result = stt_model.generate(tmp_path, **lang_kwargs, verbose=False)
             segments = (
                 sanitize_for_json(result.segments)
                 if hasattr(result, "segments") and result.segments


### PR DESCRIPTION
## Problem

When using the WebSocket realtime transcription endpoint (`/v1/audio/transcriptions/realtime`) without specifying a language (or with `"Detect"`), `_stream_transcription()` passes `language=None` explicitly to `stt_model.generate()`.

This overrides the model's own default parameter. For example, Qwen3-ASR defaults `language` to `"English"` in its `generate()` signature, but the explicit `None` overrides that, causing a crash in `_build_prompt()`:

```
AttributeError: 'NoneType' object has no attribute 'lower'
```

at `lang_name = supported_lower.get(language.lower(), language)`.

## Fix

Build the `language` kwarg dict conditionally so it is omitted entirely when unset, letting each model fall back to its own default:

```python
lang_kwargs = {"language": lang_arg} if lang_arg is not None else {}
stt_model.generate(audio_array, stream=True, **lang_kwargs, verbose=False)
```

The REST endpoint (`/v1/audio/transcriptions`) already handles this correctly via `exclude_none=True` in `model_dump()` — this fix brings the WebSocket path in line.

## Reproduction

1. Start mlx-audio server
2. Pre-load `mlx-community/Qwen3-ASR-0.6B-8bit`
3. Connect to `/v1/audio/transcriptions/realtime` without a `language` field in config (or with `"Detect"`)
4. Send audio → crash

After fix: model uses its default language (`"English"` for Qwen3-ASR) and transcription works.