### PR TITLE
fix: handle float voice parameter in KokoroPipeline (fixes #224)

### DIFF
--- a/mlx_audio/tts/models/kokoro/pipeline.py
+++ b/mlx_audio/tts/models/kokoro/pipeline.py
@@ -181,6 +181,7 @@ class KokoroPipeline:
     """
 
     def load_voice(self, voice: str, delimiter: str = ",") -> mx.array:
+        voice = str(voice)  # Ensure string type (handles float from API)
         if voice in self.voices:
             return self.voices[voice]
         logging.debug(f"Loading voice: {voice}")


### PR DESCRIPTION
## Problem
When the speech-to-speech GUI sends a voice parameter as a float value, the server crashes with:
```
AttributeError: 'float' object has no attribute 'split'
```

This happens in `load_voice()` when calling `voice.split(delimiter)` on a float-typed voice parameter.

## Root Cause
The Pydantic model declares `voice: str | None = None` but the GUI can send numeric values. Pydantic doesn't always coerce floats to strings before passing to the model methods.

## Fix
Added `voice = str(voice)` at the start of `load_voice()` to ensure type safety regardless of the input type. This is a single-line defensive fix that:
- Handles float inputs gracefully
- Preserves existing string behavior (str(str) is a no-op)
- Matches the method's type contract

## Testing
The fix is minimal and type-safe. `str()` on a float produces the expected string representation (e.g., `str(1.0)` → `"1.0"`), and `str()` on a string is a no-op.