### PR TITLE
fix(tts): allow streamed generation to save audio to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,18 @@ mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text 'Hello!' --p
 
 # Save to a specific directory
 mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text 'Hello!' --output_path ./my_audio  --lang_code a
+
+# Stream audio during generation
+mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text 'Hello!' --stream --lang_code a
+
+# Stream audio during generation and save it to disk
+mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text 'Hello!' --stream --save --lang_code a
+
+# Join multiple generated segments into one file
+mlx_audio.tts.generate --model mlx-community/Kokoro-82M-bf16 --text $'Hello!\nHow are you?' --join_audio --lang_code a
 ```
+
+By default, when generation yields multiple segments, mlx-audio saves numbered files such as `audio_000.wav` and `audio_001.wav`. Use `--join_audio` to save one combined file instead. When using `--stream`, add `--save` to write the streamed audio to disk.
 
 ### Python API
 

--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -102,6 +102,23 @@ def hertz_to_mel(pitch: float) -> float:
     return mel
 
 
+def write_joined_audio(
+    file_name: str,
+    audio_chunks: list,
+    sample_rate: int,
+    audio_format: str,
+) -> None:
+    if not audio_chunks:
+        return
+
+    audio = (
+        mx.concatenate(audio_chunks, axis=0)
+        if len(audio_chunks) > 1
+        else audio_chunks[0]
+    )
+    audio_write(file_name, audio, sample_rate, format=audio_format)
+
+
 def generate_audio(
     text: str,
     model: Optional[Union[str, nn.Module]] = None,
@@ -128,6 +145,7 @@ def generate_audio(
     temperature: float = 0.7,
     stream: bool = False,
     streaming_interval: float = 2.0,
+    save: bool = False,
     use_zero_spk_emb: bool = False,
     **kwargs,
 ) -> None:
@@ -151,10 +169,11 @@ def generate_audio(
     - join_audio (bool): Whether to join multiple audio files into one.
     - play (bool): Whether to play the generated audio.
     - verbose (bool): Whether to print status messages.
+    - save (bool): Whether to save streamed audio to a file when using stream mode.
     - model (object): A already loaded model.
     - stt_model (object): A already loaded stt model.
     Returns:
-    - None: The function writes the generated audio to a file.
+    - None: The function writes the generated audio to a file when not streaming, or when streaming with saving enabled.
     """
     try:
         play = play or stream
@@ -241,13 +260,26 @@ def generate_audio(
 
         results = model.generate(**gen_kwargs)
 
+        save_streamed_audio = stream and save
         audio_list = []
+        streamed_audio_chunks = []
+        streamed_segment_audio = {}
+        streamed_segment_sample_rates = {}
         file_name = f"{file_prefix}.{audio_format}"
         for i, result in enumerate(results):
             if play:
                 player.queue_audio(result.audio)
 
-            if join_audio:
+            if save_streamed_audio:
+                if join_audio:
+                    streamed_audio_chunks.append(result.audio)
+                else:
+                    segment_idx = result.segment_idx
+                    if segment_idx not in streamed_segment_audio:
+                        streamed_segment_audio[segment_idx] = []
+                        streamed_segment_sample_rates[segment_idx] = result.sample_rate
+                    streamed_segment_audio[segment_idx].append(result.audio)
+            elif join_audio and not stream:
                 audio_list.append(result.audio)
             elif not stream:
                 file_name = f"{file_prefix}_{i:03d}.{audio_format}"
@@ -276,14 +308,42 @@ def generate_audio(
                 print(f"Processing time:       {result.processing_time_seconds:.2f}s")
                 print(f"Peak memory usage:     {result.peak_memory_usage:.2f}GB")
 
-        if join_audio and not stream:
+        if save_streamed_audio and join_audio and streamed_audio_chunks:
+            if verbose:
+                print(f"Joining {len(streamed_audio_chunks)} streamed audio chunks")
+            write_joined_audio(
+                file_name,
+                streamed_audio_chunks,
+                model.sample_rate,
+                audio_format,
+            )
+            print(f"✅ Audio successfully generated and saving as: {file_name}")
+        elif save_streamed_audio and streamed_segment_audio:
+            for segment_idx in sorted(streamed_segment_audio):
+                file_name = f"{file_prefix}_{segment_idx:03d}.{audio_format}"
+                audio_chunks = streamed_segment_audio[segment_idx]
+                sample_rate = streamed_segment_sample_rates[segment_idx]
+                if verbose:
+                    print(
+                        "Joining "
+                        f"{len(audio_chunks)} streamed audio chunks for segment "
+                        f"{segment_idx}"
+                    )
+                write_joined_audio(
+                    file_name,
+                    audio_chunks,
+                    sample_rate,
+                    audio_format,
+                )
+                print(f"✅ Audio successfully generated and saving as: {file_name}")
+        elif join_audio and not stream and audio_list:
             if verbose:
                 print(f"Joining {len(audio_list)} audio files")
-            audio = mx.concatenate(audio_list, axis=0)
-            audio_write(
-                f"{file_prefix}.{audio_format}",
-                audio,
+            write_joined_audio(
+                file_name,
+                audio_list,
                 model.sample_rate,
+                audio_format,
             )
             if verbose:
                 print(f"✅ Audio successfully generated and saving as: {file_name}")
@@ -419,7 +479,7 @@ def parse_args():
     parser.add_argument(
         "--stream",
         action="store_true",
-        help="Stream the audio as segments instead of saving to a file",
+        help="Stream the audio as segments during generation",
     )
     parser.add_argument(
         "--streaming_interval",
@@ -427,8 +487,16 @@ def parse_args():
         default=2.0,
         help="The time interval in seconds for streaming segments",
     )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="Save streamed audio to a file. Requires --stream.",
+    )
 
     args = parser.parse_args()
+
+    if args.save and not args.stream:
+        parser.error("--save requires --stream")
 
     if args.text is None:
         if not sys.stdin.isatty():

--- a/mlx_audio/tts/tests/test_generate.py
+++ b/mlx_audio/tts/tests/test_generate.py
@@ -1,0 +1,205 @@
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_audio.tts.generate import generate_audio, parse_args
+
+
+class TestGenerateArgs(unittest.TestCase):
+    def test_save_requires_stream(self):
+        test_args = [
+            "--model",
+            "dummy-model",
+            "--text",
+            "hello",
+            "--save",
+        ]
+
+        with patch.object(sys, "argv", ["generate.py"] + test_args):
+            with self.assertRaises(SystemExit) as exc:
+                parse_args()
+
+        self.assertEqual(exc.exception.code, 2)
+
+    def test_save_with_stream_is_allowed(self):
+        test_args = [
+            "--model",
+            "dummy-model",
+            "--text",
+            "hello",
+            "--stream",
+            "--save",
+        ]
+
+        with patch.object(sys, "argv", ["generate.py"] + test_args):
+            args = parse_args()
+
+        self.assertTrue(args.stream)
+        self.assertTrue(args.save)
+
+
+class TestGenerateAudio(unittest.TestCase):
+    @staticmethod
+    def _result(audio, sample_rate=24000, segment_idx=0):
+        return SimpleNamespace(
+            audio=mx.array(audio),
+            sample_rate=sample_rate,
+            segment_idx=segment_idx,
+            audio_duration="00:00:00.100",
+            audio_samples={"samples": len(audio), "samples-per-sec": 1000.0},
+            token_count=1,
+            prompt={"tokens-per-sec": 10.0},
+            real_time_factor=1.0,
+            processing_time_seconds=0.1,
+            peak_memory_usage=0.1,
+        )
+
+    @patch("builtins.print")
+    @patch("mlx_audio.tts.generate.audio_write")
+    @patch("mlx_audio.tts.generate.AudioPlayer")
+    def test_stream_save_writes_joined_audio(
+        self, mock_audio_player, mock_audio_write, _mock_print
+    ):
+        player = MagicMock()
+        mock_audio_player.return_value = player
+
+        model = MagicMock()
+        model.sample_rate = 24000
+        model.generate.return_value = [
+            self._result([0.1, 0.2]),
+            self._result([0.3, 0.4]),
+        ]
+
+        generate_audio(
+            text="hello",
+            model=model,
+            stream=True,
+            save=True,
+            verbose=False,
+        )
+
+        mock_audio_player.assert_called_once_with(sample_rate=24000)
+        self.assertEqual(player.queue_audio.call_count, 2)
+        player.wait_for_drain.assert_called_once()
+        player.stop.assert_called_once()
+
+        mock_audio_write.assert_called_once()
+        args, kwargs = mock_audio_write.call_args
+        self.assertEqual(args[0], "audio_000.wav")
+        np.testing.assert_allclose(np.array(args[1]), np.array([0.1, 0.2, 0.3, 0.4]))
+        self.assertEqual(args[2], 24000)
+        self.assertEqual(kwargs["format"], "wav")
+
+        self.assertTrue(model.generate.call_args.kwargs["stream"])
+
+    @patch("builtins.print")
+    @patch("mlx_audio.tts.generate.audio_write")
+    @patch("mlx_audio.tts.generate.AudioPlayer")
+    def test_stream_save_groups_chunks_by_segment(
+        self, mock_audio_player, mock_audio_write, _mock_print
+    ):
+        player = MagicMock()
+        mock_audio_player.return_value = player
+
+        model = MagicMock()
+        model.sample_rate = 24000
+        model.generate.return_value = [
+            self._result([0.1, 0.2]),
+            self._result([0.3, 0.4]),
+            self._result([0.5, 0.6], segment_idx=1),
+        ]
+
+        generate_audio(
+            text="hello",
+            model=model,
+            stream=True,
+            save=True,
+            verbose=False,
+        )
+
+        self.assertEqual(mock_audio_write.call_count, 2)
+
+        first_args, first_kwargs = mock_audio_write.call_args_list[0]
+        self.assertEqual(first_args[0], "audio_000.wav")
+        np.testing.assert_allclose(
+            np.array(first_args[1]), np.array([0.1, 0.2, 0.3, 0.4])
+        )
+        self.assertEqual(first_args[2], 24000)
+        self.assertEqual(first_kwargs["format"], "wav")
+
+        second_args, second_kwargs = mock_audio_write.call_args_list[1]
+        self.assertEqual(second_args[0], "audio_001.wav")
+        np.testing.assert_allclose(np.array(second_args[1]), np.array([0.5, 0.6]))
+        self.assertEqual(second_args[2], 24000)
+        self.assertEqual(second_kwargs["format"], "wav")
+
+    @patch("builtins.print")
+    @patch("mlx_audio.tts.generate.os.makedirs")
+    @patch("mlx_audio.tts.generate.audio_write")
+    @patch("mlx_audio.tts.generate.AudioPlayer")
+    def test_stream_save_join_audio_uses_output_path_and_prefix(
+        self,
+        mock_audio_player,
+        mock_audio_write,
+        mock_makedirs,
+        _mock_print,
+    ):
+        player = MagicMock()
+        mock_audio_player.return_value = player
+
+        model = MagicMock()
+        model.sample_rate = 24000
+        model.generate.return_value = [
+            self._result([0.1, 0.2]),
+            self._result([0.3, 0.4]),
+        ]
+
+        generate_audio(
+            text="hello",
+            model=model,
+            output_path="./out",
+            file_prefix="watch",
+            stream=True,
+            save=True,
+            join_audio=True,
+            verbose=False,
+        )
+
+        mock_makedirs.assert_called_once_with("./out", exist_ok=True)
+        mock_audio_write.assert_called_once()
+        args, kwargs = mock_audio_write.call_args
+        self.assertEqual(args[0], "./out/watch.wav")
+        np.testing.assert_allclose(np.array(args[1]), np.array([0.1, 0.2, 0.3, 0.4]))
+        self.assertEqual(args[2], 24000)
+        self.assertEqual(kwargs["format"], "wav")
+
+    @patch("builtins.print")
+    @patch("mlx_audio.tts.generate.audio_write")
+    @patch("mlx_audio.tts.generate.AudioPlayer")
+    def test_stream_without_save_does_not_write(
+        self, mock_audio_player, mock_audio_write, _mock_print
+    ):
+        player = MagicMock()
+        mock_audio_player.return_value = player
+
+        model = MagicMock()
+        model.sample_rate = 24000
+        model.generate.return_value = [self._result([0.1, 0.2])]
+
+        generate_audio(
+            text="hello",
+            model=model,
+            stream=True,
+            save=False,
+            verbose=False,
+        )
+
+        mock_audio_write.assert_not_called()
+        mock_audio_player.assert_called_once_with(sample_rate=24000)
+        player.queue_audio.assert_called_once()
+        player.wait_for_drain.assert_called_once()
+        player.stop.assert_called_once()


### PR DESCRIPTION
mvdirty note: This work was specified by me, and I am a human. The changes were implemented, documentation was updated, and this PR description was (except for this note) prepared by my clanker, mvagent. I have pretty deep development experience, but not in python, and this is me dipping my toes in just enough to solve a need. The changes seem pretty clean, and we have performed a good range of both manual and automated testing of them, but let me know if anything needs updating to be more idiomatic of either python or the mlx-audio repo style.

----

## Context

`mlx_audio.tts.generate` supports normal file output and also supports low-latency streaming playback with `--stream`, but the streaming path skipped file writes entirely. That made it hard to use mlx-audio in workflows that need both immediate listening and a saved file for later playback or downstream processing.

This change adds an explicit `--save` flag for streaming mode so users can opt into both behaviors at once without changing the existing default behavior of `--stream`.

## Description

The TTS CLI save/stream behavior is controlled in `mlx_audio/tts/generate.py`.

Previously:
- non-streaming generation wrote files to disk
- `--stream` queued audio to the live player
- the streaming path bypassed the normal output-writing logic

This change introduces `--save` for use with `--stream` and preserves the usual mlx-audio file naming and output handling:
- `--stream` still streams audio during generation and does not write files by default
- `--stream --save` writes streamed output to disk after generation completes
- `--stream --save` preserves the usual numbered segment naming such as `audio_000.wav`
- `--stream --save --join_audio` writes one combined file such as `audio.wav`
- `output_path` and `file_prefix` are preserved in the streamed save path
- `--save` without `--stream` is rejected with a parser error

## Changes in the codebase

- **`mlx_audio/tts/generate.py`**
  - add a `--save` CLI flag
  - reject `--save` unless `--stream` is also present
  - buffer streamed audio for later writing while keeping live playback unchanged
  - preserve existing numbered output naming for segmented generation
  - preserve existing `join_audio`, `output_path`, and `file_prefix` behavior when saving streamed output
  - factor the final concatenated write path through a small helper

- **`mlx_audio/tts/tests/test_generate.py`**
  - add parser validation coverage for `--save`
  - add regression coverage for streamed save output naming
  - add regression coverage for multi-segment streamed output
  - add regression coverage for `output_path` / `file_prefix` handling with streamed save
  - confirm `--stream` without `--save` still does not write files

- **`README.md`**
  - add CLI examples for `--stream`, `--stream --save`, and `--join_audio`
  - document default numbered output naming and the `--join_audio` behavior

## Changes outside the codebase

None.

## Additional information

- The change is intentionally localized to `mlx_audio/tts/generate.py`; `AudioPlayer` remains playback-only.
- Host-side smoke testing confirmed:
  - streamed playback begins quickly
  - streamed audio can be saved to disk
  - `output_path`, `file_prefix`, and `join_audio` combinations behave correctly
  - `black --check` passed on changed Python files
  - `isort --check-only` passed on changed Python files
  - pytest -s mlx_audio/tts/tests/test_generate.py passes fully
- Local sandbox validation was partially limited because MLX runtime libraries are not available here (`libmlx.so`), but:
  - `git diff --check` passed
  - `black --check` passed on changed Python files
  - `isort --check-only` passed on changed Python files
  - the new pytest file reaches collection until the missing MLX runtime boundary

## Checklist
- [x] Tests added/updated
- [x] Documentation updated