### PR TITLE
fix(fish_qwen3_omni): support loading quantized/converted models in sanitize()

### DIFF
--- a/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
+++ b/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
@@ -418,17 +418,19 @@ class Model(nn.Module):
     def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
         remapped = {}
         for key, value in weights.items():
-            if key.startswith("text_model.model."):
+            if key.startswith("model."):
+                # Already in MLX format (e.g., previously converted/quantized model)
+                remapped[key] = value
+            elif key.startswith("text_model.model."):
                 new_key = key[len("text_model.model.") :]
+                remapped[f"model.{new_key}"] = value
             elif key.startswith("audio_decoder."):
                 suffix = key[len("audio_decoder.") :]
                 if suffix.startswith("codebook_embeddings."):
                     new_key = suffix
                 else:
                     new_key = f"fast_{suffix}"
-            else:
-                continue
-            remapped[f"model.{new_key}"] = value
+                remapped[f"model.{new_key}"] = value
         return remapped
 
     def _build_conversation(


### PR DESCRIPTION
## Problem

`sanitize()` in `fish_qwen3_omni/fish_speech.py` skips any weight key that does not start with `text_model.model.` or `audio_decoder.`, via `else: continue`. This means that when loading a model that was already converted to MLX format (e.g., produced by `python -m mlx_audio.convert --quantize`), all weight keys (which start with `model.`) are silently dropped, resulting in an empty dict.

The downstream effect:
- `apply_quantization()` finds no `.scales` keys → skips quantization entirely
- `load_weights()` is called with an empty dict → raises `ValueError: Missing N parameters`

This is the root cause of the bug reported in #578 ("Fish s2 pro Breaks when quantizing using convert").

## Fix

Add a `model.*` passthrough case before the existing conditions so that keys already in MLX format are preserved as-is:

```python
if key.startswith("model."):
    # Already in MLX format (e.g., previously converted/quantized model)
    remapped[key] = value
elif key.startswith("text_model.model."):
    ...
```

## How to reproduce

```bash
python -m mlx_audio.convert \
  --hf-path mlx-community/fish-audio-s2-pro-bf16 \
  --mlx-path ./fish-audio-s2-pro-4bit \
  -q --q-bits 4 --q-group-size 64 --model-domain tts

python -c "
from mlx_audio.tts.utils import load_model
model = load_model('./fish-audio-s2-pro-4bit')  # raises ValueError before fix
"
```

## Testing

After the fix, quantized models load and run correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)