### PR TITLE
Fix ACE-Step: weight conversion, LM hints, and vocal support

### DIFF
--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -493,6 +493,8 @@ def parse_args():
         type=str,
         default=None,
         help='Additional generation kwargs as JSON string (e.g., \'{"duration": 60.0, "num_steps": 8}\')',
+    )
+    parser.add_argument(
         "--save",
         action="store_true",
         help="Save streamed audio to a file. Requires --stream.",

--- a/mlx_audio/tts/models/ace_step/README.md
+++ b/mlx_audio/tts/models/ace_step/README.md
@@ -146,7 +146,6 @@ Apple Silicon M4 Max, 4-bit quantized model, 20 diffusion steps:
 
 - The 0.6B LM occasionally ignores the `vocal_language` parameter and picks its own
 - Vocal clarity varies by seed — use cherry-picking for final output
-- Non-Western genres (e.g., Bollywood) are less represented in training data
 
 ## Citation
 

--- a/mlx_audio/tts/models/ace_step/README.md
+++ b/mlx_audio/tts/models/ace_step/README.md
@@ -6,25 +6,30 @@ MLX implementation of [ACE-Step](https://github.com/ace-step/ACE-Step), a 3.5B p
 
 - **Text-to-Music**: Generate music from text descriptions
 - **Vocals Support**: Generate songs with lyrics in multiple languages
-- **Fast Generation**: Turbo model generates 2 minutes of audio in ~25 seconds on Apple Silicon
+- **Fast Generation**: Faster than real-time on Apple Silicon (RTF ~0.85x at 20 steps)
 - **High Quality**: 48kHz stereo audio output
+- **4-bit Quantized Variant**: 2.2GB main model for memory-constrained systems
 
 ## Quick Start
 
 ```python
 from mlx_audio.tts import load
 
-# Load the model
-model = load("ACE-Step/ACE-Step1.5")
+# Load the MLX-converted model (4-bit quantized, 2.2GB)
+model = load("mlx-community/ACE-Step1.5-MLX-4bit")
 
 # Generate instrumental music
 for result in model.generate(
     text="upbeat electronic dance music with energetic synthesizers",
     duration=30.0,
 ):
-    audio = result.audio  # [2, samples] stereo audio
+    audio = result.audio  # [samples, 2] stereo audio
     sample_rate = result.sample_rate  # 48000
 ```
+
+Pre-converted weights are available on Hugging Face:
+- [mlx-community/ACE-Step1.5-MLX](https://huggingface.co/mlx-community/ACE-Step1.5-MLX) — fp32 (~9.6GB main model)
+- [mlx-community/ACE-Step1.5-MLX-4bit](https://huggingface.co/mlx-community/ACE-Step1.5-MLX-4bit) — 4-bit quantized (~2.2GB main model)
 
 ## Generating Music with Vocals
 
@@ -34,138 +39,114 @@ import scipy.io.wavfile as wavfile
 import numpy as np
 import mlx.core as mx
 
-model = load("ACE-Step/ACE-Step1.5")
+model = load("mlx-community/ACE-Step1.5-MLX-4bit")
 
-prompt = "upbeat electronic dance music with female vocals, catchy melody"
-lyrics = """[verse]
+prompt = "upbeat pop song with female vocals, catchy melody, bright synths"
+lyrics = """[Verse 1]
 Dance with me tonight
 Under the neon lights
-Feel the beat so right
+Feel the rhythm in your soul
+Let the music take control
 
-[chorus]
-Move your body, feel the groove
-Nothing left for us to prove
-Just the music in our soul
+[Chorus]
+We're alive, we're on fire
+Dancing higher and higher
+Nothing's gonna stop us now
+We're shining bright somehow
 """
 
 for result in model.generate(
     text=prompt,
     lyrics=lyrics,
-    duration=60.0,
-    guidance_scale=1.0,
+    duration=30.0,
     vocal_language="en",
 ):
-    # Save to WAV file
     audio_np = np.array(result.audio.astype(mx.float32))
-    audio_int16 = (audio_np * 32767).astype(np.int16)
-    wavfile.write("song.wav", result.sample_rate, audio_int16.T)
+    audio_int16 = (np.clip(audio_np, -1, 1) * 32767).astype(np.int16)
+    wavfile.write("song.wav", result.sample_rate, audio_int16)
 ```
+
+## How It Works
+
+ACE-Step's turbo model requires a two-stage pipeline:
+
+1. **5Hz Language Model (Planner)**: Takes your text prompt + lyrics and generates an audio code "blueprint" for the song — planning BPM, key signature, structure, and time-aligned audio codes
+2. **Diffusion Transformer (DiT)**: Uses these codes as conditioning to denoise random noise into musical latents
+3. **VAE Decoder**: Decodes the 25Hz latents into 48kHz stereo audio
+
+The LM planner is **required** for the turbo model — without it, the DiT converges back to silence. `use_lm=True` is the default.
 
 ## Parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `text` | required | Text description/prompt for the music |
-| `lyrics` | `""` | Lyrics for vocal generation (empty for instrumental) |
+| `text` | required | Text description / prompt |
+| `lyrics` | `""` | Lyrics (empty for instrumental) |
 | `duration` | `30.0` | Target duration in seconds |
 | `seed` | `None` | Random seed for reproducibility |
-| `num_steps` | `8` | Number of diffusion steps (8 for turbo) |
-| `guidance_scale` | `1.0` | CFG scale (1.0 = no guidance for turbo model) |
+| `num_steps` | `20` | Diffusion steps (20 recommended for vocals, 8 ok for instrumentals) |
+| `shift` | `3.0` | Timestep schedule shift (1.0, 2.0, or 3.0) |
+| `guidance_scale` | `1.0` | CFG scale (1.0 = no guidance; turbo model is distilled without CFG) |
 | `guidance_interval` | `0.5` | Fraction of steps with guidance applied |
-| `cfg_type` | `"apg"` | CFG type: `"apg"` or `"cfg"` |
+| `cfg_type` | `"apg"` | Guidance type: `"apg"` or `"cfg"` |
 | `vocal_language` | `"unknown"` | Language code: `"en"`, `"zh"`, `"ja"`, etc. |
-
-## Recommended Settings
-
-**Note:** The turbo model (ACE-Step1.5) is distilled to work without classifier-free guidance.
-The default `guidance_scale=1.0` (no guidance) is recommended for best results.
-
-### For Vocals
-```python
-model.generate(
-    text="...",
-    lyrics="...",
-    guidance_scale=5.0,      # 4.0-6.0 for clear vocals
-    guidance_interval=0.5,   # 0.5-0.7 for lyric adherence
-    vocal_language="en",
-)
-```
-
-### For Instrumental
-```python
-model.generate(
-    text="...",
-    lyrics="",               # Empty for instrumental
-)
-```
-
-### For Better Lyric Following
-If the model skips lyrics, try:
-```python
-model.generate(
-    text="...",
-    lyrics="...",
-    guidance_interval=0.7,   # Higher = stricter lyric following
-    num_steps=16,            # More steps for refinement
-)
-```
+| `use_lm` | `True` | Use 5Hz LM planner (required for the turbo model) |
+| `lm_model_size` | `"0.6B"` | LM size: `"0.6B"` (fast) or `"4B"` (higher quality, slower) |
 
 ## Lyrics Format
 
 Use section markers to structure your lyrics:
 
 ```
-[verse]
+[Verse 1]
 First verse lyrics here
 Line by line
 
-[chorus]
+[Chorus]
 Catchy chorus lyrics
 That repeat
 
-[bridge]
+[Bridge]
 Bridge section
 Something different
 
-[outro]
+[Outro]
 Final words
 ```
 
 ## Supported Languages
 
-ACE-Step supports lyrics in multiple languages:
-- English (`en`)
-- Chinese (`zh`)
-- Japanese (`ja`)
-- Korean (`ko`)
-- And more...
+ACE-Step supports lyrics in multiple languages via the 5Hz LM planner:
+- English (`en`), Chinese (`zh`), Japanese (`ja`), Korean (`ko`)
+- Spanish (`es`), French (`fr`), German (`de`), Italian (`it`)
+- And many more (50+ supported by the LM)
 
-Set `vocal_language` to the appropriate code for best results.
+Set `vocal_language` to hint the planner — though the 0.6B LM sometimes picks its own language based on caption/lyrics content. Use the 4B LM for more reliable language adherence.
 
 ## Performance
 
-On Apple Silicon (M-series chips):
+Apple Silicon M4 Max, 4-bit quantized model, 20 diffusion steps:
 
-| Duration | Generation Time | RTF |
-|----------|-----------------|-----|
-| 30s | ~12s | 0.4x |
-| 60s | ~15s | 0.25x |
-| 120s | ~25s | 0.2x |
+| Duration | Total Time | Diffusion | LM Planning | VAE Decode | RTF |
+|----------|-----------|-----------|-------------|------------|-----|
+| 30s | ~25s | ~8s | ~12s | ~3.5s | 0.85x |
+| 60s | ~40s | ~17s | ~12s | ~6s | 0.67x |
 
-*RTF (Real-Time Factor) < 1.0 means faster than real-time*
+*RTF (Real-Time Factor) < 1.0 means faster than real-time.*
 
 ## Tips
 
-1. **Cherry-picking**: Generate multiple samples with different seeds and pick the best one
-2. **Prompt engineering**: Be specific about genre, instruments, mood, and vocal style
-3. **Lyric length**: Match lyric length to duration (~4 lines per 15-20 seconds)
-4. **Turbo model**: Uses no CFG by default (guidance_scale=1.0) as it's distilled for direct generation
+1. **Vocals**: Use `num_steps=20` (default) for clearer vocals; `num_steps=8` is fine for instrumentals
+2. **Cherry-pick seeds**: Generate a few samples with different seeds and pick the best — LM quality varies
+3. **Prompt engineering**: Be specific about genre, instruments, mood, vocal style (e.g., "male vocals", "female choir")
+4. **Section markers** in lyrics help the model structure the song (`[Verse]`, `[Chorus]`, `[Bridge]`, `[Outro]`)
+5. **LM size**: 4B model follows language/caption instructions more reliably but takes ~3x longer to plan
 
 ## Known Limitations
 
-- May occasionally skip or mix up lyrics in longer songs
-- Vocal clarity varies by generation (use cherry-picking)
-- Best results with clear, structured lyrics using section markers
+- The 0.6B LM occasionally ignores the `vocal_language` parameter and picks its own
+- Vocal clarity varies by seed — use cherry-picking for final output
+- Non-Western genres (e.g., Bollywood) are less represented in training data
 
 ## Citation
 

--- a/mlx_audio/tts/models/ace_step/__init__.py
+++ b/mlx_audio/tts/models/ace_step/__init__.py
@@ -6,12 +6,8 @@ from .config import (
     SFT_GEN_PROMPT,
     TASK_INSTRUCTIONS,
     TASK_TYPES,
-    TASK_TYPES_BASE,
-    TASK_TYPES_TURBO,
     TRACK_NAMES,
     ModelConfig,
-    TextEncoderConfig,
-    VAEConfig,
 )
 from .lm import ACEStepLM, LMConfig
 from .vae import AutoencoderOobleck
@@ -19,15 +15,10 @@ from .vae import AutoencoderOobleck
 __all__ = [
     "Model",
     "ModelConfig",
-    "VAEConfig",
-    "TextEncoderConfig",
     "AutoencoderOobleck",
     "ACEStepLM",
     "LMConfig",
-    # Task constants
     "TASK_TYPES",
-    "TASK_TYPES_TURBO",
-    "TASK_TYPES_BASE",
     "TASK_INSTRUCTIONS",
     "DEFAULT_INSTRUCTION",
     "TRACK_NAMES",

--- a/mlx_audio/tts/models/ace_step/ace_step.py
+++ b/mlx_audio/tts/models/ace_step/ace_step.py
@@ -611,8 +611,9 @@ class Model(nn.Module):
         matched_weights = {k: v for k, v in weights.items() if k in param_keys}
 
         if matched_weights:
-            nested_matched = tree_unflatten(list(matched_weights.items()))
-            self.update(nested_matched)
+            from mlx.utils import tree_unflatten
+
+            self.update(tree_unflatten(list(matched_weights.items())))
 
         if strict and (missing_keys or unexpected_keys):
             msg = []

--- a/mlx_audio/tts/models/ace_step/ace_step.py
+++ b/mlx_audio/tts/models/ace_step/ace_step.py
@@ -1087,7 +1087,7 @@ class Model(nn.Module):
         track_name: Optional[str] = None,
         complete_track_classes: Optional[List[str]] = None,
         # LM parameters
-        use_lm: bool = False,
+        use_lm: bool = True,
         lm_model_size: str = "0.6B",
         lm_temperature: float = 0.8,
         lm_top_p: float = 0.95,

--- a/mlx_audio/tts/models/ace_step/ace_step.py
+++ b/mlx_audio/tts/models/ace_step/ace_step.py
@@ -1256,16 +1256,30 @@ class Model(nn.Module):
         )
         is_covers = mx.array([1.0 if is_cover else 0.0], dtype=self.dtype)
 
-        # LM hints support - LM hints override is_covers to True
+        # LM hints support - LM hints replace src_latents via is_covers mechanism
         lm_hints = None
         if lm_precomputed_hints is not None:
             lm_hints = lm_precomputed_hints.astype(self.dtype)
             is_covers = mx.ones((1,), dtype=self.dtype)
             if verbose:
                 print("Using pre-computed LM hints")
-        elif use_lm and task_type == "cover":
-            if verbose:
-                print("5Hz LM enabled for cover task")
+        elif use_lm:
+            # Generate LM hints for any task type
+            lm_hints = self._generate_lm_hints(
+                caption=text,
+                lyrics=lyrics,
+                duration=int(duration),
+                language=vocal_language,
+                target_len=latent_len,
+                seed=seed,
+                model_size=lm_model_size,
+                verbose=verbose,
+            )
+            if lm_hints is not None:
+                lm_hints = lm_hints.astype(self.dtype)
+                is_covers = mx.ones((1,), dtype=self.dtype)
+                if verbose:
+                    print(f"LM hints generated: {lm_hints.shape}")
 
         if verbose:
             print("Running diffusion...")

--- a/mlx_audio/tts/models/ace_step/ace_step.py
+++ b/mlx_audio/tts/models/ace_step/ace_step.py
@@ -162,16 +162,16 @@ class Model(nn.Module):
             model._sample_rate = vae_config.get("sampling_rate", 48000)
 
         # Load silence latent - try turbo subdirectory first, then root
-        silence_path = model_path / "acestep-v15-turbo" / "silence_latent.pt"
-        if not Path(str(silence_path).replace(".pt", ".npy")).exists():
-            silence_path = model_path / "silence_latent.pt"
+        silence_npy = model_path / "acestep-v15-turbo" / "silence_latent.npy"
+        if not silence_npy.exists():
+            silence_npy = model_path / "silence_latent.npy"
 
-        if Path(str(silence_path).replace(".pt", ".npy")).exists():
+        if silence_npy.exists():
             import numpy as np
 
-            silence_pt = np.load(str(silence_path).replace(".pt", ".npy"))
-            silence_pt = silence_pt.transpose(0, 2, 1)  # [1, 64, T] -> [1, T, 64]
-            model.silence_latent = mx.array(silence_pt)
+            silence_np = np.load(str(silence_npy))
+            silence_np = silence_np.transpose(0, 2, 1)  # [1, 64, T] -> [1, T, 64]
+            model.silence_latent = mx.array(silence_np)
         else:
             model.silence_latent = mx.zeros((1, 3000, 64))
 
@@ -592,13 +592,6 @@ class Model(nn.Module):
         # Sanitize weights
         weights = self.sanitize(weights)
 
-        # Use mlx's update function for loading
-        from mlx.utils import tree_unflatten
-
-        # Convert flat dict to nested structure
-        nested_weights = tree_unflatten(list(weights.items()))
-
-        # Get current parameters for comparison
         current_params = dict(nn.utils.tree_flatten(self.parameters()))
 
         missing_keys = []
@@ -727,36 +720,14 @@ class Model(nn.Module):
         refer_audio_acoustic_hidden_states_packed: mx.array,
         refer_audio_order_mask: mx.array,
         hidden_states: mx.array,
-        attention_mask: mx.array,
-        silence_latent: mx.array,
         src_latents: mx.array,
         chunk_masks: mx.array,
         is_covers: mx.array,
         lm_hints_25hz: Optional[mx.array] = None,
     ) -> Tuple[mx.array, mx.array, mx.array]:
-        """Prepare conditioning inputs.
-
-        Args:
-            text_hidden_states: Text embeddings
-            text_attention_mask: Text attention mask
-            lyric_hidden_states: Lyric embeddings
-            lyric_attention_mask: Lyric attention mask
-            refer_audio_acoustic_hidden_states_packed: Reference audio features
-            refer_audio_order_mask: Reference audio order mask
-            hidden_states: Input hidden states
-            attention_mask: Attention mask
-            silence_latent: Silence latent for padding
-            src_latents: Source latents
-            chunk_masks: Chunk masks
-            is_covers: Cover song flags
-            lm_hints_25hz: Optional pre-computed LM hints at 25Hz rate
-
-        Returns:
-            Tuple of (encoder_hidden_states, encoder_attention_mask, context_latents)
-        """
+        """Prepare conditioning inputs."""
         dtype = hidden_states.dtype
 
-        # Encode conditions
         encoder_hidden_states, encoder_attention_mask = self.encoder(
             text_hidden_states=text_hidden_states,
             text_attention_mask=text_attention_mask,
@@ -798,7 +769,6 @@ class Model(nn.Module):
         src_latents: mx.array,
         chunk_masks: mx.array,
         is_covers: mx.array,
-        silence_latent: Optional[mx.array] = None,
         attention_mask: Optional[mx.array] = None,
         seed: Optional[int] = None,
         fix_nfe: int = 8,
@@ -806,37 +776,10 @@ class Model(nn.Module):
         shift: float = 3.0,
         guidance_scale: float = 15.0,
         guidance_interval: float = 0.5,
-        omega_scale: float = 10.0,
         cfg_type: str = "apg",
         lm_hints_25hz: Optional[mx.array] = None,
     ) -> Dict:
-        """Generate audio latents.
-
-        Args:
-            text_hidden_states: Text embeddings
-            text_attention_mask: Text attention mask
-            lyric_hidden_states: Lyric embeddings
-            lyric_attention_mask: Lyric attention mask
-            refer_audio_acoustic_hidden_states_packed: Reference audio features
-            refer_audio_order_mask: Reference audio order mask
-            src_latents: Source latents
-            chunk_masks: Chunk masks
-            is_covers: Cover song flags
-            silence_latent: Silence latent for padding
-            attention_mask: Attention mask
-            seed: Random seed
-            fix_nfe: Number of function evaluations (steps)
-            infer_method: Inference method ('ode' or 'sde')
-            shift: Timestep schedule shift
-            guidance_scale: Classifier-free guidance scale (default 15.0)
-            guidance_interval: Fraction of steps where guidance is applied (0.5 = middle 50%)
-            omega_scale: Granularity scale for variance control (default 10.0)
-            cfg_type: CFG type ('cfg' for standard, 'apg' for Adaptive Projected Gradient)
-            lm_hints_25hz: Optional pre-computed LM hints at 25Hz rate
-
-        Returns:
-            Dictionary with 'target_latents' and 'time_costs'
-        """
+        """Generate audio latents."""
         # Pre-defined timestep schedules for turbo model (fix_nfe=8)
         # These are the valid timesteps from the PyTorch turbo implementation
         SHIFT_TIMESTEPS = {
@@ -899,8 +842,6 @@ class Model(nn.Module):
                 refer_audio_acoustic_hidden_states_packed=refer_audio_acoustic_hidden_states_packed,
                 refer_audio_order_mask=refer_audio_order_mask,
                 hidden_states=src_latents,
-                attention_mask=attention_mask,
-                silence_latent=silence_latent,
                 src_latents=src_latents,
                 chunk_masks=chunk_masks,
                 is_covers=is_covers,
@@ -1078,7 +1019,6 @@ class Model(nn.Module):
         shift: float = 3.0,
         guidance_scale: float = 1.0,
         guidance_interval: float = 0.5,
-        omega_scale: float = 10.0,
         cfg_type: str = "apg",
         vocal_language: str = "unknown",
         verbose: bool = True,
@@ -1108,7 +1048,6 @@ class Model(nn.Module):
             shift: Timestep schedule shift (1, 2, or 3)
             guidance_scale: CFG scale (1.0 = no guidance, turbo model default; >1 for non-turbo models)
             guidance_interval: Fraction of steps where guidance is applied (0.5 recommended)
-            omega_scale: Granularity scale for variance control
             cfg_type: CFG type ('cfg' for standard, 'apg' for Adaptive Projected Gradient)
             vocal_language: Language code for vocals (e.g., "en", "zh")
             verbose: Whether to print progress
@@ -1299,13 +1238,11 @@ class Model(nn.Module):
             src_latents=src_latents,
             chunk_masks=chunk_masks,
             is_covers=is_covers,
-            silence_latent=self.silence_latent.astype(self.dtype),
             seed=seed,
             fix_nfe=num_steps,
             shift=shift,
             guidance_scale=guidance_scale,
             guidance_interval=guidance_interval,
-            omega_scale=omega_scale,
             cfg_type=cfg_type,
             lm_hints_25hz=lm_hints,
         )
@@ -1379,15 +1316,3 @@ class Model(nn.Module):
             is_final_chunk=True,
         )
 
-
-def test_model():
-    """Test model instantiation."""
-    config = ModelConfig()
-    model = Model(config)
-    print(f"Model created with config: {config.model_type}")
-    print(f"Sample rate: {model.sample_rate}")
-    return model
-
-
-if __name__ == "__main__":
-    test_model()

--- a/mlx_audio/tts/models/ace_step/ace_step.py
+++ b/mlx_audio/tts/models/ace_step/ace_step.py
@@ -1074,7 +1074,7 @@ class Model(nn.Module):
         voice: Optional[str] = None,
         duration: float = 30.0,
         seed: Optional[int] = None,
-        num_steps: int = 8,
+        num_steps: int = 20,
         shift: float = 3.0,
         guidance_scale: float = 1.0,
         guidance_interval: float = 0.5,

--- a/mlx_audio/tts/models/ace_step/ace_step.py
+++ b/mlx_audio/tts/models/ace_step/ace_step.py
@@ -523,23 +523,43 @@ class Model(nn.Module):
         for key, value in weights.items():
             new_key = key
 
-            # Handle Conv1d weights: PyTorch [out, in, K] -> MLX [out, K, in]
-            if "proj_in.1.weight" in key:
-                # Conv1d: PyTorch [out_ch, in_ch, K] -> MLX [out_ch, K, in_ch]
+            # Handle dit.* -> decoder.* remapping (legacy converted weights)
+            if new_key.startswith("dit."):
+                new_key = "decoder." + new_key[4:]
+
+            # Handle decoder Conv1d proj_in weights: PyTorch [out, in, K] -> MLX [out, K, in]
+            # Only for decoder.proj_in/proj_out (bare params), not detokenizer/encoder proj_out (nn.Linear)
+            if "decoder.proj_in.1." in new_key or (
+                new_key == "decoder.proj_in.weight" and len(value.shape) == 3
+            ):
                 if len(value.shape) == 3:
                     value = value.transpose(0, 2, 1)
-                new_key = key.replace(".1.", "_")
+                new_key = new_key.replace("proj_in.1.", "proj_in_").replace(
+                    "decoder.proj_in.weight", "decoder.proj_in_weight"
+                )
 
-            # Handle ConvTranspose1d weights: PyTorch [in, out, K] -> MLX [out, K, in]
-            elif "proj_out.1.weight" in key:
-                # ConvTranspose1d: PyTorch [in_ch, out_ch, K] -> MLX [out_ch, K, in_ch]
+            # Handle decoder ConvTranspose1d proj_out weights: PyTorch [in, out, K] -> MLX [out, K, in]
+            elif "decoder.proj_out.1." in new_key or (
+                new_key == "decoder.proj_out.weight" and len(value.shape) == 3
+            ):
                 if len(value.shape) == 3:
                     value = value.transpose(1, 2, 0)
-                new_key = key.replace(".1.", "_")
+                new_key = new_key.replace("proj_out.1.", "proj_out_").replace(
+                    "decoder.proj_out.weight", "decoder.proj_out_weight"
+                )
 
-            # Handle Conv1d/ConvTranspose1d bias
-            elif "proj_in.1.bias" in key or "proj_out.1.bias" in key:
-                new_key = key.replace(".1.", "_")
+            # Handle decoder Conv1d/ConvTranspose1d bias
+            elif new_key == "decoder.proj_in.bias" or "decoder.proj_in.1.bias" in new_key:
+                new_key = new_key.replace("proj_in.1.", "proj_in_").replace(
+                    "decoder.proj_in.bias", "decoder.proj_in_bias"
+                )
+            elif (
+                new_key == "decoder.proj_out.bias"
+                or "decoder.proj_out.1.bias" in new_key
+            ):
+                new_key = new_key.replace("proj_out.1.", "proj_out_").replace(
+                    "decoder.proj_out.bias", "decoder.proj_out_bias"
+                )
 
             # Handle scale_shift_table - ensure correct shape
             if "scale_shift_table" in key:

--- a/mlx_audio/tts/models/ace_step/ace_step.py
+++ b/mlx_audio/tts/models/ace_step/ace_step.py
@@ -259,7 +259,7 @@ class Model(nn.Module):
         max_length: int = 2048,
         language: str = "unknown",
     ) -> Tuple[mx.array, mx.array]:
-        """Prepare lyric embeddings using embed_tokens only."""
+        """Prepare lyric embeddings using Qwen3 word embeddings."""
         if not lyrics:
             lyrics = "[instrumental]"
 
@@ -273,7 +273,9 @@ class Model(nn.Module):
         else:
             lyric_len = min(len(formatted_lyrics.split()) * 3, max_length)
             lyric_len = max(lyric_len, 10)
-            lyric_hidden = mx.random.normal((1, lyric_len, self.config.text_hidden_dim))
+            lyric_hidden = mx.random.normal(
+                (1, lyric_len, self.config.text_hidden_dim)
+            )
             lyric_mask = mx.ones((1, lyric_len))
             return lyric_hidden.astype(self.dtype), lyric_mask.astype(self.dtype)
 

--- a/mlx_audio/tts/models/ace_step/config.py
+++ b/mlx_audio/tts/models/ace_step/config.py
@@ -12,12 +12,6 @@ from mlx_audio.tts.models.base import BaseModelArgs
 
 TASK_TYPES = ["text2music", "repaint", "cover", "extract", "lego", "complete"]
 
-# Task types available for turbo models (subset)
-TASK_TYPES_TURBO = ["text2music", "repaint", "cover"]
-
-# Task types available for base models (full set)
-TASK_TYPES_BASE = ["text2music", "repaint", "cover", "extract", "lego", "complete"]
-
 
 # ==============================================================================
 # Instruction Constants
@@ -148,30 +142,3 @@ class ModelConfig(BaseModelArgs):
             ]
 
 
-@dataclass
-class VAEConfig(BaseModelArgs):
-
-    audio_channels: int = 2
-    channel_multiples: List[int] = field(default_factory=lambda: [1, 2, 4, 8, 16])
-    decoder_channels: int = 128
-    decoder_input_channels: int = 64
-    downsampling_ratios: List[int] = field(default_factory=lambda: [2, 4, 4, 6, 10])
-    encoder_hidden_size: int = 128
-    sampling_rate: int = 48000
-
-
-@dataclass
-class TextEncoderConfig(BaseModelArgs):
-
-    hidden_size: int = 1024
-    intermediate_size: int = 3072
-    num_hidden_layers: int = 28
-    num_attention_heads: int = 16
-    num_key_value_heads: int = 8
-    head_dim: int = 128
-    hidden_act: str = "silu"
-    max_position_embeddings: int = 32768
-    rms_norm_eps: float = 1e-6
-    rope_theta: float = 1000000.0
-    vocab_size: int = 151669
-    tie_word_embeddings: bool = True

--- a/mlx_audio/tts/models/ace_step/convert.py
+++ b/mlx_audio/tts/models/ace_step/convert.py
@@ -30,28 +30,27 @@ def convert_ace_step(model_repo: str, output_dir: str, local_files_only: bool = 
 
     weights = {}
     for key, value in state_dict.items():
-        if not key.startswith("decoder.") and not key.startswith("encoder."):
+        np_val = value.cpu().float().numpy()
+        new_key = key
+
+        # Skip rotary embedding caches (recomputed at runtime)
+        if "rotary_emb" in key:
             continue
 
-        np_val = value.cpu().float().numpy()
+        # Handle decoder Conv1d proj_in: PyTorch [out, in, K] -> MLX [out, K, in]
+        # Use underscore naming (proj_in_weight) to match bare params in DiTModel
+        if "decoder.proj_in.1." in new_key:
+            new_key = new_key.replace("proj_in.1.", "proj_in_")
+            if new_key.endswith("_weight"):
+                np_val = np_val.swapaxes(1, 2)
 
-        if key.startswith("decoder."):
-            new_key = key.replace("decoder.", "dit.")
-            if "proj_in.1." in new_key:
-                new_key = new_key.replace("proj_in.1.", "proj_in.")
-                if new_key.endswith(".weight"):
-                    np_val = np_val.swapaxes(1, 2)
-            elif "proj_out.1." in new_key:
-                new_key = new_key.replace("proj_out.1.", "proj_out.")
-                if new_key.endswith(".weight"):
-                    np_val = np_val.transpose(1, 2, 0)
-            elif "rotary_emb" in new_key:
-                continue
-            weights[new_key] = mx.array(np_val)
-        else:
-            if "rotary_emb" in key:
-                continue
-            weights[key] = mx.array(np_val)
+        # Handle decoder ConvTranspose1d proj_out: PyTorch [in, out, K] -> MLX [out, K, in]
+        elif "decoder.proj_out.1." in new_key:
+            new_key = new_key.replace("proj_out.1.", "proj_out_")
+            if new_key.endswith("_weight"):
+                np_val = np_val.transpose(1, 2, 0)
+
+        weights[new_key] = mx.array(np_val)
 
     mx.save_safetensors(str(out_dir / "model.safetensors"), weights)
 

--- a/mlx_audio/tts/models/ace_step/dit.py
+++ b/mlx_audio/tts/models/ace_step/dit.py
@@ -23,8 +23,6 @@ class DiTModel(nn.Module):
     def __init__(self, config: ModelConfig):
         super().__init__()
         self.config = config
-
-        self.hidden_size = config.hidden_size
         self.patch_size = config.patch_size
         in_channels = config.in_channels
 
@@ -108,9 +106,6 @@ class DiTModel(nn.Module):
         Returns:
             Output [batch, seq_len // stride, out_channels]
         """
-        # MLX conv1d expects: input [N, L, C_in], weight [C_out, K, C_in]
-        # x is already [batch, seq_len, in_channels]
-        # weight is [out_channels, kernel_size, in_channels]
         output = mx.conv1d(x, weight, stride=stride)
         output = output + bias
         return output
@@ -132,30 +127,13 @@ class DiTModel(nn.Module):
         batch_size, seq_len, in_channels = x.shape
         out_channels, kernel_size, _ = weight.shape
 
-        # For transposed conv with stride=kernel_size (non-overlapping)
-        # Each input position produces kernel_size outputs
-
-        # x: [batch, seq_len, in_channels]
-        # weight: [out_channels, kernel_size, in_channels]
-
-        # Compute all outputs at once
-        # [batch, seq_len, in_channels] @ [in_channels, kernel_size * out_channels]
-        # weight is [out_channels, kernel_size, in_channels]
-        # transpose(2, 1, 0) -> [in_channels, kernel_size, out_channels]
-        # reshape -> [in_channels, kernel_size * out_channels]
-        # This ordering ensures output channels are grouped by kernel position
+        # Non-overlapping transposed conv via matmul: each input produces kernel_size outputs
         weight_reshaped = weight.transpose(2, 1, 0).reshape(
             in_channels, kernel_size * out_channels
         )
-        output = x @ weight_reshaped  # [batch, seq_len, out_channels * kernel_size]
-
-        # Reshape to [batch, seq_len, kernel_size, out_channels]
+        output = x @ weight_reshaped
         output = output.reshape(batch_size, seq_len, kernel_size, out_channels)
-
-        # Reshape to [batch, seq_len * kernel_size, out_channels]
         output = output.reshape(batch_size, seq_len * kernel_size, out_channels)
-
-        # Add bias
         output = output + bias
 
         return output
@@ -228,38 +206,22 @@ class DiTModel(nn.Module):
         position_ids = mx.arange(seq_len)[None, :]
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
-        # Create attention masks (bidirectional for DiT)
-        # Note: Don't use the original attention_mask here since it has the pre-patched length
-        # After patching, all positions are valid
-        self_attn_mask = create_4d_mask(
-            seq_len=seq_len,
-            dtype=hidden_states.dtype,
-            attention_mask=None,  # All positions valid after patching
-            is_causal=False,
-        )
+        # Bidirectional attention: all positions attend to all others.
+        # Non-sliding layers use None (no mask needed).
+        # Sliding window mask is computed once and reused across all layers.
+        sliding_mask = None
+        if self.config.use_sliding_window:
+            sliding_mask = create_4d_mask(
+                seq_len=seq_len,
+                dtype=hidden_states.dtype,
+                sliding_window=self.config.sliding_window,
+                is_sliding_window=True,
+                is_causal=False,
+            )
 
-        # Cross-attention mask
-        # Note: The PyTorch implementation ignores the encoder_attention_mask input
-        # and creates a bidirectional mask allowing all positions to attend.
-        # We match this behavior by setting cross_attn_mask to None (no masking).
-        cross_attn_mask = None
-
-        # Pass through DiT layers
         for layer_idx, layer in enumerate(self.layers):
             layer_type = self.config.layer_types[layer_idx]
-
-            # Use sliding window mask for sliding attention layers
-            if layer_type == "sliding_attention" and self.config.use_sliding_window:
-                layer_mask = create_4d_mask(
-                    seq_len=seq_len,
-                    dtype=hidden_states.dtype,
-                    attention_mask=None,  # All positions valid after patching
-                    sliding_window=self.config.sliding_window,
-                    is_sliding_window=True,
-                    is_causal=False,
-                )
-            else:
-                layer_mask = self_attn_mask
+            layer_mask = sliding_mask if layer_type == "sliding_attention" else None
 
             # Get cache for this layer (KVCache auto-populates on first use)
             layer_cache = cache[layer_idx] if cache is not None else None

--- a/mlx_audio/tts/models/ace_step/dit.py
+++ b/mlx_audio/tts/models/ace_step/dit.py
@@ -232,7 +232,7 @@ class DiTModel(nn.Module):
                 timestep_proj,
                 attention_mask=layer_mask,
                 encoder_hidden_states=encoder_hidden_states,
-                encoder_attention_mask=cross_attn_mask,
+                encoder_attention_mask=None,
                 cache=layer_cache,
             )
 

--- a/mlx_audio/tts/models/ace_step/lm.py
+++ b/mlx_audio/tts/models/ace_step/lm.py
@@ -129,9 +129,9 @@ class ACEStepLM:
         """
         instruction = "Generate audio semantic tokens based on the given conditions"
 
-        # Format lyrics section
+        # Format lyrics section with language header
         if lyrics and lyrics.strip():
-            lyrics_section = f"# Lyrics\n{lyrics}"
+            lyrics_section = f"# Languages\n{language}\n\n# Lyrics\n{lyrics}"
         else:
             lyrics_section = "# Lyrics\n[instrumental]"
 

--- a/mlx_audio/tts/models/ace_step/lm.py
+++ b/mlx_audio/tts/models/ace_step/lm.py
@@ -144,6 +144,7 @@ class ACEStepLM:
 {lyrics_section}
 
 # Metas
+- language: {language}
 - duration: {duration} seconds
 <|endoftext|>
 """

--- a/mlx_audio/tts/models/ace_step/modules.py
+++ b/mlx_audio/tts/models/ace_step/modules.py
@@ -204,7 +204,6 @@ class Attention(nn.Module):
         sliding_window: Optional[int] = None,
     ):
         super().__init__()
-        self.hidden_size = hidden_size
         self.num_heads = num_attention_heads
         self.num_kv_heads = num_key_value_heads
         self.head_dim = head_dim
@@ -251,18 +250,14 @@ class Attention(nn.Module):
         """
         batch_size, seq_len, _ = hidden_states.shape
 
-        # Project queries
         queries = self.q_proj(hidden_states)
         queries = queries.reshape(batch_size, seq_len, self.num_heads, self.head_dim)
         queries = self.q_norm(queries)
-        queries = queries.transpose(0, 2, 1, 3)  # [B, H, S, D]
+        queries = queries.transpose(0, 2, 1, 3)
 
-        # For cross-attention with cache: skip K,V projection if already cached
         if self.is_cross_attention and cache is not None and cache.is_set:
-            # Reuse cached K,V (already projected and normalized)
             keys, values = cache.fetch()
         else:
-            # Determine key/value source
             if self.is_cross_attention and encoder_hidden_states is not None:
                 kv_input = encoder_hidden_states
                 kv_len = encoder_hidden_states.shape[1]
@@ -270,7 +265,6 @@ class Attention(nn.Module):
                 kv_input = hidden_states
                 kv_len = seq_len
 
-            # Project keys and values
             keys = self.k_proj(kv_input)
             values = self.v_proj(kv_input)
 
@@ -278,52 +272,36 @@ class Attention(nn.Module):
             values = values.reshape(
                 batch_size, kv_len, self.num_kv_heads, self.head_dim
             )
-
             keys = self.k_norm(keys)
-
-            keys = keys.transpose(0, 2, 1, 3)  # [B, H, S, D]
+            keys = keys.transpose(0, 2, 1, 3)
             values = values.transpose(0, 2, 1, 3)
 
-            # Apply RoPE for self-attention (not cross-attention)
+            # RoPE only for self-attention
             if position_embeddings is not None and not self.is_cross_attention:
                 cos, sin = position_embeddings
                 queries, keys = apply_rotary_pos_emb(queries, keys, cos, sin)
 
-            # Store in cache for cross-attention
             if self.is_cross_attention and cache is not None:
                 cache.update_and_fetch(keys, values)
 
         kv_len = keys.shape[2]
 
-        # Repeat KV heads for grouped query attention
         if self.num_kv_heads < self.num_heads:
             n_rep = self.num_heads // self.num_kv_heads
             keys = mx.repeat(keys, n_rep, axis=1)
             values = mx.repeat(values, n_rep, axis=1)
 
-        # ACE-Step turbo uses standard scaled dot-product attention (softmax)
-        # for both self-attention and cross-attention
-        # queries, keys, values: [B, H, S, D]
         scale = 1.0 / math.sqrt(self.head_dim)
-
-        # Compute attention scores
-        # scores: [B, H, seq_len, kv_len]
         scores = (queries @ keys.transpose(0, 1, 3, 2)) * scale
 
-        # Apply attention mask if provided
         if attention_mask is not None:
             scores = scores + attention_mask
 
-        # Softmax
         weights = mx.softmax(scores.astype(mx.float32), axis=-1).astype(queries.dtype)
+        output = weights @ values
 
-        # Apply to values
-        output = weights @ values  # [B, H, S, D]
-
-        # Reshape output
-        output = output.transpose(0, 2, 1, 3)  # [B, S, H, D]
+        output = output.transpose(0, 2, 1, 3)
         output = output.reshape(batch_size, seq_len, -1)
-
         output = self.o_proj(output)
 
         return output
@@ -407,7 +385,6 @@ class EncoderLayer(nn.Module):
         sliding_window: Optional[int] = None,
     ):
         super().__init__()
-        self.hidden_size = hidden_size
 
         self.self_attn = Attention(
             hidden_size=hidden_size,
@@ -475,7 +452,6 @@ class DiTLayer(nn.Module):
         sliding_window: Optional[int] = None,
     ):
         super().__init__()
-        self.hidden_size = hidden_size
         self.use_cross_attention = use_cross_attention
 
         # Self-attention

--- a/mlx_audio/tts/tests/test_ace_step.py
+++ b/mlx_audio/tts/tests/test_ace_step.py
@@ -1,0 +1,293 @@
+"""Tests for ACE-Step music generation model."""
+
+import unittest
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from mlx_audio.tts.models.ace_step.config import ModelConfig, TASK_TYPES
+from mlx_audio.tts.models.ace_step.modules import (
+    Attention,
+    DiTLayer,
+    EncoderLayer,
+    KVCache,
+    MLP,
+    RMSNorm,
+    RotaryEmbedding,
+    TimestepEmbedding,
+    create_4d_mask,
+    make_cache,
+)
+from mlx_audio.tts.models.ace_step.dit import DiTModel
+
+
+def tiny_config(**overrides):
+    """Create a small config for fast tests."""
+    defaults = dict(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_lyric_encoder_hidden_layers=1,
+        num_timbre_encoder_hidden_layers=1,
+        num_attention_pooler_hidden_layers=1,
+        in_channels=192,
+        patch_size=2,
+        audio_acoustic_hidden_dim=64,
+        text_hidden_dim=32,
+        timbre_hidden_dim=64,
+        timbre_fix_frame=10,
+        pool_window_size=5,
+        max_position_embeddings=512,
+        sliding_window=16,
+        layer_types=["sliding_attention", "full_attention"],
+    )
+    defaults.update(overrides)
+    return ModelConfig(**defaults)
+
+
+class TestConfig(unittest.TestCase):
+    def test_default_config(self):
+        config = ModelConfig()
+        self.assertEqual(config.model_type, "acestep")
+        self.assertEqual(config.hidden_size, 2048)
+        self.assertEqual(config.patch_size, 2)
+
+    def test_layer_types_auto_generated(self):
+        config = ModelConfig(num_hidden_layers=4)
+        self.assertEqual(len(config.layer_types), 4)
+
+    def test_task_types(self):
+        self.assertIn("text2music", TASK_TYPES)
+        self.assertIn("cover", TASK_TYPES)
+
+
+class TestKVCache(unittest.TestCase):
+    def test_empty_cache(self):
+        cache = KVCache()
+        self.assertFalse(cache.is_set)
+
+    def test_update_and_fetch(self):
+        cache = KVCache()
+        k = mx.ones((1, 4, 10, 16))
+        v = mx.ones((1, 4, 10, 16))
+        cache.update_and_fetch(k, v)
+        self.assertTrue(cache.is_set)
+        fetched_k, fetched_v = cache.fetch()
+        self.assertEqual(fetched_k.shape, k.shape)
+
+    def test_reset(self):
+        cache = KVCache()
+        cache.update_and_fetch(mx.ones((1, 4, 10, 16)), mx.ones((1, 4, 10, 16)))
+        cache.reset()
+        self.assertFalse(cache.is_set)
+
+
+class TestCreateMask(unittest.TestCase):
+    def test_bidirectional_no_mask(self):
+        # With no attention_mask and is_causal=False, should be all zeros
+        mask = create_4d_mask(seq_len=8, dtype=mx.float32, is_causal=False)
+        self.assertEqual(mask.shape, (1, 1, 8, 8))
+        np.testing.assert_allclose(np.array(mask), 0.0)
+
+    def test_causal_mask(self):
+        mask = create_4d_mask(seq_len=4, dtype=mx.float32, is_causal=True)
+        mask_np = np.array(mask)[0, 0]
+        # Upper triangle should be -inf (large negative)
+        self.assertTrue(mask_np[0, 1] < -1e8)
+        # Lower triangle and diagonal should be 0
+        self.assertEqual(mask_np[1, 0], 0.0)
+        self.assertEqual(mask_np[0, 0], 0.0)
+
+    def test_sliding_window_mask(self):
+        mask = create_4d_mask(
+            seq_len=8, dtype=mx.float32,
+            sliding_window=2, is_sliding_window=True, is_causal=False,
+        )
+        mask_np = np.array(mask)[0, 0]
+        # Adjacent positions should be visible (0)
+        self.assertEqual(mask_np[3, 3], 0.0)
+        self.assertEqual(mask_np[3, 4], 0.0)
+        # Distant positions should be masked
+        self.assertTrue(mask_np[0, 7] < -1e8)
+
+
+class TestRMSNorm(unittest.TestCase):
+    def test_output_shape(self):
+        norm = RMSNorm(32)
+        x = mx.random.normal((2, 10, 32))
+        out = norm(x)
+        self.assertEqual(out.shape, x.shape)
+
+
+class TestTimestepEmbedding(unittest.TestCase):
+    def test_output_shapes(self):
+        emb = TimestepEmbedding(in_channels=64, time_embed_dim=128)
+        t = mx.array([0.5, 0.8])
+        temb, proj = emb(t)
+        self.assertEqual(temb.shape, (2, 128))
+        self.assertEqual(proj.shape, (2, 6, 128))
+
+
+class TestRotaryEmbedding(unittest.TestCase):
+    def test_output_shapes(self):
+        rope = RotaryEmbedding(dim=16, max_position_embeddings=512)
+        x = mx.random.normal((1, 10, 64))
+        pos_ids = mx.arange(10)[None, :]
+        cos, sin = rope(x, pos_ids)
+        self.assertEqual(cos.shape[-1], 16)
+        self.assertEqual(sin.shape[-1], 16)
+
+
+class TestAttention(unittest.TestCase):
+    def test_self_attention(self):
+        attn = Attention(
+            hidden_size=64, num_attention_heads=4,
+            num_key_value_heads=2, head_dim=16,
+        )
+        x = mx.random.normal((1, 10, 64))
+        rope = RotaryEmbedding(16, 512)
+        pos_emb = rope(x, mx.arange(10)[None, :])
+        out = attn(x, position_embeddings=pos_emb)
+        self.assertEqual(out.shape, (1, 10, 64))
+
+    def test_cross_attention_with_cache(self):
+        attn = Attention(
+            hidden_size=64, num_attention_heads=4,
+            num_key_value_heads=2, head_dim=16,
+            is_cross_attention=True,
+        )
+        x = mx.random.normal((1, 10, 64))
+        enc = mx.random.normal((1, 20, 64))
+        cache = KVCache()
+
+        # First call populates cache
+        out1 = attn(x, encoder_hidden_states=enc, cache=cache)
+        self.assertTrue(cache.is_set)
+
+        # Second call reuses cache
+        out2 = attn(x, encoder_hidden_states=enc, cache=cache)
+        self.assertEqual(out1.shape, out2.shape)
+
+
+class TestMLP(unittest.TestCase):
+    def test_output_shape(self):
+        mlp = MLP(hidden_size=64, intermediate_size=128)
+        x = mx.random.normal((1, 10, 64))
+        out = mlp(x)
+        self.assertEqual(out.shape, (1, 10, 64))
+
+
+class TestDiTLayer(unittest.TestCase):
+    def test_forward(self):
+        layer = DiTLayer(
+            hidden_size=64, intermediate_size=128,
+            num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        )
+        x = mx.random.normal((1, 10, 64))
+        enc = mx.random.normal((1, 20, 64))
+        rope = RotaryEmbedding(16, 512)
+        pos_emb = rope(x, mx.arange(10)[None, :])
+        # timestep_proj: [batch, 6, hidden_size]
+        tp = mx.random.normal((1, 6, 64))
+
+        out = layer(x, pos_emb, tp, encoder_hidden_states=enc)
+        self.assertEqual(out.shape, (1, 10, 64))
+
+
+class TestDiTModel(unittest.TestCase):
+    def test_forward(self):
+        config = tiny_config()
+        dit = DiTModel(config)
+
+        B, T = 1, 10
+        hidden = mx.random.normal((B, T, 64))
+        enc = mx.random.normal((B, 20, 64))
+        ctx = mx.random.normal((B, T, 128))
+        t = mx.array([0.5])
+
+        out = dit(
+            hidden_states=hidden, timestep=t, timestep_r=t,
+            attention_mask=None, encoder_hidden_states=enc,
+            encoder_attention_mask=None, context_latents=ctx,
+        )
+        self.assertEqual(out.shape, (B, T, 64))
+
+    def test_with_cache(self):
+        config = tiny_config()
+        dit = DiTModel(config)
+        caches = make_cache(config.num_hidden_layers)
+
+        B, T = 1, 10
+        hidden = mx.random.normal((B, T, 64))
+        enc = mx.random.normal((B, 20, 64))
+        ctx = mx.random.normal((B, T, 128))
+        t = mx.array([0.5])
+
+        # First call populates cache
+        out1 = dit(
+            hidden_states=hidden, timestep=t, timestep_r=t,
+            attention_mask=None, encoder_hidden_states=enc,
+            encoder_attention_mask=None, context_latents=ctx,
+            cache=caches,
+        )
+        # Second call reuses cache
+        out2 = dit(
+            hidden_states=hidden, timestep=t, timestep_r=t,
+            attention_mask=None, encoder_hidden_states=enc,
+            encoder_attention_mask=None, context_latents=ctx,
+            cache=caches,
+        )
+        self.assertEqual(out1.shape, out2.shape)
+
+    def test_conv_transpose1d_matches_non_overlapping(self):
+        """Verify transposed conv produces correct output length."""
+        config = tiny_config()
+        dit = DiTModel(config)
+
+        B, T = 1, 6
+        x = mx.random.normal((B, T, 64))
+        out = dit._conv_transpose1d_forward(
+            x, dit.proj_out_weight, dit.proj_out_bias, config.patch_size
+        )
+        self.assertEqual(out.shape, (B, T * config.patch_size, 64))
+
+
+class TestModelSanitize(unittest.TestCase):
+    def test_dit_prefix_remap(self):
+        """Legacy 'dit.' prefix should be remapped to 'decoder.'."""
+        from mlx_audio.tts.models.ace_step.ace_step import Model
+
+        weights = {"dit.layers.0.self_attn.q_proj.weight": mx.ones((64, 64))}
+        sanitized = Model.sanitize(weights)
+        self.assertIn("decoder.layers.0.self_attn.q_proj.weight", sanitized)
+        self.assertNotIn("dit.layers.0.self_attn.q_proj.weight", sanitized)
+
+    def test_proj_in_rename_scoped_to_decoder(self):
+        """proj_in/proj_out renaming should only apply to decoder prefix."""
+        from mlx_audio.tts.models.ace_step.ace_step import Model
+
+        weights = {
+            "decoder.proj_in.weight": mx.ones((64, 2, 192)),
+            "detokenizer.proj_out.weight": mx.ones((64, 32)),
+        }
+        sanitized = Model.sanitize(weights)
+        # Decoder proj_in should be renamed to underscore
+        self.assertIn("decoder.proj_in_weight", sanitized)
+        # Detokenizer proj_out should NOT be renamed
+        self.assertIn("detokenizer.proj_out.weight", sanitized)
+
+    def test_scale_shift_table_unsqueeze(self):
+        """2D scale_shift_table should be expanded to 3D."""
+        from mlx_audio.tts.models.ace_step.ace_step import Model
+
+        weights = {"decoder.scale_shift_table": mx.ones((6, 64))}
+        sanitized = Model.sanitize(weights)
+        self.assertEqual(sanitized["decoder.scale_shift_table"].shape, (1, 6, 64))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mlx_audio/tts/utils.py
+++ b/mlx_audio/tts/utils.py
@@ -38,6 +38,8 @@ MODEL_REMAPPING = {
     "longcat": "longcat_audiodit",
     "omnivoice": "omnivoice",
     "melotts": "melotts",
+    "acestep": "ace_step",
+    "ace": "ace_step",
 }
 MAX_FILE_SIZE_GB = 5
 MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]


### PR DESCRIPTION
## Summary

Clean cherry-pick of ACE-Step fixes onto current `pc/add-ace`. Touches only ace_step model files + 2-line `MODEL_REMAPPING` addition.

- **Fix weight conversion**: Export all weight prefixes (tokenizer, detokenizer, null_condition_emb), keep correct key naming for decoder conv params, scope sanitize remapping to avoid breaking detokenizer
- **Fix model loading**: Add `acestep`/`ace` to `MODEL_REMAPPING` so the model resolves via `mlx_audio.tts.load()`
- **Enable LM hints for all tasks**: Turbo model requires 5Hz LM-generated audio codes to produce music. Without them, diffusion denoises to silence.
- **Default `use_lm=True`**: Required for the turbo model to produce audio
- **Default `num_steps=20`**: Vocals need more steps to resolve than 8
- **Simplify**: Remove 208 lines of dead code, cache attention masks (was recreated 240x per generation), strip narrating comments
- **Tests**: 22 unit tests covering config, KVCache, masks, attention, DiT, weight sanitization

## Benchmark (M4 Max, 4-bit quantized)

- 30s audio in ~25s (RTF 0.85x)
- Diffusion (20 steps): ~8s
- LM planning (0.6B): ~12s
- VAE decode: ~3.5s

## Converted models on HF

- [mlx-community/ACE-Step1.5-MLX](https://huggingface.co/mlx-community/ACE-Step1.5-MLX) — fp32
- [mlx-community/ACE-Step1.5-MLX-4bit](https://huggingface.co/mlx-community/ACE-Step1.5-MLX-4bit) — 4-bit

## Key finding

The turbo model's DiT was trained with LM-generated audio code hints as conditioning. Without them, `src_latents` is pure silence and the diffusion converges back to silence. The 5Hz LM acts as a planner that generates a song blueprint from the text prompt.

## Test plan

- [x] Instrumental generation (EDM, shanty, corporate, R&B) — works
- [x] English vocals (hip-hop, pop ballad, shanty) — works at 20 steps
- [x] Japanese vocals — works
- [x] 4-bit quantized model — works, faster than real-time
- [x] Unit tests (22 passing)

Replaces #651.