### PR TITLE
Align Fish Speech sampling with official PyTorch inference

### DIFF
--- a/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
+++ b/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
@@ -27,7 +27,6 @@ from .tokenizer import IM_END_TOKEN, FishTokenizer
 RAS_WIN_SIZE = 10
 RAS_HIGH_TEMP = 1.0
 RAS_HIGH_TOP_P = 0.9
-RAS_MAX_RETRY = 4
 
 
 @dataclass
@@ -337,7 +336,6 @@ class DualARTransformer(nn.Module):
         return self.fast_output(x[:, -1])
 
 
-@mx.compile
 def _sample_logits(
     logits: mx.array, temperature: float, top_p: float, top_k: int
 ) -> mx.array:
@@ -476,30 +474,33 @@ class Model(nn.Module):
             raise ValueError("Semantic logits bias is not initialized.")
 
         biased_logits = logits + self.semantic_logit_bias.astype(logits.dtype)
-        normal = _sample_logits(
+
+        # Sample both normal and high-temp tokens in a single pass, matching the
+        # official PyTorch implementation's single-fallback RAS pattern (no retry loop).
+        normal_token = _sample_logits(
             biased_logits, temperature=temperature, top_p=top_p, top_k=top_k
         )
-        mx.eval(normal)
+        high_token = _sample_logits(
+            biased_logits,
+            temperature=RAS_HIGH_TEMP,
+            top_p=RAS_HIGH_TOP_P,
+            top_k=top_k,
+        )
+        mx.eval(normal_token, high_token)
 
-        for _ in range(RAS_MAX_RETRY):
-            token_value = int(normal[0].item())
-            if token_value not in previous_semantic_tokens:
-                return normal
-            if not (
-                self.config.semantic_start_token_id
-                <= token_value
-                <= self.config.semantic_end_token_id
-            ):
-                return normal
-            normal = _sample_logits(
-                biased_logits,
-                temperature=RAS_HIGH_TEMP,
-                top_p=RAS_HIGH_TOP_P,
-                top_k=top_k,
-            )
-            mx.eval(normal)
-
-        return normal
+        # RAS: if the normal token repeats within the window AND is semantic,
+        # use the high-temp fallback instead.  If the high-temp token also
+        # repeats, it is accepted as-is (exactly one fallback attempt).
+        token_value = int(normal_token[0].item())
+        in_window = token_value in previous_semantic_tokens
+        is_semantic = (
+            self.config.semantic_start_token_id
+            <= token_value
+            <= self.config.semantic_end_token_id
+        )
+        if in_window and is_semantic:
+            return high_token
+        return normal_token
 
     def _generate_codes_for_batch(
         self,
@@ -536,13 +537,8 @@ class Model(nn.Module):
         previous_semantic_tokens: list[int] = []
         generated_steps = []
         im_end_id = self.tokenizer.get_token_id(IM_END_TOKEN)
-        text_token_count = len(self.tokenizer.encode(batch_text))
-        semantic_token_budget = min(
-            max_new_tokens,
-            max(32, text_token_count * 12),
-        )
 
-        for _ in range(semantic_token_budget):
+        for _ in range(max_new_tokens):
             semantic_token = self._sample_semantic(
                 logits=logits,
                 previous_semantic_tokens=previous_semantic_tokens,
@@ -561,6 +557,9 @@ class Model(nn.Module):
             semantic_code = (
                 semantic_token - self.config.semantic_start_token_id
             ).astype(mx.int32)
+            semantic_code = mx.clip(
+                semantic_code, 0, self.config.audio_decoder_config.vocab_size - 1
+            )
             previous_codebooks = semantic_code[:, None]
             fast_cache = self.model.make_fast_cache()
             fast_prefill = self.model.fast_forward_cached(hidden_state, fast_cache)
@@ -729,7 +728,7 @@ class Model(nn.Module):
             model.tokenizer.vocab_size,
             model.config.text_config.vocab_size,
         )
-        semantic_bias = mx.full((1, vocab_size), -1e9, dtype=mx.float32)
+        semantic_bias = mx.full((1, vocab_size), float("-inf"), dtype=mx.float32)
         semantic_bias[
             :,
             model.config.semantic_start_token_id : model.config.semantic_end_token_id

--- a/mlx_audio/tts/tests/test_fish_speech_sampling.py
+++ b/mlx_audio/tts/tests/test_fish_speech_sampling.py
@@ -1,0 +1,292 @@
+"""Tests for Fish Speech sampling alignment with the official PyTorch implementation.
+
+Verifies three fixes that align the MLX sampling behaviour with
+the upstream ``fish-speech`` inference pipeline:
+
+1. RAS (Repetition Aware Sampling) uses a single-pass fallback
+   (sample normal + high-temp, then conditionally swap) instead of a
+   retry loop.
+2. Semantic codes are clamped to ``[0, codebook_size - 1]`` before the
+   fast-pathway embedding lookup.
+3. The semantic logit bias uses ``-inf`` (not ``-1e9``) so that masked
+   tokens receive exactly zero probability after softmax.
+"""
+
+import unittest
+
+import mlx.core as mx
+
+
+def _tiny_config():
+    """A minimal config where the semantic token range fits inside the vocab."""
+    from mlx_audio.tts.models.fish_qwen3_omni.config import ModelConfig
+
+    return ModelConfig.from_dict(
+        {
+            "semantic_start_token_id": 16,
+            "semantic_end_token_id": 23,
+            "text_config": {
+                "vocab_size": 32,
+                "n_layer": 1,
+                "n_head": 2,
+                "dim": 8,
+                "intermediate_size": 16,
+                "n_local_heads": 1,
+                "head_dim": 4,
+                "norm_eps": 1e-6,
+                "max_seq_len": 64,
+                "attention_qk_norm": True,
+            },
+            "audio_decoder_config": {
+                "vocab_size": 8,
+                "n_layer": 1,
+                "n_head": 2,
+                "dim": 8,
+                "intermediate_size": 16,
+                "n_local_heads": 1,
+                "head_dim": 4,
+                "num_codebooks": 2,
+                "norm_eps": 1e-6,
+                "max_seq_len": 3,
+            },
+        }
+    )
+
+
+def _make_model():
+    from mlx_audio.tts.models.fish_qwen3_omni.fish_speech import Model
+
+    config = _tiny_config()
+    model = Model(config)
+    # Manually build the semantic_logit_bias (normally done in post_load_hook).
+    vocab_size = config.text_config.vocab_size
+    semantic_bias = mx.full((1, vocab_size), float("-inf"), dtype=mx.float32)
+    semantic_bias[
+        :,
+        config.semantic_start_token_id : config.semantic_end_token_id + 1,
+    ] = 0.0
+    model.semantic_logit_bias = semantic_bias
+    return model
+
+
+# ── Fix 1: RAS single-pass fallback ──────────────────────────────────
+
+
+class TestRASSinglePassFallback(unittest.TestCase):
+    """RAS must use a single-pass fallback (sample normal + high-temp, then
+    conditionally swap) instead of a retry loop."""
+
+    def test_ras_no_retry_constant(self):
+        """RAS_MAX_RETRY should no longer exist (replaced by single-pass)."""
+        import mlx_audio.tts.models.fish_qwen3_omni.fish_speech as mod
+
+        self.assertFalse(
+            hasattr(mod, "RAS_MAX_RETRY"),
+            "RAS_MAX_RETRY constant should be removed (single-pass fallback).",
+        )
+
+    def test_ras_returns_normal_when_not_in_window(self):
+        """Normal token is returned when it is not in the RAS window."""
+        model = _make_model()
+        config = model.config
+
+        # Logits that strongly prefer the first semantic token.
+        logits = mx.full((1, config.text_config.vocab_size), -1e4, dtype=mx.float32)
+        logits[:, config.semantic_start_token_id] = 10.0
+        mx.random.seed(0)
+
+        token = model._sample_semantic(
+            logits,
+            previous_semantic_tokens=[],  # empty window
+            top_p=0.9,
+            top_k=8,
+            temperature=0.7,
+        )
+        mx.eval(token)
+        tok_val = int(token[0].item())
+        self.assertTrue(
+            config.semantic_start_token_id <= tok_val <= config.semantic_end_token_id,
+            f"Expected a semantic token, got {tok_val}",
+        )
+
+    def test_ras_uses_high_temp_when_token_repeats(self):
+        """When the normal sample repeats in the window, the high-temp token
+        is used instead (single fallback, no retry loop)."""
+        model = _make_model()
+        config = model.config
+
+        # Make logits overwhelmingly prefer semantic_start_token_id so that
+        # the "normal" sample is almost certainly that token.
+        logits = mx.full((1, config.text_config.vocab_size), -1e4, dtype=mx.float32)
+        logits[:, config.semantic_start_token_id] = 100.0
+        # Also give some probability to the next token so high-temp can pick it.
+        logits[:, config.semantic_start_token_id + 1] = 0.0
+
+        # Put semantic_start_token_id in the window so it counts as a repeat.
+        window = [config.semantic_start_token_id]
+
+        mx.random.seed(42)
+        token = model._sample_semantic(
+            logits,
+            previous_semantic_tokens=window,
+            top_p=0.9,
+            top_k=8,
+            temperature=0.01,  # very low temp → almost deterministic normal sample
+        )
+        mx.eval(token)
+        # The function should have detected the repeat and returned the
+        # high-temp sample.  We cannot predict the exact value since it
+        # depends on sampling, but we verify it returned a valid semantic token.
+        tok_val = int(token[0].item())
+        self.assertTrue(
+            config.semantic_start_token_id <= tok_val <= config.semantic_end_token_id,
+            f"Expected a semantic token from high-temp fallback, got {tok_val}",
+        )
+
+    def test_ras_accepts_non_semantic_repeat(self):
+        """Non-semantic tokens are returned even if they appear in the RAS
+        window (RAS only applies to semantic tokens)."""
+        model = _make_model()
+        config = model.config
+
+        # Build logits that strongly prefer a non-semantic token (token 0).
+        logits = mx.full((1, config.text_config.vocab_size), -1e4, dtype=mx.float32)
+        logits[:, 0] = 100.0
+        # Allow the non-semantic token through the bias by overriding it.
+        model.semantic_logit_bias[:, 0] = 0.0
+
+        # Put token 0 in the window — it should still be returned because
+        # it is not a semantic token.
+        window = [0]
+
+        mx.random.seed(0)
+        token = model._sample_semantic(
+            logits,
+            previous_semantic_tokens=window,
+            top_p=0.9,
+            top_k=8,
+            temperature=0.01,
+        )
+        mx.eval(token)
+        self.assertEqual(int(token[0].item()), 0)
+
+
+# ── Fix 2: semantic code clamp ───────────────────────────────────────
+
+
+class TestSemanticCodeClamp(unittest.TestCase):
+    """Semantic codes must be clamped to [0, codebook_size - 1] before the
+    fast-pathway embedding lookup, matching the official PyTorch
+    ``torch.clamp(a, min=0, max=model.config.codebook_size - 1)``."""
+
+    def test_clamp_prevents_negative_index(self):
+        """Subtracting semantic_start_token_id from a token below that range
+        must be clamped to 0, not left as a negative index."""
+        config = _tiny_config()
+        token_below = mx.array(
+            [config.semantic_start_token_id - 5], dtype=mx.int32
+        )
+        code = (token_below - config.semantic_start_token_id).astype(mx.int32)
+        code = mx.clip(code, 0, config.audio_decoder_config.vocab_size - 1)
+        mx.eval(code)
+        self.assertEqual(int(code[0].item()), 0)
+
+    def test_clamp_prevents_overflow(self):
+        """A token above the semantic range must be clamped to
+        codebook_size - 1."""
+        config = _tiny_config()
+        token_above = mx.array(
+            [config.semantic_end_token_id + 100], dtype=mx.int32
+        )
+        code = (token_above - config.semantic_start_token_id).astype(mx.int32)
+        code = mx.clip(code, 0, config.audio_decoder_config.vocab_size - 1)
+        mx.eval(code)
+        self.assertEqual(
+            int(code[0].item()), config.audio_decoder_config.vocab_size - 1
+        )
+
+    def test_clamp_present_in_source(self):
+        """Verify that ``mx.clip`` is present in the model source."""
+        import inspect
+
+        from mlx_audio.tts.models.fish_qwen3_omni.fish_speech import Model
+
+        source = inspect.getsource(Model._generate_codes_for_batch)
+        self.assertIn(
+            "mx.clip", source, "mx.clip must guard the semantic code offset"
+        )
+
+
+# ── Fix 3: logit bias uses -inf ──────────────────────────────────────
+
+
+class TestSemanticLogitBias(unittest.TestCase):
+    """The semantic logit bias must use ``-inf`` (not ``-1e9``) so that
+    masked tokens receive exactly zero probability after softmax."""
+
+    def test_bias_uses_neg_inf(self):
+        """Masked positions must be -inf."""
+        model = _make_model()
+        bias = model.semantic_logit_bias
+        mx.eval(bias)
+
+        val = float(bias[0, 0].item())
+        self.assertEqual(val, float("-inf"), "Masked positions must be -inf, not -1e9")
+
+    def test_bias_zero_for_semantic_range(self):
+        """Semantic token positions must have bias == 0."""
+        model = _make_model()
+        config = model.config
+        bias = model.semantic_logit_bias
+        mx.eval(bias)
+
+        semantic_slice = bias[
+            0,
+            config.semantic_start_token_id : config.semantic_end_token_id + 1,
+        ]
+        mx.eval(semantic_slice)
+        for i in range(semantic_slice.shape[0]):
+            val = float(semantic_slice[i].item())
+            self.assertEqual(
+                val,
+                0.0,
+                f"Semantic token at offset {i} "
+                f"(id={config.semantic_start_token_id + i}) bias should be 0.0",
+            )
+
+    def test_bias_zeroes_masked_probs_after_softmax(self):
+        """After softmax, masked positions should have exactly 0 probability
+        (only possible with -inf, not -1e9)."""
+        model = _make_model()
+        config = model.config
+        bias = model.semantic_logit_bias
+        # Fake uniform logits.
+        logits = mx.ones_like(bias)
+        biased = logits + bias
+        probs = mx.softmax(biased, axis=-1)
+        mx.eval(probs)
+
+        # Non-semantic token should have exactly 0 probability.
+        self.assertEqual(
+            float(probs[0, 0].item()),
+            0.0,
+            "Non-semantic tokens must have exactly 0 probability after softmax",
+        )
+        # Semantic token should have non-zero probability.
+        self.assertGreater(
+            float(probs[0, config.semantic_start_token_id].item()), 0.0
+        )
+
+    def test_bias_source_uses_neg_inf(self):
+        """Verify that the source code uses float('-inf'), not -1e9."""
+        import inspect
+
+        from mlx_audio.tts.models.fish_qwen3_omni.fish_speech import Model
+
+        source = inspect.getsource(Model.post_load_hook)
+        self.assertNotIn("-1e9", source, "Source must not use -1e9 for logit bias")
+        self.assertIn('"-inf"', source, "Source must use float('-inf') for logit bias")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #571

## Summary

Fixes five sampling differences between the mlx-audio Fish Speech (`fish_qwen3_omni`) implementation and the [official `fish-speech` PyTorch inference pipeline](https://github.com/fishaudio/fish-speech). These differences caused compressed dynamic range: quiet/whispered speech was louder than expected, and volume expressiveness differed from the reference.

### Root cause analysis

Weight conversion and codec were ruled out via bit-identical tensor comparisons (358/358 LLM tensors, 361/361 codec tensors) and cross-decode tests (PyTorch codes decoded through the MLX codec produce identical audio). The issue was isolated entirely to the token sampling code.

### Changes

1. **RAS single-pass fallback**: Replaced the 4-retry loop with the official sample-both-then-swap pattern. Both normal and high-temp tokens are sampled upfront; if the normal token repeats in the RAS window and is semantic, the high-temp token is used instead. This is the highest-impact fix, since the retry loop was pushing token selection further from the natural distribution.

2. **Clamp semantic code**: Added `mx.clip()` before the fast-pathway embedding lookup to prevent out-of-range indices, matching PyTorch's `torch.clamp(a, min=0, max=codebook_size - 1)`.

3. **Use `-inf` for logit bias**: Changed `-1e9` to `float("-inf")` so masked tokens receive exactly zero probability after softmax, matching PyTorch's `float("-inf")`.

4. **Remove `semantic_token_budget` heuristic**: Now uses `max_new_tokens` directly, matching PyTorch which has no additional generation cap. The heuristic (`text_token_count * 12`) was truncating generation for some prompts before the model naturally produced EOS.

5. **Remove `@mx.compile` from `_sample_logits`**: The decorator cached the random state from the first trace, which caused `mx.random.seed()` to have no effect on generation. Seeds now work correctly. No measurable speed impact (~24 tok/s either way).

### Verification

- Cross-decode tests confirm the MLX codec is bit-identical to PyTorch
- Multi-seed benchmarks show whisper is now consistently quieter than normal speech
- 11 new unit tests covering all sampling fixes (RAS behavior, clamp bounds, bias values)

## Test plan

- [x] `pytest mlx_audio/tts/tests/test_fish_speech_sampling.py` (11/11 passing)
- [x] Multi-seed generation benchmark confirms volume variation now matches expected prosody
- [x] Cross-decode: PyTorch codes through MLX codec produces identical audio
- [x] Speed benchmark: ~24 tok/s with and without changes (no regression)