### PR TITLE
Remove unnecessary mx.eval from flow matching for 2.3x speedup

### DIFF
--- a/mlx_audio/tts/models/tada/tada.py
+++ b/mlx_audio/tts/models/tada/tada.py
@@ -239,7 +239,6 @@ class Model(nn.Module):
                 speech, t_curr, cond, neg_cond, a_cfg, d_cfg
             )
             speech = speech + dt * velocity
-            mx.eval(speech)
             t_curr = t_span[i]
 
         return speech
@@ -1125,9 +1124,7 @@ class Model(nn.Module):
                     cache=cache,
                     compute_logits=need_logits,
                 )
-                mx.eval(hidden)
-                if cache:
-                    mx.eval(*[c for pair in cache for c in pair])
+                mx.eval(hidden, *[c for pair in cache for c in pair] if cache else [])
                 neg_cond = hidden[B : 2 * B]
                 cond = hidden[:B]
                 text_only_logits = (


### PR DESCRIPTION
## Summary

- Remove `mx.eval(speech)` from the flow matching ODE solver loop — it forced GPU synchronization 20 times per AR token, preventing MLX from lazily fusing the computation graph.
- Consolidate separate `mx.eval(hidden)` + `mx.eval(*cache)` calls into single `mx.eval` calls.

**Benchmark (1B, unquantized, avg of 3 runs):**

| | Before | After | HumeAI reference |
|---|---|---|---|
| Avg RTF | 10.7 | **4.7** | 5.0 |

The HumeAI reference (`mlx-tada`) does not call `mx.eval` inside its `solve()` loop, which is why it was ~2x faster.

## Test plan

- [x] Benchmarked 3 runs before/after, confirmed RTF improvement
- [x] Verified audio output quality unchanged
- [x] Pre-commit (black + isort) passes