### PR TITLE
feat: add STS category to get_model_category and load_model

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -40,7 +40,22 @@ from pydantic import BaseModel
 
 from mlx_audio.audio_io import read as audio_read
 from mlx_audio.audio_io import write as audio_write
-from mlx_audio.utils import load_model
+from mlx_audio.utils import (
+    get_model_category,
+    get_model_name_parts,
+    load_config,
+    load_model,
+)
+
+# Voice descriptions for STS models (OpenAI voice names → natural language)
+STS_VOICE_MAP = {
+    "alloy": "US female",
+    "echo": "US male",
+    "fable": "UK female",
+    "onyx": "UK male",
+    "nova": "US female",
+    "shimmer": "UK female",
+}
 
 
 def sanitize_for_json(obj: Any) -> Any:
@@ -74,19 +89,44 @@ MLX_AUDIO_NUM_WORKERS = os.getenv("MLX_AUDIO_NUM_WORKERS", "2")
 
 class ModelProvider:
     def __init__(self):
-        self.models: Dict[str, Dict[str, Any]] = {}
+        self.models: Dict[str, Any] = {}
+        self.processors: Dict[str, Any] = {}
+        self.categories: Dict[str, str] = {}
         self.lock = asyncio.Lock()
 
     def load_model(self, model_name: str):
         if model_name not in self.models:
             self.models[model_name] = load_model(model_name)
 
+            # Determine and store category
+            config = load_config(model_name)
+            name_parts = get_model_name_parts(model_name)
+            model_type = config.get("model_type", None)
+            category = get_model_category(model_type, name_parts)
+            self.categories[model_name] = category
+
+            # Load processor for STS models that need one
+            if category == "sts" and model_type == "lfm_audio":
+                from mlx_audio.sts.models.lfm_audio import LFM2AudioProcessor
+
+                self.processors[model_name] = (
+                    LFM2AudioProcessor.from_pretrained(model_name)
+                )
+
         return self.models[model_name]
+
+    def get_category(self, model_name: str) -> Optional[str]:
+        return self.categories.get(model_name)
+
+    def get_processor(self, model_name: str):
+        return self.processors.get(model_name)
 
     async def remove_model(self, model_name: str) -> bool:
         async with self.lock:
             if model_name in self.models:
                 del self.models[model_name]
+                self.processors.pop(model_name, None)
+                self.categories.pop(model_name, None)
                 return True
             return False
 
@@ -323,12 +363,64 @@ async def generate_audio(model, payload: SpeechRequest):
     yield buffer.getvalue()
 
 
+async def generate_sts_audio(model, processor, payload: SpeechRequest):
+    """Generate audio from an STS model (e.g. LFM2.5-Audio) using ChatState."""
+    from mlx_audio.sts.models.lfm_audio import ChatState, LFMModality
+    from mlx_audio.sts.models.lfm_audio.model import AUDIO_EOS_TOKEN
+
+    voice = payload.voice or "echo"
+    voice_desc = STS_VOICE_MAP.get(voice, voice)
+
+    chat = ChatState(processor)
+    chat.new_turn("system")
+    chat.add_text(f"Perform TTS. Use the {voice_desc} voice.")
+    chat.end_turn()
+    chat.new_turn("user")
+    chat.add_text(payload.input)
+    chat.end_turn()
+    chat.new_turn("assistant")
+
+    audio_codes = []
+    for token, modality in model.generate_sequential(
+        **dict(chat.items()),
+        max_new_tokens=payload.max_tokens,
+        temperature=payload.temperature or 1.0,
+        top_k=payload.top_k or 50,
+        audio_temperature=0.8,
+        audio_top_k=64,
+    ):
+        mx.eval(token)
+        if modality == LFMModality.AUDIO_OUT:
+            if token[0].item() == AUDIO_EOS_TOKEN:
+                break
+            audio_codes.append(token)
+
+    if not audio_codes:
+        raise HTTPException(status_code=400, detail="No audio generated")
+
+    codes = mx.stack(audio_codes, axis=0)[None, :].transpose(0, 2, 1)
+    waveform = processor.decode_audio(codes)
+    audio_np = np.array(waveform[0], dtype=np.float32)
+
+    buffer = io.BytesIO()
+    audio_write(buffer, audio_np, model.sample_rate, format=payload.response_format)
+    yield buffer.getvalue()
+
+
 @app.post("/v1/audio/speech")
 async def tts_speech(payload: SpeechRequest):
     """Generate speech audio following the OpenAI text-to-speech API."""
     model = model_provider.load_model(payload.model)
