### PR TITLE
Fix Qwen3-TTS streaming memory leak.

### DIFF
--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -2072,6 +2072,7 @@ class Model(nn.Module):
                     is_final_chunk=True,
                 )
             self.speech_tokenizer.decoder.reset_streaming_state()
+            mx.clear_cache()
             return
 
         if not generated_codes:
@@ -2386,6 +2387,7 @@ class Model(nn.Module):
                     is_final_chunk=True,
                 )
             self.speech_tokenizer.decoder.reset_streaming_state()
+            mx.clear_cache()
             return
 
         if not generated_codes:


### PR DESCRIPTION
When running the mlx-server and sending stream-able "/v1/audio/speech" requests with the Qwen3-TTS model, memory usage would continue to grow by 3-4GB per request until being culled after about 10GB. Then the cycle would repeat.

The Qwen3-TTS streaming model does a good job keeping memory usage down during the stream, but it fails to do one final `mx.clear_cache()` after yielding the last streaming chunk.

This PR fixes the leak.