### PR TITLE
docs(qwen3-tts): add real-time streaming tuning guide

### DIFF
--- a/docs/models/tts/qwen3-tts.md
+++ b/docs/models/tts/qwen3-tts.md
@@ -112,6 +112,26 @@ for result in model.generate(
     # Play or process each chunk for low-latency output
 ```
 
+### Real-time tuning (Qwen3-TTS 12.5Hz codec)
+
+For live translation and assistants, `streaming_interval` is the main latency knob:
+
+- `streaming_interval = chunk_tokens / 12.5`
+- Smaller chunks reduce first-audio latency
+- Larger chunks improve smoothness and reduce decode overhead
+
+Practical baseline on Apple Silicon + 4-bit CustomVoice:
+
+| chunk tokens | `streaming_interval` | first-chunk feel | recommendation |
+|--------------|----------------------|------------------|----------------|
+| 2 | `0.16` | very fast, choppy | debug only |
+| 4 | `0.32` | fast + stable | default for real-time |
+| 6 | `0.48` | smoother, slower | quality-focused |
+| 8 | `0.64` | stable, higher delay | fallback |
+
+!!! tip "Start point for real-time UX"
+    Use `stream=True, streaming_interval=0.32` first, then tune toward `0.48` if you hear chunk boundaries.
+
 ### Batch Generation
 
 Generate multiple texts with different voices in a single batched forward pass:


### PR DESCRIPTION
## Summary
Add a practical real-time tuning section for Qwen3-TTS streaming in the model docs.

## What this adds
- Explains the `streaming_interval = chunk_tokens / 12.5` relation for Qwen3-TTS codec rate.
- Adds a small tuning matrix (`chunk_tokens` 2/4/6/8) with trade-offs for latency vs smoothness.
- Recommends `stream=True, streaming_interval=0.32` as a pragmatic default for real-time usage, with guidance to move to `0.48` when smoother chunks are needed.

## Why
Users deploying live translation / assistant pipelines often need concrete first-pass values rather than only API descriptions. This doc update shortens trial-and-error and aligns expectations around chunk boundaries vs latency.

## Scope
Docs-only change. No runtime behavior changes.
