### PR TITLE
Qwen3 CustomVoice ignores clone refs at /v1/audio/speech and falls back to speaker-only path

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -263,6 +263,7 @@ async def remove_model(model_name: str):
 async def generate_audio(model, payload: SpeechRequest):
     # Load reference audio if provided
     ref_audio = payload.ref_audio
+    ref_text = payload.ref_text
     audio_chunks = []
     sample_rate = None
     if ref_audio and isinstance(ref_audio, str):
@@ -280,6 +281,15 @@ async def generate_audio(model, payload: SpeechRequest):
             ref_audio, sample_rate=model.sample_rate, volume_normalize=normalize
         )
 
+    if ref_text and isinstance(ref_text, str) and os.path.exists(ref_text):
+        try:
+            with open(ref_text, encoding="utf-8") as fh:
+                ref_text = fh.read()
+        except OSError as exc:
+            raise HTTPException(
+                status_code=400, detail=f"Reference text file unreadable: {ref_text}: {exc}"
+            ) from exc
+
     for result in model.generate(
         payload.input,
         voice=payload.voice,
@@ -289,7 +299,7 @@ async def generate_audio(model, payload: SpeechRequest):
         instruct=payload.instruct,
         lang_code=payload.lang_code,
         ref_audio=ref_audio,
-        ref_text=payload.ref_text,
+        ref_text=ref_text,
         temperature=payload.temperature,
         top_p=payload.top_p,
         top_k=payload.top_k,

--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -936,29 +936,6 @@ class Model(nn.Module):
             )
             return
 
-                if tts_model_type == "custom_voice":
-            if not voice:
-                raise ValueError(
-                    "CustomVoice model requires 'voice' (speaker name) "
-                    "(e.g., 'Chelsie', 'Ethan', 'Vivian')"
-                )
-            yield from self.generate_custom_voice(
-                text=text,
-                speaker=voice,
-                language=lang_code,
-                instruct=instruct,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                top_k=top_k,
-                top_p=top_p,
-                repetition_penalty=repetition_penalty,
-                verbose=verbose,
-                stream=stream,
-                streaming_interval=streaming_interval,
-            )
-            return
-
-        # Base model generation
         if self.speech_tokenizer is None:
             raise ValueError("Speech tokenizer not loaded")
 
@@ -988,6 +965,30 @@ class Model(nn.Module):
                 streaming_interval=streaming_interval,
             )
             return
+
+        if tts_model_type == "custom_voice":
+            if not voice:
+                raise ValueError(
+                    "CustomVoice model requires 'voice' (speaker name) "
+                    "(e.g., 'Chelsie', 'Ethan', 'Vivian')"
+                )
+            yield from self.generate_custom_voice(
+                text=text,
+                speaker=voice,
+                language=lang_code,
+                instruct=instruct,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                top_k=top_k,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                verbose=verbose,
+                stream=stream,
+                streaming_interval=streaming_interval,
+            )
+            return
+
+        # Base model generation
 
         # Split text into segments
         if split_pattern:


### PR DESCRIPTION
## Context
Qwen3 `CustomVoice` models were not honoring clone references at the OpenAI-compatible `/v1/audio/speech` endpoint. From a product perspective, that made the API behave in a misleading way: callers could provide `ref_audio` and `ref_text`, but the request still took the predefined-speaker path instead of the actual voice-cloning path.

In practice, this meant voice cloning did not work reliably for `CustomVoice` models unless callers stumbled into unintended behavior. The goal of this change is to make the API respect explicit clone inputs and behave in the way users expect.

## Description
This change fixes two parts of the request flow.

First, in `mlx_audio/tts/models/qwen3_tts/qwen3_tts.py`, the generation branch order is updated so that when both `ref_audio` and `ref_text` are present and the speech tokenizer encoder is available, the model uses the existing ICL cloning path before considering the `custom_voice` speaker-only path.

Second, in `mlx_audio/server.py`, `ref_text` is resolved from a server-side file path before calling `model.generate()`, matching the existing handling of `ref_audio`. This allows deployments that provide clone references as server-local paths to work consistently for both the reference audio and its transcript.

Together, these changes make clone-reference requests work correctly for `CustomVoice` models while preserving the existing speaker/emotion behavior when clone refs are not provided.

## Changes in the codebase
- Updated `mlx_audio/tts/models/qwen3_tts/qwen3_tts.py` so clone-reference requests prefer the ICL cloning path even when the loaded model is `custom_voice`.
- Preserved the existing `generate_custom_voice()` behavior for requests that do not provide clone references.
- Updated `mlx_audio/server.py` so `ref_text` file paths are resolved server-side before passing the value into `model.generate()`, mirroring the existing `ref_audio` handling.

## Changes outside the codebase
There are no infrastructure, database, or external service changes in this PR.

This change was validated against a live OpenAI-compatible `/v1/audio/speech` deployment using a Qwen3 `CustomVoice` model and server-side reference file paths.

## Additional information
This PR keeps the external API shape unchanged. Callers still provide the same request fields, but the internal handling now aligns with the expectation that clone refs should drive cloning behavior when they are present.

This also improves compatibility for deployments that store reference media and transcripts on the server and pass those paths through the API layer.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Issue referenced (Closes #557)
