### PR TITLE
fix(vibevoice): preserve quantization metadata in sanitize() for quantized model loading

### DIFF
--- a/mlx_audio/tts/models/vibevoice/vibevoice.py
+++ b/mlx_audio/tts/models/vibevoice/vibevoice.py
@@ -250,8 +250,9 @@ class Model(nn.Module):
 
             # Check if key exists in model
             if new_key not in curr_shapes:
-                # Debug: uncomment to see missing keys
-                # print(f"Warning: Key {new_key} (from {k}) not found in model")
+                # Preserve quantization metadata -- model isn't quantized yet at sanitize time
+                if new_key.endswith((".scales", ".biases")):
+                    new_weights[new_key] = v
                 continue
 
             target_shape = curr_shapes[new_key]

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -1318,6 +1318,31 @@ class TestVibeVoiceModel(unittest.TestCase):
         self.assertNotIn("model.prediction_head.t_embedder.mlp.0.weight", sanitized)
         self.assertNotIn("model.prediction_head.adaLN_modulation.1.weight", sanitized)
 
+    def test_sanitize_preserves_quantization_metadata(self):
+        """Test that sanitize preserves .scales and .biases for quantized models."""
+        from mlx.utils import tree_flatten
+
+        from mlx_audio.tts.models.vibevoice.vibevoice import Model
+
+        config = self._default_config
+        model = Model(config)
+
+        # Start with the model's own weights
+        weights = dict(tree_flatten(model.parameters()))
+
+        # Add mock quantization metadata for the key from the bug report:
+        # "Expected shape (151936, 896) but received shape (151936, 224)
+        #  for parameter language_model.embed_tokens.weight"
+        quant_key = "language_model.embed_tokens.weight"
+        weights[f"{quant_key}.scales"] = mx.ones((1,))
+        weights[f"{quant_key}.biases"] = mx.ones((1,))
+
+        sanitized = model.sanitize(weights)
+
+        # Quantization metadata must survive sanitization
+        self.assertIn(f"{quant_key}.scales", sanitized)
+        self.assertIn(f"{quant_key}.biases", sanitized)
+
     def test_config_defaults(self):
         """Test VibeVoiceModel uses correct config defaults."""
         from mlx_audio.tts.models.vibevoice.config import ModelConfig


### PR DESCRIPTION
## Context

Loading quantized VibeVoice TTS models (8/6/5/4-bit from mlx-community) fails with:

```
ValueError: Expected shape (151936, 896) but received shape (151936, 224)
for parameter language_model.embed_tokens.weight
```

The fp16 variant loads fine. This is the same class of bug fixed for fish_qwen3_omni in #584.

## Description

`sanitize()` filters out weight keys not found in the model's current parameter shapes. At sanitize time the model hasn't been quantized yet, so quantization metadata keys (`.scales`, `.biases`) don't exist in the model and are silently dropped.

Later, `apply_quantization()` checks `f"{p}.scales" in weights` to decide which layers to quantize. Since sanitize removed the scales, it skips quantization entirely. The model stays full-size but the weight file has quantized shapes, causing the mismatch.

The fix preserves `.scales` and `.biases` keys through sanitization, matching the existing pattern in `chatterbox/s3gen`.

## Changes in the codebase

- **`mlx_audio/tts/models/vibevoice/vibevoice.py`**: In `sanitize()`, preserve quantization metadata keys (`.scales`, `.biases`) that aren't in `curr_shapes`, instead of dropping them. This allows `apply_quantization()` to find the metadata and properly quantize the model before weight loading.
- **`mlx_audio/tts/tests/test_models.py`**: Add `test_sanitize_preserves_quantization_metadata` to verify `.scales` and `.biases` keys survive sanitization.

## Changes outside the codebase

None.

## Additional information

- Same root cause as #584 (fish_qwen3_omni sanitize fix), different fix approach because vibevoice uses shape-based filtering while fish_speech uses prefix-based filtering.
- The `.endswith((".scales", ".biases"))` pattern matches the existing approach in `chatterbox/s3gen/s3gen.py`.
- Tested with `mlx-community/VibeVoice-Realtime-0.5B-8bit`.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Issue referenced (e.g., "Closes #...")