### PR TITLE
fix: optioanl dependencies - all & server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,10 @@ tts = [
 server = [
     "fastapi>=0.95.0",
     "uvicorn>=0.22.0",
-    "python-multipart>=0.0.22"
+    "python-multipart>=0.0.22",
+
+    "webrtcvad>=2.0.10",
+    "setuptools<81",
 ]
 
 # STS (Speech-to-Speech) requires both STT and TTS + additional deps
@@ -70,6 +73,7 @@ sts = [
     "sentencepiece>=0.2.0",
     
     "webrtcvad>=2.0.10",
+    "setuptools<81",
 ]
 
 # Full installation (all features)
@@ -86,8 +90,10 @@ all = [
 
     "fastapi>=0.95.0",
     "uvicorn>=0.22.0",
+    "python-multipart>=0.0.22",
 
     "webrtcvad>=2.0.10",
+    "setuptools<81",
 ]
 
 # Development dependencies


### PR DESCRIPTION
## Context

Fix 3 dependencies issues:

1. `mlx_audio.server` depends on `webrtcvad`.
2. `setuptools>=81` breaks `webrtcvad`, Closes #566 
3. `python-multipart>=0.0.22"` should be included in `all`, as `mlx_audio.server` relies on it.

## Checklist
- [x] Tests added/updated
- [x] Documentation updated
- [x] Issue referenced (e.g., "Closes #...")
