### PR TITLE
Restore *.pth in download patterns for VoxCPM

### DIFF
--- a/mlx_audio/utils.py
+++ b/mlx_audio/utils.py
@@ -88,6 +88,7 @@ DEFAULT_ALLOW_PATTERNS = [
     "*.jsonl",
     "*.yaml",
     "*.npz",
+    "*.pth",
 ]
 
 


### PR DESCRIPTION
The Voxtral TTS PR (#607) removed `*.pth` from `DEFAULT_ALLOW_PATTERNS` in `utils.py`. This breaks VoxCPM which expects `audiovae.pth` after download (`mlx_audio/tts/models/voxcpm/voxcpm.py:114`).

Restores `*.pth` to the allow patterns.