+    processor = model_provider.get_processor(payload.model)
+
+    generator = (
+        generate_sts_audio(model, processor, payload)
+        if processor is not None
+        else generate_audio(model, payload)
+    )
+
     return StreamingResponse(
-        generate_audio(model, payload),
+        generator,
         media_type=f"audio/{payload.response_format}",
         headers={
             "Content-Disposition": f"attachment; filename=speech.{payload.response_format}"
@@ -368,6 +460,34 @@ def generate_transcription_stream(stt_model, tmp_path: str, gen_kwargs: dict):
             os.remove(tmp_path)
 
 
+def generate_sts_transcription(model, processor, audio_data, sample_rate):
+    """Generate transcription from an STS model (e.g. LFM2.5-Audio) using ChatState."""
+    from mlx_audio.sts.models.lfm_audio import ChatState, LFMModality
+
+    audio = mx.array(audio_data)
+
+    chat = ChatState(processor)
+    chat.new_turn("system")
+    chat.add_text("Perform ASR.")
+    chat.end_turn()
+    chat.new_turn("user")
+    chat.add_audio(audio, sample_rate=sample_rate)
+    chat.end_turn()
+    chat.new_turn("assistant")
+
+    text_parts = []
+    for token, modality in model.generate_sequential(
+        **dict(chat.items()),
+        max_new_tokens=512,
+    ):
+        mx.eval(token)
+        if modality == LFMModality.TEXT:
+            text_parts.append(processor.decode_text(token[None]))
+
+    text = "".join(text_parts).replace("<|im_end|>", "").strip()
+    yield json.dumps({"text": text}) + "\n"
+
+
 @app.post("/v1/audio/transcriptions")
 async def stt_transcriptions(
     file: UploadFile = File(...),
@@ -382,7 +502,7 @@ async def stt_transcriptions(
     prefill_step_size: int = Form(2048),
     text: Optional[str] = Form(None),
 ):
-    """Transcribe audio using an STT model in OpenAI format."""
+    """Transcribe audio using an STT or STS model in OpenAI format."""
     # Create TranscriptionRequest from form fields
     payload = TranscriptionRequest(
         model=model,
@@ -401,6 +521,16 @@ async def stt_transcriptions(
     tmp = io.BytesIO(data)
     audio, sr = audio_read(tmp, always_2d=False)
     tmp.close()
+
+    # Use STS transcription path if model has a processor
+    processor = model_provider.get_processor(payload.model)
+    if processor is not None:
+        stt_model = model_provider.load_model(payload.model)
+        return StreamingResponse(
+            generate_sts_transcription(stt_model, processor, audio, sr),
+            media_type="application/x-ndjson",
+        )
+
     _, ext = os.path.splitext(file.filename)
     tmp_path = f"/tmp/{time.time()}.{ext if ext else 'mp3'}"
     audio_write(tmp_path, audio, sr)

--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -96,22 +96,29 @@ class ModelProvider:
 
     def load_model(self, model_name: str):
         if model_name not in self.models:
-            self.models[model_name] = load_model(model_name)
-
-            # Determine and store category
+            # Determine category before loading
             config = load_config(model_name)
             name_parts = get_model_name_parts(model_name)
             model_type = config.get("model_type", None)
             category = get_model_category(model_type, name_parts)
             self.categories[model_name] = category
 
-            # Load processor for STS models that need one
+            # STS models with their own from_pretrained (e.g. LFM2.5-Audio)
             if category == "sts" and model_type == "lfm_audio":
-                from mlx_audio.sts.models.lfm_audio import LFM2AudioProcessor
+                from mlx_audio.sts.models.lfm_audio import (
+                    LFM2AudioModel,
+                    LFM2AudioProcessor,
+                )
 
+                self.models[model_name] = LFM2AudioModel.from_pretrained(
+                    model_name
+                )
+                mx.eval(self.models[model_name].parameters())
                 self.processors[model_name] = (
                     LFM2AudioProcessor.from_pretrained(model_name)
                 )
+            else:
+                self.models[model_name] = load_model(model_name)
 
         return self.models[model_name]
 

--- a/mlx_audio/sts/models/mossformer2_se/__init__.py
+++ b/mlx_audio/sts/models/mossformer2_se/__init__.py
@@ -11,10 +11,15 @@ from .config import MossFormer2SEConfig
 from .model import MossFormer2SEModel
 from .mossformer2_se_wrapper import MossFormer2SE
 
+Model = MossFormer2SEModel
+ModelConfig = MossFormer2SEConfig
+
 __all__ = [
     "MossFormer2SEConfig",
     "MossFormer2SE",
     "MossFormer2SEModel",
+    "Model",
+    "ModelConfig",
     "load_audio",
     "save_audio",
 ]

--- a/mlx_audio/sts/utils.py
+++ b/mlx_audio/sts/utils.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+from typing import Union
+
+import mlx.nn as nn
+
+from mlx_audio.utils import base_load_model
+
+MODEL_REMAPPING = {
+    "lfm_audio": "lfm_audio",
+    "deepfilternet": "deepfilternet",
+    "deepfilter": "deepfilternet",
+    "mossformer2_se": "mossformer2_se",
+    "mossformer2": "mossformer2_se",
+}
+
+
+def load_model(
+    model_path: Union[str, Path], lazy: bool = False, strict: bool = False, **kwargs
+) -> nn.Module:
+    """
+    Load and initialize an STS (speech-to-speech) model from a given path.
+
+    Args:
+        model_path: The path or HuggingFace repo to load the model from.
+        lazy: If False, evaluate model parameters immediately.
+        strict: If True, raise an error if any weights are missing.
+        **kwargs: Additional keyword arguments (revision, force_download).
+
+    Returns:
+        nn.Module: The loaded and initialized model.
+    """
+    return base_load_model(
+        model_path=model_path,
+        category="sts",
+        model_remapping=MODEL_REMAPPING,
+        lazy=lazy,
+        strict=strict,
+        **kwargs,
+    )
+
+
+def load(
+    model_path: Union[str, Path], lazy: bool = False, strict: bool = False, **kwargs
+) -> nn.Module:
+    """
+    Load an STS model from a local path or HuggingFace repository.
+
+    This is the main entry point for loading STS models. It automatically
+    detects the model type and initializes the appropriate model class.
+
+    Args:
+        model_path: The local path or HuggingFace repo ID to load from.
+        lazy: If False, evaluate model parameters immediately.
+        strict: If True, raise an error if any weights are missing.
+        **kwargs: Additional keyword arguments:
+            - revision (str): HuggingFace revision/branch to use
+            - force_download (bool): Force re-download of model files
+
+    Returns:
+        nn.Module: The loaded and initialized model.
+    """
+    return load_model(model_path, lazy=lazy, strict=strict, **kwargs)

--- a/mlx_audio/utils.py
+++ b/mlx_audio/utils.py
@@ -413,6 +413,7 @@ _stt_utils = None
 _tts_utils = None
 _vad_utils = None
 _lid_utils = None
+_sts_utils = None
 
 
 def _get_stt_utils():
@@ -453,6 +454,16 @@ def _get_lid_utils():
 
         _lid_utils = lid_utils
     return _lid_utils
+
+
+def _get_sts_utils():
+    """Lazy load STS utils."""
+    global _sts_utils
+    if _sts_utils is None:
+        from mlx_audio.sts import utils as sts_utils
+
+        _sts_utils = sts_utils
+    return _sts_utils
 
 
 def audio_volume_normalize(audio, coeff: float = 0.2):
@@ -632,17 +643,19 @@ def is_valid_module_name(name: str) -> bool:
 
 
 def get_model_category(model_type: str, model_name: List[str]) -> Optional[str]:
-    """Determine whether a model belongs to the TTS, STT, LID, or VAD category."""
+    """Determine whether a model belongs to the TTS, STT, STS, LID, or VAD category."""
     stt_utils = _get_stt_utils()
     tts_utils = _get_tts_utils()
     vad_utils = _get_vad_utils()
     lid_utils = _get_lid_utils()
+    sts_utils = _get_sts_utils()
 
     candidates = [model_type] + (model_name or [])
 
     categories = [
         ("tts", tts_utils.MODEL_REMAPPING),
         ("stt", stt_utils.MODEL_REMAPPING),
+        ("sts", sts_utils.MODEL_REMAPPING),
         ("lid", lid_utils.MODEL_REMAPPING),
         ("vad", vad_utils.MODEL_REMAPPING),
     ]
@@ -682,7 +695,7 @@ def get_model_name_parts(model_path: Union[str, Path]) -> str:
 
 
 def load_model(model_name: str):
-    """Load a TTS, STT, LID, or VAD model based on its configuration and name.
+    """Load a TTS, STT, STS, LID, or VAD model based on its configuration and name.
 
     Args:
         model_name (str): Name or path of the model to load
@@ -695,6 +708,7 @@ def load_model(model_name: str):
     """
     tts_utils = _get_tts_utils()
     stt_utils = _get_stt_utils()
+    sts_utils = _get_sts_utils()
     vad_utils = _get_vad_utils()
     lid_utils = _get_lid_utils()
 
@@ -711,6 +725,7 @@ def load_model(model_name: str):
     model_loaders = {
         "tts": tts_utils.load_model,
         "stt": stt_utils.load_model,
+        "sts": sts_utils.load_model,
         "lid": lid_utils.load_model,
         "vad": vad_utils.load_model,
     }


### PR DESCRIPTION
## Summary

`get_model_category()` in `mlx_audio/utils.py` only checks tts/stt/lid/vad categories, so STS models like LFM2.5-Audio can't be loaded via the standard `load_model()` path or served via `python -m mlx_audio.server`.

This PR adds full STS support — category detection, model loading, **and** server endpoints.

### 1. Category detection (`mlx_audio/utils.py`)
- Add `_get_sts_utils()` lazy loader
- Add `("sts", sts_utils.MODEL_REMAPPING)` to `get_model_category()`
- Add `"sts": sts_utils.load_model` to `load_model()`

### 2. STS utils (`mlx_audio/sts/utils.py` — new file)
- `MODEL_REMAPPING` for `lfm_audio`, `deepfilternet`/`deepfilter`, `mossformer2_se`/`mossformer2`
- `load_model()` / `load()` following the same pattern as lid/vad/stt/tts

### 3. Server support (`mlx_audio/server.py`)
- `ModelProvider` tracks model categories and loads STS models via `from_pretrained()` (avoids `base_load_model` config incompatibility)
- `generate_sts_audio()` — TTS via ChatState conversation (system prompt + voice description + user text)
- `generate_sts_transcription()` — STT via ChatState conversation (system prompt + user audio + ASR instruction)
- `/v1/audio/speech` and `/v1/audio/transcriptions` auto-detect STS models and use the appropriate generation path
- OpenAI voice names (alloy, echo, fable, etc.) mapped to natural language voice descriptions

### 4. Model compatibility (`mlx_audio/sts/models/mossformer2_se/__init__.py`)
- Add `Model`/`ModelConfig` aliases (lfm_audio and deepfilternet already had them)

> **Note:** `moshi` and `sam_audio` are not included in `MODEL_REMAPPING` because they use custom loading patterns and don't expose `Model`/`ModelConfig` aliases. They can be added in a follow-up.

## Test plan

- [x] `get_model_category("lfm_audio", ...)` returns `"sts"`
- [x] `get_model_category("deepfilternet", ...)` returns `"sts"`
- [x] `get_model_category("mossformer2_se", ...)` returns `"sts"`
- [x] Existing categories (e.g. `whisper` → `stt`) still work
- [x] All imports resolve correctly (`ChatState`, `LFMModality`, `AUDIO_EOS_TOKEN`)
- [x] **End-to-end TTS**: `python -m mlx_audio.server` → POST `/v1/audio/speech` with `mlx-community/LFM2.5-Audio-1.5B-4bit` → 49KB WAV audio
- [x] **End-to-end STT**: POST `/v1/audio/transcriptions` with the generated WAV → `"Hello this is a test of the speech-to-speech model."` (correct transcription)

Related to #516