### PR TITLE
docs(whisper): add distil-whisper to supported models list

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ for result in model.generate("Hello from MLX-Audio!", voice="af_heart"):
 | Model | Description | Languages | Repo |
 |-------|-------------|-----------|------|
 | **Whisper** | OpenAI's robust STT model | 99+ languages | [mlx-community/whisper-large-v3-turbo-asr-fp16](https://huggingface.co/mlx-community/whisper-large-v3-turbo-asr-fp16) |
+| **Distil-Whisper** | Distilled fast Whisper variants | EN | [distil-whisper/distil-large-v3](https://huggingface.co/distil-whisper/distil-large-v3) |
 | **Qwen3-ASR** | Alibaba's multilingual ASR | ZH, EN, JA, KO, + more | [mlx-community/Qwen3-ASR-1.7B-8bit](https://huggingface.co/mlx-community/Qwen3-ASR-1.7B-8bit) |
 | **Qwen3-ForcedAligner** | Word-level audio alignment | ZH, EN, JA, KO, + more | [mlx-community/Qwen3-ForcedAligner-0.6B-8bit](https://huggingface.co/mlx-community/Qwen3-ForcedAligner-0.6B-8bit) |
 | **Parakeet** | NVIDIA's accurate STT | EN (v2), 25 EU languages (v3) | [mlx-community/parakeet-tdt-0.6b-v3](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3) |

--- a/mlx_audio/stt/models/whisper/README.md
+++ b/mlx_audio/stt/models/whisper/README.md
@@ -1,0 +1,18 @@
+# Whisper
+
+MLX implementation of [Whisper](https://github.com/openai/whisper) by OpenAI. Also natively supports distilled variants like [Distil-Whisper](https://huggingface.co/distil-whisper/distil-large-v3).
+
+## Usage
+
+```python
+from mlx_audio.stt import load
+
+# Standard Whisper
+model = load("mlx-community/whisper-large-v3-turbo-asr-fp16")
+
+# Distil-Whisper
+# model = load("distil-whisper/distil-large-v3")
+
+result = model.generate("audio.wav")
+print(result.text)
+```


### PR DESCRIPTION
## Description
updates the README files to officially document that `distil-whisper` variants work natively out of the box using the existing whisper implementation.

closes #554

since `distil-whisper` shares the exact same architecture/config class as standard whisper, `mlx_audio.stt.load(distil-whisper/distil-large-v3)` already functions perfectly without any code changes. this PR simply adds it to the STT tables so users know it's a supported option.

## Changes in the codebase
- updated main `README.md` STT table to include `Distil-Whisper`
- added `mlx_audio/stt/models/whisper/README.md` to explicitly show usage examples for both standard and distilled variants

## Checklist
- [x] Documentation updated
- [x] Issue referenced - closes #554