### PR TITLE
fix(fish_speech): prevent fast_ path and embeddings from quantizing to fix convert script

### DIFF
--- a/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
+++ b/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
@@ -407,6 +407,14 @@ class Model(nn.Module):
     def model_type(self) -> str:
         return "fish_speech"
 
+    @classmethod
+    def model_quant_predicate(cls, path: str, module) -> bool:
+        import mlx.nn as nn
+        return (
+            not isinstance(module, nn.Embedding)
+            and "fast_" not in path
+        )
+
     def load_weights(self, weights, strict: bool = True):
         remapped = []
         for key, value in weights:
@@ -418,6 +426,9 @@ class Model(nn.Module):
     def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
         remapped = {}
         for key, value in weights.items():
+            if key.startswith("model."):
+                remapped[key] = value
+                continue
             if key.startswith("text_model.model."):
                 new_key = key[len("text_model.model.") :]
             elif key.startswith("audio_decoder."):


### PR DESCRIPTION
## Description
fixes a bug where attempting to quantize the `fish-audio-s2-pro` model using the `mlx_audio.convert` script would fail.

closes #578 

as reported by a user, during quantization, the script would incorrectly attempt to quantize the `fast_` parallel generation paths and standard `Embedding` layers within the fish architecture, causing size/shape mismatches and crashing the conversion.

## Changes in the codebase
- added a `model_quant_predicate` class method to `fish_speech.py` that correctly filters out `nn.Embedding` instances and paths containing `fast_` from the quantization loop
- updated `sanitize()` to properly preserve keys starting with `model.` so they don't get accidentally dropped or mis-mapped during standard loaded weights evaluation

## Checklist
- [x] Issue referenced - closes #578