### PR TITLE
Fix: cap max_tokens in base generation to prevent stuttering

### DIFF
--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -1001,9 +1001,14 @@ class Model(nn.Module):
         for segment_idx, segment_text in enumerate(segments):
             start_time = time.time()
 
+            # Cap max_tokens based on segment text length to prevent runaway generation.
+            # Same formula as ICL mode: at 12.5 Hz, factor of 6 gives ~50% margin.
+            target_token_count = len(self.tokenizer.encode(segment_text))
+            effective_max_tokens = min(max_tokens, max(75, target_token_count * 6))
+
             # Create progress bar for token generation
             pbar = tqdm(
-                total=max_tokens,
+                total=effective_max_tokens,
                 desc=f"Segment {segment_idx + 1}/{len(segments)}",
                 unit="tokens",
                 disable=not verbose,
@@ -1044,7 +1049,7 @@ class Model(nn.Module):
                 chunk_start_time = time.time()
                 self.speech_tokenizer.decoder.reset_streaming_state()
 
-            for step in range(max_tokens):
+            for step in range(effective_max_tokens):
                 # Forward pass through talker
                 logits, hidden = self.talker(
                     input_embeds,


### PR DESCRIPTION
## Summary

- The ICL and voice_design generation modes already cap `max_tokens` proportional to text length (`min(max_tokens, max(75, target_token_count * 6))`), but base generation uses the raw `max_tokens` (default 4096 ≈ 5.5 min of audio) regardless of input length.
- This allows the model to generate far more audio tokens than the text warrants, producing stuttered/repeated speech at the tail end.
- This PR applies the same `effective_max_tokens` formula to the base generation loop, matching the existing ICL mode pattern.

## Observed behavior

With Qwen3-TTS-12Hz-1.7B-Base-bf16, a 38-token input ("Mm... О, это интересно! IT менеджер — хорошая профессия...") occasionally generated ~250 codec tokens (~20s audio) instead of the expected ~150 tokens (~12s), with audible stuttering/repetition in the excess portion.

With the cap: `max(75, 38 * 6) = 228 tokens ≈ 18.2s` — well above the normal 10–13s range but below the stuttered 20s output.

## Test plan

- [x] Verified 5 baseline generations (10.2–12.5s) are unaffected by the cap
- [x] Confirmed the stuttered 20s case (250 tokens) would be prevented (cap = 228)
- [x] Cap formula matches existing ICL mode (line 1863) and voice_design mode (line 2177)