### PR TITLE
fix: convert numpy audio to mx.array in realtime STT streaming path

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -522,7 +522,7 @@ async def _stream_transcription(
     """Handle both streaming and non-streaming model inference over WebSocket.
 
     Streaming models (whose generate() accepts a ``stream`` parameter) receive
-    the numpy array directly and yield token deltas sent as
+    the audio as an ``mx.array`` and yield token deltas sent as
     ``{"type": "delta", "delta": "..."}`` messages, followed by a
     ``{"type": "complete", ...}`` message.
 
@@ -533,7 +533,7 @@ async def _stream_transcription(
 
     if supports_stream and streaming:
         result_iter = stt_model.generate(
-            audio_array, stream=True, language=language, verbose=False
+            mx.array(audio_array), stream=True, language=language, verbose=False
         )
         accumulated = ""
         detected_language = language

--- a/mlx_audio/tests/test_server.py
+++ b/mlx_audio/tests/test_server.py
@@ -2,6 +2,7 @@ import functools
 import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import mlx.core as mx
 import numpy as np
 import pytest
 
@@ -319,20 +320,36 @@ def test_realtime_ws_streaming_structured_chunks(client, mock_model_provider):
     assert "Hello" in combined
 
 
-def test_realtime_ws_numpy_direct_pass(client, mock_model_provider):
-    """Streaming models receive numpy arrays directly, not file paths."""
+def test_realtime_ws_mx_array_pass(client, mock_model_provider):
+    """Streaming models receive mx.array, not file paths."""
     gen_fn = _make_streaming_generate(["test"])
     _, mock_stt_model = _ws_send_audio_and_collect(client, mock_model_provider, gen_fn)
 
-    # Check that generate was called with a numpy array (not a string path)
+    # Check that generate was called with an mx.array (not a string path)
     tracked = mock_stt_model.generate
     assert len(tracked.call_args_list) > 0, "generate was never called"
     first_arg = tracked.call_args_list[0][0][
         0
     ]  # first call, positional args, first arg
     assert isinstance(
-        first_arg, np.ndarray
-    ), f"Expected numpy array, got {type(first_arg)}"
+        first_arg, mx.array
+    ), f"Expected mx.array, got {type(first_arg)}"
+
+
+def test_realtime_ws_mx_array_supports_bfloat16_cast(client, mock_model_provider):
+    """Regression: models like Parakeet that cast to bfloat16 must receive mx.array."""
+
+    def gen_fn(audio, *, stream=False, language=None, verbose=False, **kwargs):
+        if stream:
+            # Parakeet's stream_generate does this internally
+            _ = audio.astype(mx.bfloat16)
+            return iter(["ok"])
+        return MagicMock(text="ok", segments=None, language=None)
+
+    messages, _ = _ws_send_audio_and_collect(client, mock_model_provider, gen_fn)
+    completes = [m for m in messages if m.get("type") == "complete"]
+    assert len(completes) >= 1
+    assert completes[0]["text"] == "ok"
 
 
 def test_realtime_ws_streaming_disabled_fallback(client, mock_model_provider):


### PR DESCRIPTION
## Context

The realtime STT WebSocket endpoint (`/v1/audio/transcriptions/realtime`) crashes when used with models that expect `mx.array` input in their streaming path — notably Parakeet, which calls `audio.astype(mx.bfloat16)` internally.

The bug was introduced in #494 (streaming support for realtime STT). The `_stream_transcription()` function accumulates audio as a numpy `float32` array and passes it directly to `stt_model.generate(audio_array, stream=True)`. Models like Parakeet that operate on MLX dtypes in their `stream_generate()` fail with:

```
TypeError: Cannot interpret 'mlx.core.bfloat16' as a data type
```

The non-streaming POST endpoint (`/v1/audio/transcriptions`) is unaffected — it writes to a temp file.

## Description

Wrap the numpy audio buffer in `mx.array()` before passing it to `stt_model.generate()` in the streaming branch of `_stream_transcription()`.

This is safe for all streaming-capable STT models (verified against each model's streaming code path):
- **Parakeet**: `stream_generate()` calls `audio.astype(dtype)` with `dtype=mx.bfloat16` — requires `mx.array`. This is the model that crashes without this fix.
- **Whisper**: `generate_streaming()` already normalizes input via `isinstance` check and converts to `mx.array` if needed.
- **Granite Speech**: `_load_audio()` handles both `np.ndarray` and `mx.array` explicitly.
- **Voxtral Realtime**: `_load_audio()` converts input to `np.ndarray` via `np.array()` — `np.array(mx_array)` works.
- **GLM-ASR**: `stream_transcribe()` converts `mx.array` to `np.array` before processing.
- **Qwen3-ASR**: `stream_transcribe()` converts `mx.array` to `np.array` before processing.

## Changes in the codebase

- **`mlx_audio/server.py`**: `_stream_transcription()` now calls `stt_model.generate(mx.array(audio_array), ...)` instead of `stt_model.generate(audio_array, ...)`. Updated the docstring to reflect that streaming models receive `mx.array`, not numpy.
- **`mlx_audio/tests/test_server.py`**: Renamed `test_realtime_ws_numpy_direct_pass` → `test_realtime_ws_mx_array_pass` and updated assertion from `np.ndarray` to `mx.array`. Added regression test `test_realtime_ws_mx_array_supports_bfloat16_cast` with a mock model that performs `audio.astype(mx.bfloat16)`, proving the old code crashes and the fix works.

## Changes outside the codebase

None.

## Additional information

- Only the streaming branch is affected. The non-streaming fallback path writes to a temp file and is unchanged.
- Not all models crash — it depends on whether the model's `stream_generate` assumes MLX arrays. But the server should normalize the type regardless.
- Related issues: #494 (streaming support for realtime STT — introduced the bug), #482 (streaming issues with other models), #544 (realtime WebSocket crashes with Qwen3-ASR).

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (inline docstring only — no user-facing docs changed)
- [ ] Issue referenced (e.g., "Closes #...")