### PR TITLE
Fix voice cloning: aligner position indexing off-by-one

### DIFF
--- a/mlx_audio/tts/models/tada/tada.py
+++ b/mlx_audio/tts/models/tada/tada.py
@@ -1635,13 +1635,15 @@ def _align_text_tokens(
         best_t = start + np.argmax(token_scores[i, start:end])
         positions[i] = best_t
 
-    # Map CTC positions to codec frame positions
-    token_positions = ctc_to_codec[positions]
+    # Map CTC positions to codec frame positions (0-indexed)
+    codec_positions = ctc_to_codec[positions]
 
-    # Create token masks
+    # Create token masks at 0-indexed positions
     token_masks = np.zeros(num_frames, dtype=np.int64)
-    for pos in token_positions:
+    for pos in codec_positions:
         if 0 <= pos < num_frames:
             token_masks[pos] = 1
 
-    return token_positions, token_masks
+    # Return 1-indexed positions (matches reference aligner convention:
+    # encoder gathers at positions-1, which must land on masked frames)
+    return codec_positions + 1, token_masks


### PR DESCRIPTION
## Summary

- **Voice cloning was broken** — the encoder produced all-zero acoustic features because of a position indexing mismatch between the aligner and encoder.

The encoder gathers features at `token_positions - 1` (matching the [reference aligner convention](https://github.com/HumeAI/tada/blob/main/apple/mlx_tada/aligner.py#L322-L324)). But `_align_text_tokens` returned 0-indexed positions and set `token_masks` at those same indices. This meant the encoder gathered at `position - 1`, which always had `mask = 0` → all-zero features → no voice cloning.

**Fix**: Return 1-indexed positions (`codec_positions + 1`) while keeping masks at 0-indexed positions — matching the reference aligner which does `positions_1indexed = positions + 1` and `pos_emb[positions] = 1`.

**Before**: Encoder output all zeros → male default voice regardless of reference audio
**After**: Encoder output has proper acoustic features (mean=-0.016, std=1.1) → voice cloning works

## Test plan

- [x] Verified encoder now produces non-zero token_values (shape=(1,20,512), std=1.1)
- [x] Compared aligner convention against HumeAI reference implementation
- [x] Pre-commit (black + isort) passes
- [ ] Full generation test running (unquantized, ~10min)