### PR TITLE
fix: serialize MLX inference to prevent concurrent Metal command buffer crash

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -196,6 +196,14 @@ class SeparationResponse(BaseModel):
 # Initialize the ModelProvider
 model_provider = ModelProvider()
 
+# MLX's Metal backend is not thread-safe. Concurrent inference calls from
+# multiple coroutines share the same Metal command buffer, triggering:
+#   "A command encoder is already encoding to this command buffer"
+# This is a known upstream issue: https://github.com/ml-explore/mlx/issues/2133
+# Serialise all inference through this lock so only one request uses the GPU
+# at a time.
+_inference_lock = asyncio.Lock()
+
 
 @app.get("/")
 async def root():
@@ -261,6 +269,12 @@ async def remove_model(model_name: str):
 
 
 async def generate_audio(model, payload: SpeechRequest):
+    async with _inference_lock:
+        async for chunk in _generate_audio_inner(model, payload):
+            yield chunk
+
+
+async def _generate_audio_inner(model, payload: SpeechRequest):
     # Load reference audio if provided
     ref_audio = payload.ref_audio
     audio_chunks = []
@@ -414,8 +428,13 @@ async def stt_transcriptions(
     signature = inspect.signature(stt_model.generate)
     gen_kwargs = {k: v for k, v in gen_kwargs.items() if k in signature.parameters}
 
+    async def locked_transcription_stream():
+        async with _inference_lock:
+            for chunk in generate_transcription_stream(stt_model, tmp_path, gen_kwargs):
+                yield chunk
+
     return StreamingResponse(
-        generate_transcription_stream(stt_model, tmp_path, gen_kwargs),
+        locked_transcription_stream(),
         media_type="application/x-ndjson",
     )
 

--- a/mlx_audio/tests/test_server.py
+++ b/mlx_audio/tests/test_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import functools
 import io
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,7 +14,7 @@ pytest.importorskip("multipart", reason="python-multipart is required for server
 
 from fastapi.testclient import TestClient
 
-from mlx_audio.server import app
+from mlx_audio.server import _inference_lock, app
 
 
 @pytest.fixture
@@ -355,3 +356,67 @@ def test_realtime_ws_streaming_disabled_fallback(client, mock_model_provider):
     # Should have at least one legacy text message
     text_msgs = [m for m in messages if "text" in m and "type" not in m]
     assert len(text_msgs) >= 1, f"Expected legacy text message, got: {messages}"
+
+
+# ---------------------------------------------------------------------------
+# Inference lock tests
+# ---------------------------------------------------------------------------
+
+
+def test_inference_lock_exists():
+    # _inference_lock must be an asyncio.Lock so concurrent GPU access is serialised
+    assert isinstance(_inference_lock, asyncio.Lock)
+
+
+def test_tts_acquires_inference_lock(client, mock_model_provider):
+    # generate_audio must acquire _inference_lock so concurrent requests cannot
+    # interleave MLX/Metal GPU calls (Metal assertion: "A command encoder is
+    # already encoding to this command buffer")
+    mock_tts_model = MagicMock()
+    mock_tts_model.generate = MagicMock(wraps=sync_mock_audio_stream_generator)
+    mock_model_provider.load_model = MagicMock(return_value=mock_tts_model)
+
+    mock_lock = MagicMock()
+    mock_lock.__aenter__ = AsyncMock(return_value=None)
+    mock_lock.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mlx_audio.server._inference_lock", mock_lock):
+        response = client.post(
+            "/v1/audio/speech",
+            json={"model": "test_tts_model", "input": "Hello world"},
+        )
+
+    assert response.status_code == 200
+    mock_lock.__aenter__.assert_called_once()
+    mock_lock.__aexit__.assert_called_once()
+
+
+def test_stt_acquires_inference_lock(client, mock_model_provider):
+    # stt_transcriptions must acquire _inference_lock for the same reason.
+    mock_stt_model = MagicMock()
+    mock_stt_model.generate = MagicMock(
+        return_value={"text": "This is a test transcription."}
+    )
+    mock_model_provider.load_model = MagicMock(return_value=mock_stt_model)
+
+    sample_rate = 16000
+    t = np.linspace(0, 1, sample_rate, endpoint=False)
+    audio_data = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+    buf = io.BytesIO()
+    audio_write(buf, audio_data, sample_rate, format="mp3")
+    buf.seek(0)
+
+    mock_lock = MagicMock()
+    mock_lock.__aenter__ = AsyncMock(return_value=None)
+    mock_lock.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mlx_audio.server._inference_lock", mock_lock):
+        response = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", buf, "audio/mp3")},
+            data={"model": "test_stt_model"},
+        )
+
+    assert response.status_code == 200
+    mock_lock.__aenter__.assert_called_once()
+    mock_lock.__aexit__.assert_called_once()


### PR DESCRIPTION
## Context

When the server receives concurrent requests (e.g. multiple clients calling `/v1/audio/speech` or `/v1/audio/transcriptions` at the same time), multiple coroutines end up calling `model.generate()` simultaneously. MLX's Metal backend is not thread-safe — this is a known upstream issue ([ml-explore/mlx#2133](https://github.com/ml-explore/mlx/issues/2133)) — so concurrent GPU access triggers an assertion failure that crashes the server process:

```
-[AGXG16GFamilyCommandBuffer tryCoalescingPreviousComputeCommandEncoderWithConfig:nextEncoderClass:]:1094:
failed assertion `A command encoder is already encoding to this command buffer'
[1] abort      mlx_audio.server --host 0.0.0.0 --port 8000
```

## Description

Introduce a module-level `asyncio.Lock` (`_inference_lock`) and acquire it for the entire duration of each TTS and STT inference call. This ensures only one coroutine accesses the Metal GPU at a time.

Since MLX uses a single-stream execution model on Metal, serialising inference at the asyncio level does not reduce throughput — concurrent requests would compete for the GPU anyway. Requests are queued and processed one at a time instead of crashing.

## Changes in the codebase

**`mlx_audio/server.py`**
- Add `_inference_lock = asyncio.Lock()` after `model_provider` initialisation
- Wrap `generate_audio` to acquire the lock for the full generation, delegating actual work to `_generate_audio_inner`
- Wrap `generate_transcription_stream` in `stt_transcriptions` with the lock via a `locked_transcription_stream` inner async generator

**`mlx_audio/tests/test_server.py`**
- `test_inference_lock_exists` — asserts `_inference_lock` is an `asyncio.Lock`
- `test_tts_acquires_inference_lock` — verifies the TTS endpoint acquires and releases the lock
- `test_stt_acquires_inference_lock` — verifies the STT endpoint acquires and releases the lock

## Changes outside the codebase

None.

## Additional information

The exact same Metal assertion (`A command encoder is already encoding to this command buffer`) is reproduced in [ml-explore/mlx#3078](https://github.com/ml-explore/mlx/issues/3078) by a user running two independent models from concurrent threads, confirming this is an MLX-level constraint rather than a bug in mlx-audio's model code.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Issue referenced (e.g., "Closes #...")