### PR TITLE
fix(stt): remove PyTorch dependency from Cohere ASR buffer loading

### DIFF
--- a/mlx_audio/stt/models/cohere_asr/audio.py
+++ b/mlx_audio/stt/models/cohere_asr/audio.py
@@ -52,21 +52,18 @@ class CohereAudioFrontend:
         if not safetensor_path.exists():
             return
 
-        try:
-            from safetensors import safe_open
-        except ImportError:
-            return
+        weights = mx.load(str(safetensor_path))
 
-        with safe_open(str(safetensor_path), framework="pt", device="cpu") as f:
-            keys = set(f.keys())
-            if "preprocessor.featurizer.fb" in keys:
-                fb = f.get_tensor("preprocessor.featurizer.fb").float().cpu().numpy()
-                self.fb = mx.array(fb.squeeze(0)).astype(mx.float32)
-            if "preprocessor.featurizer.window" in keys:
-                window = (
-                    f.get_tensor("preprocessor.featurizer.window").float().cpu().numpy()
-                )
-                self.window = mx.array(window).astype(mx.float32)
+        fb_key = "preprocessor.featurizer.fb"
+        if fb_key in weights:
+            fb = weights[fb_key]
+            if fb.ndim == 3:
+                fb = fb.squeeze(0)
+            self.fb = fb.astype(mx.float32)
+
+        win_key = "preprocessor.featurizer.window"
+        if win_key in weights:
+            self.window = weights[win_key].astype(mx.float32)
 
     def _normalize_waveform(self, waveform) -> np.ndarray:
         if isinstance(waveform, mx.array):


### PR DESCRIPTION
## Summary

- **Remove unnecessary PyTorch dependency** from `CohereAudioFrontend.load_buffers_from_checkpoint` in the Cohere ASR model (introduced in #605).
- Replace `safe_open(framework="pt")` with `mx.load()`, which reads safetensors files natively and returns `mx.array` directly — eliminating the `torch.Tensor → numpy → mx.array` round-trip.
- This avoids pulling in ~2 GB of PyTorch just to load two small preprocessor tensors (`preprocessor.featurizer.fb` and `preprocessor.featurizer.window`).

## Details

`safe_open(..., framework="pt")` requires `torch` to be installed. Without it, loading the Cohere Transcribe model fails with `ModuleNotFoundError: No module named 'torch'`. Since `mx.load()` already supports safetensors (and is used elsewhere in the codebase, e.g. `mlx_audio/utils.py:load_weights`), the fix is a straightforward replacement with no behavioral change.

Only one file is modified: `mlx_audio/stt/models/cohere_asr/audio.py`.

## Testing

Mirrored this fix in venv source code and tested using a demo audio.
```
Transcribing: sample_en.mp3  (language=en)

============================================================
Transcription:
Yesterday it was 35 degrees in Barcelona, but today the temperature will go down to minus 20 degrees.
============================================================
Prompt tokens:     9
Generation tokens: 23
Prompt TPS:        0.6
Generation TPS:    1.6
Total time:        14.66s

Segments (1):
  [0.00s – 11.04s] Yesterday it was 35 degrees in Barcelona, but today the temperature will go down to minus 20 degrees.
```