### PR TITLE
feat(voxtral_realtime): live input streaming with cooperative decode

### DIFF
--- a/docs/models/stt/voxtral-realtime.md
+++ b/docs/models/stt/voxtral-realtime.md
@@ -35,6 +35,49 @@ for chunk in model.generate("audio.wav", stream=True):
     print(chunk, end="", flush=True)
 ```
 
+### Live Input Streaming
+
+When the audio is arriving in real time (mic, WebSocket, network), feed
+samples as they become available instead of passing a completed array:
+
+```python
+import threading
+import numpy as np
+from mlx_audio.stt.models.voxtral_realtime.streaming import StreamingAudioSource
+
+source = StreamingAudioSource()
+
+def producer():
+    for chunk in capture_microphone_chunks():  # 16 kHz float32 np.ndarray
+        source.append(chunk)
+    source.close()
+
+threading.Thread(target=producer, daemon=True).start()
+
+for delta in model.generate_streaming(source):
+    print(delta, end="", flush=True)
+```
+
+For cooperative integrations (async servers, multiple concurrent
+streams) use the lower-level session API. `feed()` is a cheap
+thread-safe queue push; `step(max_decode_tokens=N)` runs a bounded
+unit of MLX work and returns the deltas emitted during that call.
+Releasing the MLX executor between `step()` calls lets another
+stream — or an LLM request — interleave on the same executor:
+
+```python
+session = model.create_streaming_session()
+
+# Producer side (any thread or asyncio task):
+session.feed(samples)           # cheap, non-blocking
+session.close()                 # end-of-stream signal
+
+# Consumer side (MLX executor thread):
+while not session.done:
+    for delta in session.step(max_decode_tokens=4):
+        emit(delta)
+```
+
 ### Adjusting Transcription Delay
 
 Lower delay values produce faster output but may reduce accuracy:

--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -824,6 +824,123 @@ async def stt_realtime_transcriptions(websocket: WebSocket):
             pass
 
 
+DEFAULT_REALTIME_MODEL = os.getenv(
+    "MLX_AUDIO_REALTIME_MODEL",
+    "mlx-community/Voxtral-Mini-4B-Realtime-2602-4bit",
+)
+
+
+@app.websocket("/v1/realtime")
+async def voxtral_realtime_ws(websocket: WebSocket):
+    """OpenAI Realtime API-compatible WebSocket endpoint for voxtral_realtime.
+
+    Protocol (subset):
+      client → server
+        { "type": "session.update", "session": {...} }           # optional
+        { "type": "input_audio_buffer.append", "audio": "<b64 PCM16>" }
+        { "type": "input_audio_buffer.commit", "final": true }   # flush+finish
+      server → client
+        { "type": "session.created", "session": {...} }
+        { "type": "response.audio_transcript.delta", "delta": "..." }
+        { "type": "response.audio_transcript.done", "text": "..." }
+        { "type": "error", "error": {"message": "..."} }
+
+    Model is selected via the ``?model=<repo>`` query string; defaults to
+    ``$MLX_AUDIO_REALTIME_MODEL`` or mlx-community's 4-bit checkpoint.
+    """
+    await websocket.accept()
+
+    model_name = websocket.query_params.get("model", DEFAULT_REALTIME_MODEL)
+    try:
+        model = model_provider.load_model(model_name)
+    except Exception as e:
+        await websocket.send_json({"type": "error", "error": {"message": f"load failed: {e}"}})
+        await websocket.close()
+        return
+
+    if not hasattr(model, "create_streaming_session"):
+        await websocket.send_json({
+            "type": "error",
+            "error": {"message": f"model {model_name!r} does not support streaming"},
+        })
+        await websocket.close()
+        return
+
+    temperature = 0.0
+    session = model.create_streaming_session(temperature=temperature)
+    full_text_parts: list[str] = []
+
+    async def drain_deltas(max_decode_tokens: int = 8) -> bool:
+        """Run one session.step off-loop, ship deltas. Returns session.done."""
+        deltas = await asyncio.to_thread(session.step, max_decode_tokens=max_decode_tokens)
+        for delta in deltas:
+            full_text_parts.append(delta)
+            await websocket.send_json({
+                "type": "response.audio_transcript.delta",
+                "delta": delta,
+            })
+        return session.done
+
+    async def send_done():
+        await websocket.send_json({
+            "type": "response.audio_transcript.done",
+            "text": "".join(full_text_parts),
+        })
+
+    await websocket.send_json({
+        "type": "session.created",
+        "session": {"model": model_name, "input_audio_format": "pcm16"},
+    })
+
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                await websocket.send_json({"type": "error", "error": {"message": "invalid JSON"}})
+                continue
+
+            msg_type = msg.get("type", "")
+
+            if msg_type == "session.update":
+                await websocket.send_json({"type": "session.updated"})
+
+            elif msg_type == "input_audio_buffer.append":
+                audio_b64 = msg.get("audio", "")
+                if not audio_b64:
+                    continue
+                pcm16 = np.frombuffer(base64.b64decode(audio_b64), dtype=np.int16)
+                samples = pcm16.astype(np.float32) / 32768.0
+                session.feed(samples)
+                # Opportunistic draining between chunks so deltas flow early.
+                await drain_deltas(max_decode_tokens=8)
+
+            elif msg_type == "input_audio_buffer.commit":
+                if msg.get("final"):
+                    session.close()
+                    while not await drain_deltas(max_decode_tokens=16):
+                        pass
+                    await send_done()
+                    # Start a fresh session for any subsequent utterance.
+                    session = model.create_streaming_session(temperature=temperature)
+                    full_text_parts = []
+
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        try:
+            await websocket.send_json({"type": "error", "error": {"message": str(e)}})
+        except Exception:
+            pass
+    finally:
+        try:
+            await websocket.close()
+        except Exception:
+            pass
+        mx.clear_cache()
+
+
 class MLXAudioStudioServer:
     def __init__(self, start_ui=False, log_dir="logs"):
         self.start_ui = start_ui

--- a/mlx_audio/stt/models/voxtral_realtime/config.py
+++ b/mlx_audio/stt/models/voxtral_realtime/config.py
@@ -1,8 +1,28 @@
 import inspect
+import math
 from dataclasses import dataclass, field
 from typing import Optional
 
 from mlx_audio.base import BaseModelArgs
+
+SAMPLE_RATE = 16000
+FRAME_RATE = 12.5
+HOP_LENGTH = 160
+RAW_AUDIO_LENGTH_PER_TOK = int(SAMPLE_RATE // FRAME_RATE)  # 1280
+AUDIO_LENGTH_PER_TOK = RAW_AUDIO_LENGTH_PER_TOK // HOP_LENGTH  # 8
+
+
+def _num_audio_tokens(audio_len: int) -> int:
+    if audio_len % HOP_LENGTH != 0:
+        audio_len = math.ceil(audio_len / HOP_LENGTH - 1)
+    else:
+        audio_len = audio_len // HOP_LENGTH
+    return math.ceil(audio_len / AUDIO_LENGTH_PER_TOK)
+
+
+def _num_delay_tokens(delay_ms: float) -> int:
+    delay_len = int(delay_ms / 1000.0 * SAMPLE_RATE)
+    return _num_audio_tokens(delay_len)
 
 
 @dataclass

--- a/mlx_audio/stt/models/voxtral_realtime/decoder.py
+++ b/mlx_audio/stt/models/voxtral_realtime/decoder.py
@@ -10,7 +10,8 @@
 
 Optimizations:
 - GQA handled natively by mx.fast.scaled_dot_product_attention (no repeat)
-- KV cache trimmed to sliding window size
+- KV cache is a ring buffer (mlx_lm RotatingKVCache) so steady-state decode
+  does O(1) in-place writes instead of rebuilding the cache every token
 - Single-token generation skips mask computation
 - RoPE inv_freq cached in attention module
 """
@@ -19,9 +20,9 @@ import math
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx_lm.models.cache import RotatingKVCache
 
 from .config import DecoderConfig
-from .encoder import _interleaved_rope
 
 
 def compute_time_embedding(
@@ -90,83 +91,47 @@ class DecoderAttention(nn.Module):
         self.wv = nn.Linear(config.dim, kv_dim, bias=False)
         self.wo = nn.Linear(q_dim, config.dim, bias=False)
 
-        # Cache RoPE inverse frequencies (constant across calls)
-        half_dim = config.head_dim // 2
-        self._rope_inv_freq = 1.0 / (
-            config.rope_theta
-            ** (mx.arange(0, config.head_dim, 2, dtype=mx.float32) / config.head_dim)
-        )
-
-    def _rope_freqs(self, positions):
-        """Compute cos/sin from cached inv_freq."""
-        angles = positions[:, None].astype(mx.float32) * self._rope_inv_freq[None, :]
-        return mx.cos(angles), mx.sin(angles)
-
-    def __call__(self, x, positions, cache=None):
+    def __call__(self, x, start_pos, cache=None):
         """
         Args:
             x: [seq, dim]
-            positions: [seq] position indices
-            cache: Optional (k_cache, v_cache, cache_pos_offset) tuple
+            start_pos: absolute position of the first token in ``x``
+            cache: Optional RotatingKVCache for this layer (state is mutated in place).
 
         Returns:
-            (output, new_cache) where new_cache is (k, v, pos_offset)
+            output tensor [seq, dim].
         """
         seq_len = x.shape[0]
         q = self.wq(x)
         k = self.wk(x)
         v = self.wv(x)
 
-        # RoPE with cached inv_freq
-        cos, sin = self._rope_freqs(positions)
-        q = _interleaved_rope(q, cos, sin, self.n_heads, self.head_dim)
-        k = _interleaved_rope(k, cos, sin, self.n_kv_heads, self.head_dim)
-
-        # Update KV cache
-        if cache is not None:
-            k_cache, v_cache, cache_pos_offset = cache
-            k = mx.concatenate([k_cache, k], axis=0)
-            v = mx.concatenate([v_cache, v], axis=0)
-        else:
-            cache_pos_offset = 0
-
-        kv_len = k.shape[0]
-
-        # Trim KV cache to sliding window (bounds memory + computation)
-        if kv_len > self.sliding_window:
-            trim = kv_len - self.sliding_window
-            k = k[trim:]
-            v = v[trim:]
-            cache_pos_offset += trim
-            kv_len = self.sliding_window
-
-        # Save cache in flat 2D form BEFORE reshaping to 4D for attention.
-        # This ensures next call's concatenation works (both sides are 2D).
-        new_cache = (k, v, cache_pos_offset)
-
-        # Reshape for attention: [1, heads, seq, head_dim]
+        # Reshape to [B=1, n_heads, seq, head_dim] for fused RoPE + SDPA kernels.
         q = q.reshape(1, seq_len, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
-        k = k.reshape(1, kv_len, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
-        v = v.reshape(1, kv_len, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = k.reshape(1, seq_len, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(1, seq_len, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
 
-        # GQA: mx.fast.scaled_dot_product_attention handles n_heads != n_kv_heads
-        # natively via internal broadcast — no mx.repeat needed.
+        # Fused RoPE kernel (GPT-J style = traditional=True interleaved pairs).
+        q = mx.fast.rope(
+            q, self.head_dim, traditional=True, base=self.rope_theta,
+            scale=1.0, offset=start_pos,
+        )
+        k = mx.fast.rope(
+            k, self.head_dim, traditional=True, base=self.rope_theta,
+            scale=1.0, offset=start_pos,
+        )
 
-        # Mask: for single-token generation (seq_len=1), all KV entries are
-        # in the past and within the sliding window (already trimmed above),
-        # so no mask is needed. For prefill (seq_len > 1), apply causal mask.
-        if seq_len == 1:
-            mask = None
-        elif seq_len <= self.sliding_window and cache is None:
-            # Use SDPA's optimized causal kernel (avoids materializing T*T mask)
-            mask = "causal"
+        if cache is not None:
+            k, v = cache.update_and_fetch(k, v)
+            # update_and_fetch returns the view of the ring buffer containing
+            # all tokens still in the sliding window (bounded by max_size).
+            if seq_len == 1:
+                mask = None
+            else:
+                mask = cache.make_mask(seq_len, window_size=self.sliding_window)
         else:
-            # Full position-based mask needed when sliding window is active
-            q_pos = positions[:, None]  # [seq_q, 1]
-            k_pos = mx.arange(cache_pos_offset, cache_pos_offset + kv_len)[None, :]
-            causal = k_pos <= q_pos
-            window = k_pos >= (q_pos - self.sliding_window + 1)
-            mask = mx.where(causal & window, mx.array(0.0), mx.array(-1e9))
+            # No cache: either prefill without caching, or encoder-style one-shot.
+            mask = "causal" if seq_len > 1 else None
 
         attn_out = mx.fast.scaled_dot_product_attention(
             q, k, v, scale=self.scale, mask=mask
@@ -177,7 +142,7 @@ class DecoderAttention(nn.Module):
             seq_len, self.n_heads * self.head_dim
         )
 
-        return self.wo(attn_out), new_cache
+        return self.wo(attn_out)
 
 
 class DecoderLayer(nn.Module):
@@ -201,10 +166,10 @@ class DecoderLayer(nn.Module):
         self.feed_forward_w3 = nn.Linear(config.dim, config.hidden_dim, bias=False)
         self.feed_forward_w2 = nn.Linear(config.hidden_dim, config.dim, bias=False)
 
-    def __call__(self, x, positions, ada_scale=None, cache=None):
-        # Attention
+    def __call__(self, x, start_pos, ada_scale=None, cache=None):
+        # Attention (cache is mutated in place by RotatingKVCache.update_and_fetch)
         h = self.attention_norm(x)
-        h, new_cache = self.attention(h, positions, cache=cache)
+        h = self.attention(h, start_pos, cache=cache)
         x = x + h
 
         # FFN with adaptive norm
@@ -216,7 +181,7 @@ class DecoderLayer(nn.Module):
         up = self.feed_forward_w3(h)
         x = x + self.feed_forward_w2(gate * up)
 
-        return x, new_cache
+        return x
 
 
 class Decoder(nn.Module):
@@ -243,10 +208,18 @@ class Decoder(nn.Module):
         self._ada_scales = scales
 
     def embed_token(self, token_id: int) -> mx.array:
-        return self.tok_embeddings.weight[token_id]
+        """Look up the dequantized embedding for a single token id."""
+        return self.tok_embeddings(mx.array([token_id]))[0]
 
     def embed_tokens(self, token_ids: mx.array) -> mx.array:
         return self.tok_embeddings(token_ids)
+
+    def make_cache(self):
+        """Allocate a fresh per-layer ring-buffer KV cache sized to the sliding window."""
+        return [
+            RotatingKVCache(max_size=self.config.sliding_window, keep=0)
+            for _ in self.layers
+        ]
 
     def forward(self, embeds, start_pos=0, cache=None):
         """Run decoder forward.
@@ -254,25 +227,31 @@ class Decoder(nn.Module):
         Args:
             embeds: [seq, dim] input embeddings (audio_embed + tok_embed)
             start_pos: Starting position for RoPE
-            cache: List of (k, v, pos_offset) per layer, or None
+            cache: list of RotatingKVCache per layer. If None, a fresh cache is
+                allocated and returned; otherwise the provided caches are mutated
+                in place to avoid per-step reallocation.
 
         Returns:
-            (hidden_states, new_cache)
+            (hidden_states, cache) — cache is returned so callers can keep a
+            handle to the same list across steps.
         """
-        h = embeds
-        seq_len = h.shape[0]
-        positions = mx.arange(start_pos, start_pos + seq_len)
+        if cache is None:
+            cache = self.make_cache()
 
-        new_cache = []
+        h = embeds
         for i, layer in enumerate(self.layers):
-            layer_cache = cache[i] if cache is not None else None
             ada_scale = self._ada_scales[i] if self._ada_scales is not None else None
-            h, kv = layer(h, positions, ada_scale=ada_scale, cache=layer_cache)
-            new_cache.append(kv)
+            h = layer(h, start_pos, ada_scale=ada_scale, cache=cache[i])
 
         h = self.norm(h)
-        return h, new_cache
+        return h, cache
 
     def logits(self, h):
-        """Compute logits via tied embeddings: h @ tok_embeddings^T."""
-        return h @ self.tok_embeddings.weight.T
+        """Compute logits via tied embeddings.
+
+        Uses ``Embedding.as_linear`` so quantized and full-precision embeddings
+        both route through the right kernel (mx.quantized_matmul vs
+        ``h @ weight.T``). This is what makes the 4-bit tok-embedding path
+        actually fast.
+        """
+        return self.tok_embeddings.as_linear(h)

--- a/mlx_audio/stt/models/voxtral_realtime/encoder.py
+++ b/mlx_audio/stt/models/voxtral_realtime/encoder.py
@@ -2,16 +2,17 @@
 
 32-layer causal transformer with:
 - Causal conv1d stem (128 -> 1280, stride 1; 1280 -> 1280, stride 2)
-- Interleaved RoPE (theta=1M)
+- Interleaved RoPE (theta=1M), fused via mx.fast.rope
 - Sliding window attention (750)
 - SwiGLU FFN
 - Selective biases (wq/wv/wo yes, wk no; w2 only in FFN)
 - 4x downsample + adapter MLP
 
 Optimizations:
-- RoPE frequencies computed once and shared across all 32 layers
-- Attention mask computed once and shared across all 32 layers
-- Interleave via stack+reshape instead of indexed assignment
+- RoPE applied via the fused mx.fast.rope kernel (traditional=True) instead of
+  a Python interleave — matches the voxmlx path and avoids 32 layers' worth
+  of manual reshape/stack overhead per step.
+- Attention mask computed once per chunk and shared across all 32 layers.
 """
 
 import math
@@ -20,38 +21,6 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from .config import EncoderConfig
-
-
-def _interleaved_rope(x, cos, sin, n_heads, head_dim):
-    """Apply interleaved (GPT-J style) RoPE.
-
-    Rotates consecutive pairs: (x[0], x[1]), (x[2], x[3]), ...
-    x: [seq, n_heads * head_dim]
-    cos, sin: [seq, head_dim // 2]
-    """
-    seq_len = x.shape[0]
-    x = x.reshape(seq_len, n_heads, head_dim)
-    x1 = x[..., ::2]  # even indices
-    x2 = x[..., 1::2]  # odd indices
-    cos = cos[:, None, :]  # [seq, 1, hd/2]
-    sin = sin[:, None, :]
-    o1 = x1 * cos - x2 * sin
-    o2 = x2 * cos + x1 * sin
-    # Interleave back via stack (avoids indexed assignment on zeros)
-    out = mx.stack([o1, o2], axis=-1).reshape(seq_len, n_heads, head_dim)
-    return out.reshape(seq_len, n_heads * head_dim)
-
-
-def _compute_rope_freqs(positions, head_dim, theta):
-    """Compute cos/sin frequencies for RoPE.
-
-    positions: [seq_len] int array
-    Returns: (cos, sin) each [seq_len, head_dim // 2]
-    """
-    half_dim = head_dim // 2
-    freqs = 1.0 / (theta ** (mx.arange(0, head_dim, 2, dtype=mx.float32) / head_dim))
-    angles = positions[:, None].astype(mx.float32) * freqs[None, :]
-    return mx.cos(angles), mx.sin(angles)
 
 
 class CausalConv1d(nn.Module):
@@ -91,27 +60,33 @@ class EncoderAttention(nn.Module):
         self.wv = nn.Linear(config.dim, attn_dim, bias=True)
         self.wo = nn.Linear(attn_dim, config.dim, bias=True)
 
-    def __call__(self, x, rope_cos, rope_sin, mask, cache=None):
+    def __call__(self, x, rope_offset, mask, cache=None):
         """
         Args:
             x: [seq, dim]
-            rope_cos, rope_sin: precomputed [seq, head_dim // 2]
-            mask: precomputed additive mask, or "causal" string
-            cache: optional RotatingKVCache for chunked encoding
+            rope_offset: absolute position of the first token in ``x``.
+            mask: precomputed additive mask, or "causal" string.
+            cache: optional RotatingKVCache for chunked encoding.
         """
         seq_len = x.shape[0]
         q = self.wq(x)
         k = self.wk(x)
         v = self.wv(x)
 
-        # RoPE (using pre-computed frequencies)
-        q = _interleaved_rope(q, rope_cos, rope_sin, self.n_heads, self.head_dim)
-        k = _interleaved_rope(k, rope_cos, rope_sin, self.n_heads, self.head_dim)
-
         # Reshape for attention: [1, n_heads, seq, head_dim]
         q = q.reshape(1, seq_len, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
         k = k.reshape(1, seq_len, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
         v = v.reshape(1, seq_len, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+        # Fused RoPE (traditional=True = GPT-J style interleaved pairs).
+        q = mx.fast.rope(
+            q, self.head_dim, traditional=True, base=self.rope_theta,
+            scale=1.0, offset=rope_offset,
+        )
+        k = mx.fast.rope(
+            k, self.head_dim, traditional=True, base=self.rope_theta,
+            scale=1.0, offset=rope_offset,
+        )
 
         # Update KV cache if provided (for chunked encoding)
         if cache is not None:
@@ -141,10 +116,10 @@ class EncoderLayer(nn.Module):
         self.feed_forward_w3 = nn.Linear(config.dim, config.hidden_dim, bias=False)
         self.feed_forward_w2 = nn.Linear(config.hidden_dim, config.dim, bias=True)
 
-    def __call__(self, x, rope_cos, rope_sin, mask, cache=None):
+    def __call__(self, x, rope_offset, mask, cache=None):
         # Attention
         h = self.attention_norm(x)
-        h = self.attention(h, rope_cos, rope_sin, mask, cache=cache)
+        h = self.attention(h, rope_offset, mask, cache=cache)
         x = x + h
 
         # SwiGLU FFN
@@ -227,14 +202,11 @@ class AudioEncoder(nn.Module):
             x = conv_out[chunk_start:chunk_end]
             chunk_len = x.shape[0]
 
-            positions = mx.arange(chunk_start, chunk_end)
-            rope_cos, rope_sin = _compute_rope_freqs(
-                positions, self.config.head_dim, self.config.rope_theta
-            )
-
+            # The mask depends only on chunk_len + cache offset, not on the
+            # layer weights — compute it once and reuse across all 32 layers.
+            mask = caches[0].make_mask(chunk_len, window_size=sw)
             for i, layer in enumerate(self.transformer_layers):
-                mask = caches[i].make_mask(chunk_len, window_size=sw)
-                x = layer(x, rope_cos, rope_sin, mask, cache=caches[i])
+                x = layer(x, chunk_start, mask, cache=caches[i])
 
             yield self.transformer_norm(x)
 
@@ -268,14 +240,9 @@ class AudioEncoder(nn.Module):
         Returns:
             mx.array: [seq/4, decoder_dim] adapter output
         """
-        seq_len = conv_out.shape[0]
-        positions = mx.arange(seq_len)
-        rope_cos, rope_sin = _compute_rope_freqs(
-            positions, self.config.head_dim, self.config.rope_theta
-        )
         x = conv_out
         for layer in self.transformer_layers:
-            x = layer(x, rope_cos, rope_sin, "causal")
+            x = layer(x, 0, "causal")
         x = self.transformer_norm(x)
         return self.downsample_and_project(x)
 

--- a/mlx_audio/stt/models/voxtral_realtime/streaming.py
+++ b/mlx_audio/stt/models/voxtral_realtime/streaming.py
@@ -19,7 +19,6 @@ import mlx.nn as nn
 import numpy as np
 
 from .config import RAW_AUDIO_LENGTH_PER_TOK, _num_delay_tokens
-from .encoder import _compute_rope_freqs
 
 
 class StreamingAudioSource:
@@ -133,47 +132,47 @@ class StreamingMel:
         self._closed = True
         return self._drain(final=True)
 
-    def _get_sample(self, raw_idx: int) -> Optional[float]:
-        """Return raw audio value at global index, applying reflect padding.
+    def _extract_windows(self, k_start: int, k_end: int) -> Optional[np.ndarray]:
+        """Vectorized window extraction for a contiguous range of frames.
 
-        Returns None if the index cannot be resolved from available data.
+        Builds ``[n_frames, window_size]`` directly with numpy advanced indexing
+        — the previous per-frame Python loop over window_size (400) was 400
+        iterations per mel frame, costing single-digit milliseconds per 80 ms
+        realtime chunk and dominating the CPU side of the streaming pipeline.
+
+        Returns None if any frame in the range can't be resolved yet (e.g. the
+        right-reflect region isn't legal because we haven't closed).
         """
         N = self._n_received
-        if raw_idx < 0:
-            src = -raw_idx
-        elif raw_idx >= N:
-            src = 2 * N - 2 - raw_idx
-        else:
-            src = raw_idx
-        if src < 0 or src >= N:
+        n_frames = k_end - k_start
+        if n_frames <= 0:
             return None
-        buf_idx = src - self._buf_start
-        if buf_idx < 0 or buf_idx >= len(self._buf):
-            return None
-        return float(self._buf[buf_idx])
 
-    def _extract_window(self, k: int) -> Optional[np.ndarray]:
-        """Build the raw window for frame k using reflect padding where needed."""
-        start = k * self.hop_length - self.pad_size
-        out = np.empty(self.window_size, dtype=np.float32)
-        N = self._n_received
-        for i in range(self.window_size):
-            r = start + i
-            if r < 0:
-                src = -r
-            elif r >= N:
-                if not self._closed:
-                    return None  # right-reflect only allowed after close
-                src = 2 * N - 2 - r
-            else:
-                src = r
-            if src < 0 or src >= N:
-                return None
-            buf_idx = src - self._buf_start
-            if buf_idx < 0 or buf_idx >= len(self._buf):
-                return None
-            out[i] = self._buf[buf_idx]
-        return out
+        # Global raw indices for every (frame, sample) pair
+        frame_starts = np.arange(k_start, k_end) * self.hop_length - self.pad_size
+        offsets = np.arange(self.window_size)
+        r = frame_starts[:, None] + offsets[None, :]  # [n_frames, window_size]
+
+        # Reflect padding: left uses src = -r, right uses src = 2N-2-r
+        left_mask = r < 0
+        right_mask = r >= N
+
+        if right_mask.any() and not self._closed:
+            return None  # caller should wait for more audio / close()
+
+        src = np.where(left_mask, -r, np.where(right_mask, 2 * N - 2 - r, r))
+
+        # Any index still out of [0, N) signals a buffer gap (should not happen
+        # in normal use, but matches the conservative behavior of the previous
+        # scalar loop).
+        if ((src < 0) | (src >= N)).any():
+            return None
+
+        buf_idx = src - self._buf_start
+        if (buf_idx < 0).any() or (buf_idx >= len(self._buf)).any():
+            return None
+
+        return self._buf[buf_idx]  # [n_frames, window_size], float32 view/copy
 
     def _drain(self, *, final: bool) -> Optional[mx.array]:
         N = self._n_received
@@ -183,25 +182,15 @@ class StreamingMel:
         else:
             # No right-reflect allowed yet. Right-boundary rule:
             #   frame k needs raw[k*hop + pad - 1] in-range -> k*hop + pad <= N.
-            # _extract_window also guards the left-reflect requirement (raw[pad]
-            # at k=0 demands N > pad), which is tighter only for N in [pad, pad].
             max_k_inclusive = (N - self.pad_size) // self.hop_length
 
         if self._next_k > max_k_inclusive:
             return None
 
-        windows: list[np.ndarray] = []
-        while self._next_k <= max_k_inclusive:
-            w = self._extract_window(self._next_k)
-            if w is None:
-                break
-            windows.append(w)
-            self._next_k += 1
-
-        if not windows:
+        frames_np = self._extract_windows(self._next_k, max_k_inclusive + 1)
+        if frames_np is None:
             return None
-
-        frames_np = np.stack(windows, axis=0)  # [n_new, window_size]
+        self._next_k = max_k_inclusive + 1
         frames_mx = mx.array(frames_np, dtype=mx.float32) * self._window[None, :]
         spectrum = mx.fft.rfft(frames_mx, n=self.window_size, axis=-1)
         magnitudes = mx.abs(spectrum) ** 2  # [n_new, freq_bins]
@@ -326,13 +315,17 @@ class StreamingConvStem:
 
     def step(self, mel_chunk: mx.array) -> mx.array:
         """Process a mel chunk. mel_chunk: [mel_bins, n_frames]. Returns [n_out, dim]."""
+        # Cast mel to conv weight dtype (bf16) so the entire encoder/projection
+        # pipeline runs in bf16 instead of fp32. Keeping fp32 propagates all
+        # the way to the decoder input and forces the decoder forward to run
+        # in fp32 (~2x slower than bf16 on Apple Silicon).
+        target_dtype = self._c0.conv.conv.weight.dtype
         if mel_chunk.shape[1] == 0:
-            # Empty -> empty output at the right type
             return mx.zeros(
-                (0, self._c0.conv.conv.weight.shape[0]), dtype=mel_chunk.dtype
+                (0, self._c0.conv.conv.weight.shape[0]), dtype=target_dtype
             )
         # Match batch: conv_stem takes mel.T[None, :, :] ([1, frames, 128])
-        x = mel_chunk.T  # [frames, 128]
+        x = mel_chunk.T.astype(target_dtype)  # [frames, 128]
         x = self._c0.step(x)
         x = nn.gelu(x)
         x = self._c1.step(x)
@@ -371,22 +364,16 @@ class StreamingEncoder:
         if chunk_len == 0:
             return conv_chunk
 
-        positions = mx.arange(self._pos, self._pos + chunk_len)
-        rope_cos, rope_sin = _compute_rope_freqs(
-            positions, self.encoder.config.head_dim, self.encoder.config.rope_theta
+        # The mask only depends on chunk_len + the current KV offset, so build
+        # it once from cache[0] and share it across all 32 layers. Must be a
+        # materialized array: under streaming, K_len = Q_len + cache_size and
+        # SDPA's "causal" string shortcut is only valid when Q_len == K_len.
+        mask = self._caches[0].make_mask(
+            chunk_len, window_size=self._sw, return_array=True
         )
-
         x = conv_chunk
         for i, layer in enumerate(self.encoder.transformer_layers):
-            # Always materialize the mask as an array. SDPA's "causal" string
-            # shortcut is safe only when Q_len == K_len (full-chunk path);
-            # under streaming, K_len = Q_len + cache_size and we must provide
-            # an explicit mask aligned with the actual key count.
-            mask = self._caches[i].make_mask(
-                chunk_len, window_size=self._sw, return_array=True
-            )
-            x = layer(x, rope_cos, rope_sin, mask, cache=self._caches[i])
-
+            x = layer(x, self._pos, mask, cache=self._caches[i])
         out = self.encoder.transformer_norm(x)
         self._pos += chunk_len
         return out
@@ -615,7 +602,9 @@ class VoxtralStreamingSession:
 
         h, self._cache = self.model.decoder.forward(prefix_embeds, start_pos=0)
         logits = self.model.decoder.logits(h[-1])
-        cache_arrays = [t for lc in self._cache for t in lc[:2]]
+        cache_arrays = [
+            a for c in self._cache for a in (c.keys, c.values) if a is not None
+        ]
         mx.eval(logits, *cache_arrays)
         self._next_tok = self.model._next_token_mx(logits, self.temperature)
         mx.async_eval(self._next_tok)
@@ -623,6 +612,7 @@ class VoxtralStreamingSession:
     def _decode_some(self, max_decode_tokens: int) -> list[str]:
         deltas: list[str] = []
         eos = self.model.config.eos_token_id
+        tok_emb = self.model.decoder.tok_embeddings
 
         for _ in range(max_decode_tokens):
             # Before consuming the pending token, make sure we'll be able
@@ -632,39 +622,58 @@ class VoxtralStreamingSession:
             if self._n_adapter() <= self._pos and not self._flushed_close:
                 return deltas
 
-            token = int(self._next_tok.item())
+            if self._n_adapter() <= self._pos:
+                # Closed and out of audio: the right-pad (silence) tokens we
+                # appended at close() should already have let the model emit
+                # EOS. Flush the last pending token without further padding —
+                # matches voxmlx's finalize() behavior.
+                token = int(self._next_tok.item())
+                self.generated.append(token)
+                text_so_far = self.model._tokenizer.decode(
+                    [t for t in self.generated if t != eos]
+                )
+                if text_so_far != self._prev_text:
+                    deltas.append(text_so_far[len(self._prev_text):])
+                    self._prev_text = text_so_far
+                self._done = True
+                return deltas
+
+            # Dispatch the current forward BEFORE the .item() sync so the
+            # previous step's eval overlaps with the current step's compute
+            # queueing — this is the pipelining pattern voxmlx uses. We pass
+            # ``self._next_tok`` (an mx.array living on the GPU) directly to
+            # the embedding lookup instead of round-tripping via
+            # ``mx.array([int(token)])``, which would force a CPU→GPU sync
+            # on every step.
+            prev_tok_mx = self._next_tok  # shape [], argmax result
+            token_embed = tok_emb(prev_tok_mx.reshape(1))[0]
+            embed = self._adapter_at(self._pos) + token_embed
+
+            h, self._cache = self.model.decoder.forward(
+                embed[None, :], start_pos=self._pos, cache=self._cache
+            )
+            logits = self.model.decoder.logits(h.squeeze(0))
+            new_next_tok = self.model._next_token_mx(logits, self.temperature)
+            mx.async_eval(new_next_tok)
+
+            # Now read the PREVIOUS step's token from the GPU. This .item()
+            # only waits for the argmax from the prior iteration — the
+            # current iteration's forward is already queued.
+            token = int(prev_tok_mx.item())
             self.generated.append(token)
 
             text_so_far = self.model._tokenizer.decode(
                 [t for t in self.generated if t != eos]
             )
             if text_so_far != self._prev_text:
-                deltas.append(text_so_far[len(self._prev_text) :])
+                deltas.append(text_so_far[len(self._prev_text):])
                 self._prev_text = text_so_far
 
             if token == eos or len(self.generated) > self.max_tokens:
                 self._done = True
                 return deltas
 
-            if self._n_adapter() > self._pos:
-                embed = self._adapter_at(self._pos) + self.model.decoder.embed_token(
-                    token
-                )
-            else:
-                # Closed and out of audio: run a few trailing steps to
-                # let the decoder emit whatever is pending, then stop.
-                embed = self.model.decoder.embed_token(token)
-                self._trailing_after_close += 1
-                if self._trailing_after_close > 32:
-                    self._done = True
-                    return deltas
-
-            h, self._cache = self.model.decoder.forward(
-                embed[None, :], start_pos=self._pos, cache=self._cache
-            )
-            logits = self.model.decoder.logits(h.squeeze(0))
-            self._next_tok = self.model._next_token_mx(logits, self.temperature)
-            mx.async_eval(self._next_tok)
+            self._next_tok = new_next_tok
             self._pos += 1
             if len(self.generated) % 256 == 0:
                 mx.clear_cache()
@@ -688,9 +697,7 @@ class StreamingDownsampler:
     def step(self, encoded_chunk: mx.array) -> mx.array:
         """encoded_chunk: [n_frames, dim]. Returns adapter frames [n_out, decoder_dim]."""
         if encoded_chunk.shape[0] == 0:
-            return mx.zeros(
-                (0, self._dim), dtype=encoded_chunk.dtype
-            )  # dummy; caller ignores
+            return self._empty_adapter(encoded_chunk.dtype)
 
         if self._buf is not None and self._buf.shape[0] > 0:
             x = mx.concatenate([self._buf, encoded_chunk], axis=0)
@@ -709,5 +716,11 @@ class StreamingDownsampler:
         return projected
 
     def _empty_adapter(self, dtype) -> mx.array:
+        """Empty return that matches the adapter output dim (decoder dim, 3072).
+
+        Callers check ``shape[0] > 0`` so the second dim is never read today,
+        but keeping both zero-return paths consistent avoids a latent bug if
+        anything ever reshapes or concatenates these empties.
+        """
         proj_out_dim = self.encoder.audio_language_projection_2.weight.shape[0]
         return mx.zeros((0, proj_out_dim), dtype=dtype)

--- a/mlx_audio/stt/models/voxtral_realtime/streaming.py
+++ b/mlx_audio/stt/models/voxtral_realtime/streaming.py
@@ -5,9 +5,6 @@ Mirrors the batch mel/conv_stem path but accepts audio incrementally via
 raw audio has arrived. At close() the residual tail is flushed using
 right-reflect padding so the stream output matches the batch output
 sample-for-sample for any audio that is fully fed then closed.
-
-This module is additive. The existing batch path in audio.py/encoder.py
-is unchanged and still used by Model.generate().
 """
 
 from __future__ import annotations
@@ -21,6 +18,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
+from .config import RAW_AUDIO_LENGTH_PER_TOK, _num_delay_tokens
 from .encoder import _compute_rope_freqs
 
 
@@ -207,15 +205,8 @@ class StreamingMel:
         frames_mx = mx.array(frames_np, dtype=mx.float32) * self._window[None, :]
         spectrum = mx.fft.rfft(frames_mx, n=self.window_size, axis=-1)
         magnitudes = mx.abs(spectrum) ** 2  # [n_new, freq_bins]
-        # Batch drops the NYQUIST bin via magnitudes[:-1, :].T where the first
-        # axis is TIME. In our shape [n_new, freq_bins], the time axis is 0,
-        # so parity with batch requires us NOT to slice frames here (that
-        # happens via drop-last across the whole stream). But batch also
-        # slices axis 0 of [n_frames, n_freq] which is TIME. Recheck:
-        #   batch magnitudes = [n_frames, n_freq].
-        #   magnitudes[:-1, :] drops the LAST TIME frame. (drop-last rule)
-        # Our shape matches. We don't slice here; drop-last was applied
-        # already by max_k_inclusive when final=True.
+        # Drop-last (the batch path's magnitudes[:-1, :] over the TIME axis)
+        # is applied globally via max_k_inclusive when final=True, not here.
         mel_spec = magnitudes @ self.mel_filters  # [n_new, mel_bins]
         log_spec = mx.log10(mx.maximum(mel_spec, 1e-10))
         min_val = self.global_log_mel_max - 8.0
@@ -420,6 +411,32 @@ class VoxtralStreamingSession:
     (does MLX work and returns a bounded number of deltas) lets the
     caller release the MLX executor between ``step`` calls, so other
     MLX-bound work can be interleaved.
+
+    Parameters:
+        max_tokens: decode stop cap (total tokens per utterance).
+        temperature: sampling temperature (0 = greedy).
+        transcription_delay_ms: target decoder lag behind audio, i.e.
+            how much audio the encoder accumulates BEFORE the decoder
+            emits its first token. This is the core latency/quality
+            knob:
+              - Smaller (e.g. 160, 320 ms): deltas appear sooner but
+                the decoder has less acoustic context, so WER rises
+                and partial hypotheses flip more often.
+              - Larger (e.g. 640, 960 ms): more stable transcripts,
+                but each delta arrives that many ms after the word
+                was spoken.
+              - 2400 ms: per Mistral's recommended-settings table
+                (see ``config.py`` link), this is the high-latency
+                preset whose WER is within a fraction of a point of
+                the offline (non-streaming) mode — use it when you
+                need offline-grade quality but still want the
+                incremental-delta API (e.g. live captioning of
+                pre-recorded audio, or tolerant real-time flows).
+            Defaults to ``config.transcription_delay_ms`` (480 ms,
+            Mistral's sweet spot between latency and quality). This
+            also shifts the prompt length
+            (``1 + n_left + n_delay``) and the right pad injected at
+            ``close()``.
     """
 
     def __init__(
@@ -430,8 +447,6 @@ class VoxtralStreamingSession:
         temperature: float = 0.0,
         transcription_delay_ms: Optional[int] = None,
     ) -> None:
-        from .voxtral_realtime import RAW_AUDIO_LENGTH_PER_TOK, _num_delay_tokens
-
         self.model = model
         self.max_tokens = max_tokens
         self.temperature = temperature
@@ -508,6 +523,16 @@ class VoxtralStreamingSession:
         ready, then decodes up to ``max_decode_tokens`` tokens (stopping
         early if we catch up to the available audio). Returns a list of
         text deltas emitted during this call.
+
+        ``max_decode_tokens`` is the yield granularity, not a free
+        speedup: each call decodes at most that many tokens and then
+        returns so the caller can release the MLX executor for other
+        work. Smaller values (4-8) interleave more finely but pay
+        per-call overhead; larger values (32-64) amortize overhead but
+        hold the executor longer. Pick based on how often other MLX
+        tasks need to run; if decoding is the bottleneck, a higher
+        value is usually fine because interleaving can't create
+        compute that isn't there.
         """
         if self._done:
             return []

--- a/mlx_audio/stt/models/voxtral_realtime/streaming.py
+++ b/mlx_audio/stt/models/voxtral_realtime/streaming.py
@@ -1,0 +1,688 @@
+"""Streaming audio ingestion pipeline for Voxtral Realtime.
+
+Mirrors the batch mel/conv_stem path but accepts audio incrementally via
+.append(samples) and .close(). Frames are produced as soon as enough
+raw audio has arrived. At close() the residual tail is flushed using
+right-reflect padding so the stream output matches the batch output
+sample-for-sample for any audio that is fully fed then closed.
+
+This module is additive. The existing batch path in audio.py/encoder.py
+is unchanged and still used by Model.generate().
+"""
+
+from __future__ import annotations
+
+import math
+import queue
+import threading
+from typing import Iterator, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .encoder import _compute_rope_freqs
+
+
+class StreamingAudioSource:
+    """Thread-safe blocking queue of raw audio samples.
+
+    Producer side calls .append(np.ndarray) as audio arrives and .close()
+    when the stream ends. Consumer side calls .read() which blocks until
+    some samples are available OR the source is closed (whichever first).
+    .read() returns (samples, closed_flag). After close, subsequent reads
+    drain any buffered audio and then return (empty, True).
+    """
+
+    def __init__(self, sample_rate: int = 16000) -> None:
+        self.sample_rate = sample_rate
+        self._q: "queue.Queue[Optional[np.ndarray]]" = queue.Queue()
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def append(self, samples: np.ndarray) -> None:
+        if samples.size == 0:
+            return
+        if samples.dtype != np.float32:
+            samples = samples.astype(np.float32)
+        self._q.put(samples.reshape(-1).copy())
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        self._q.put(None)  # sentinel
+
+    def read(self, timeout: Optional[float] = None) -> tuple[np.ndarray, bool]:
+        """Block until samples are available or the source closes.
+
+        Returns (samples, closed). ``samples`` can be empty only when
+        ``closed`` is True. Drains any buffered chunks in a single call
+        so multiple small appends are coalesced before decoding runs.
+        """
+        try:
+            first = self._q.get(timeout=timeout)
+        except queue.Empty:
+            return np.zeros(0, dtype=np.float32), False
+        if first is None:
+            return np.zeros(0, dtype=np.float32), True
+
+        chunks: list[np.ndarray] = [first]
+        closed = False
+        while True:
+            try:
+                nxt = self._q.get_nowait()
+            except queue.Empty:
+                break
+            if nxt is None:
+                closed = True
+                break
+            chunks.append(nxt)
+        return np.concatenate(chunks), closed
+
+
+class StreamingMel:
+    """Incrementally compute log-mel spectrogram frames.
+
+    Parity contract with compute_mel_spectrogram(audio_all):
+        Feed the same samples through .append (in any chunking),
+        then .close(). Concatenating the returned per-call outputs
+        yields the same [mel_bins, frames] spectrogram (up to fp
+        rounding) as the batch call.
+    """
+
+    def __init__(
+        self,
+        mel_filters: mx.array,
+        window_size: int = 400,
+        hop_length: int = 160,
+        global_log_mel_max: float = 1.5,
+    ):
+        self.window_size = window_size
+        self.hop_length = hop_length
+        self.pad_size = window_size // 2
+        self.global_log_mel_max = global_log_mel_max
+        self.mel_filters = mel_filters  # [freq_bins, mel_bins]
+
+        n = mx.arange(window_size, dtype=mx.float32)
+        self._window = 0.5 * (1.0 - mx.cos(2.0 * math.pi * n / window_size))
+        mx.eval(self._window)
+
+        # Raw audio ring: _buf[0] corresponds to raw index _buf_start
+        self._buf: np.ndarray = np.zeros(0, dtype=np.float32)
+        self._buf_start: int = 0
+        self._n_received: int = 0
+        self._next_k: int = 0
+        self._closed: bool = False
+
+    def append(self, samples: np.ndarray) -> Optional[mx.array]:
+        """Append samples; return [mel_bins, n_new_frames] or None if no frame ready."""
+        if self._closed:
+            raise RuntimeError("StreamingMel is closed")
+        if samples.dtype != np.float32:
+            samples = samples.astype(np.float32)
+        if samples.ndim != 1:
+            samples = samples.reshape(-1)
+        self._buf = np.concatenate([self._buf, samples])
+        self._n_received += len(samples)
+        return self._drain(final=False)
+
+    def close(self) -> Optional[mx.array]:
+        """Close stream; flush trailing frames with right-reflect pad, apply drop-last."""
+        if self._closed:
+            return None
+        self._closed = True
+        return self._drain(final=True)
+
+    def _get_sample(self, raw_idx: int) -> Optional[float]:
+        """Return raw audio value at global index, applying reflect padding.
+
+        Returns None if the index cannot be resolved from available data.
+        """
+        N = self._n_received
+        if raw_idx < 0:
+            src = -raw_idx
+        elif raw_idx >= N:
+            src = 2 * N - 2 - raw_idx
+        else:
+            src = raw_idx
+        if src < 0 or src >= N:
+            return None
+        buf_idx = src - self._buf_start
+        if buf_idx < 0 or buf_idx >= len(self._buf):
+            return None
+        return float(self._buf[buf_idx])
+
+    def _extract_window(self, k: int) -> Optional[np.ndarray]:
+        """Build the raw window for frame k using reflect padding where needed."""
+        start = k * self.hop_length - self.pad_size
+        out = np.empty(self.window_size, dtype=np.float32)
+        N = self._n_received
+        for i in range(self.window_size):
+            r = start + i
+            if r < 0:
+                src = -r
+            elif r >= N:
+                if not self._closed:
+                    return None  # right-reflect only allowed after close
+                src = 2 * N - 2 - r
+            else:
+                src = r
+            if src < 0 or src >= N:
+                return None
+            buf_idx = src - self._buf_start
+            if buf_idx < 0 or buf_idx >= len(self._buf):
+                return None
+            out[i] = self._buf[buf_idx]
+        return out
+
+    def _drain(self, *, final: bool) -> Optional[mx.array]:
+        N = self._n_received
+        if final:
+            # Match batch: n_frames_raw = 1 + N//hop, then drop last -> N//hop frames.
+            max_k_inclusive = N // self.hop_length - 1
+        else:
+            # No right-reflect allowed yet. Right-boundary rule:
+            #   frame k needs raw[k*hop + pad - 1] in-range -> k*hop + pad <= N.
+            # _extract_window also guards the left-reflect requirement (raw[pad]
+            # at k=0 demands N > pad), which is tighter only for N in [pad, pad].
+            max_k_inclusive = (N - self.pad_size) // self.hop_length
+
+        if self._next_k > max_k_inclusive:
+            return None
+
+        windows: list[np.ndarray] = []
+        while self._next_k <= max_k_inclusive:
+            w = self._extract_window(self._next_k)
+            if w is None:
+                break
+            windows.append(w)
+            self._next_k += 1
+
+        if not windows:
+            return None
+
+        frames_np = np.stack(windows, axis=0)  # [n_new, window_size]
+        frames_mx = mx.array(frames_np, dtype=mx.float32) * self._window[None, :]
+        spectrum = mx.fft.rfft(frames_mx, n=self.window_size, axis=-1)
+        magnitudes = mx.abs(spectrum) ** 2  # [n_new, freq_bins]
+        # Batch drops the NYQUIST bin via magnitudes[:-1, :].T where the first
+        # axis is TIME. In our shape [n_new, freq_bins], the time axis is 0,
+        # so parity with batch requires us NOT to slice frames here (that
+        # happens via drop-last across the whole stream). But batch also
+        # slices axis 0 of [n_frames, n_freq] which is TIME. Recheck:
+        #   batch magnitudes = [n_frames, n_freq].
+        #   magnitudes[:-1, :] drops the LAST TIME frame. (drop-last rule)
+        # Our shape matches. We don't slice here; drop-last was applied
+        # already by max_k_inclusive when final=True.
+        mel_spec = magnitudes @ self.mel_filters  # [n_new, mel_bins]
+        log_spec = mx.log10(mx.maximum(mel_spec, 1e-10))
+        min_val = self.global_log_mel_max - 8.0
+        log_spec = mx.maximum(log_spec, min_val)
+        log_spec = (log_spec + 4.0) / 4.0
+        out = log_spec.T  # [mel_bins, n_new]
+        mx.eval(out)
+        return out
+
+    def trim(self, keep_from_raw_idx: int) -> None:
+        """Drop buffered samples with global index < keep_from_raw_idx.
+
+        Call sparingly; streaming only needs roughly window_size samples of
+        history at steady state, but right-reflect at close needs the tail.
+        """
+        keep_from_raw_idx = max(self._buf_start, keep_from_raw_idx)
+        drop = keep_from_raw_idx - self._buf_start
+        if drop > 0:
+            self._buf = self._buf[drop:]
+            self._buf_start += drop
+
+
+class StreamingCausalConv1d:
+    """Incremental causal Conv1d wrapper over an existing CausalConv1d module.
+
+    Reuses the weights of the wrapped module. Manages edge state between
+    calls so the concatenation of outputs equals the batch output for the
+    concatenation of inputs.
+
+    Usage:
+        sc = StreamingCausalConv1d(existing_causal_conv)
+        y0 = sc.step(x0)  # [n0_out, C_out]
+        y1 = sc.step(x1)
+        ...  # concat(y*) == existing_causal_conv(concat(x*))
+    """
+
+    def __init__(self, causal_conv):
+        self.conv = causal_conv  # CausalConv1d
+        self.kernel_size = causal_conv.kernel_size
+        self.stride = causal_conv.stride
+        self.left_pad = causal_conv.padding  # kernel - stride
+        # keep = (kernel - stride) is the state size we carry between calls.
+        self._keep = self.kernel_size - self.stride
+        self._state: Optional[mx.array] = None  # [n_state, C_in]
+        self._initialized = False
+
+    def step(self, x_new: mx.array) -> mx.array:
+        """Feed new input [n_new, C_in]; return output [n_out, C_out].
+
+        On the first call, the required left-pad of (kernel - stride) zeros
+        is prepended (matching CausalConv1d behavior). Subsequent calls reuse
+        the cached tail of prior inputs as left context.
+        """
+        if x_new.shape[0] == 0:
+            return x_new[:0]  # empty passthrough
+        if not self._initialized:
+            if self._keep > 0:
+                pad = mx.zeros((self._keep, x_new.shape[-1]), dtype=x_new.dtype)
+                context = mx.concatenate([pad, x_new], axis=0)
+            else:
+                context = x_new
+            self._initialized = True
+        else:
+            context = (
+                mx.concatenate([self._state, x_new], axis=0)
+                if self._state is not None
+                else x_new
+            )
+
+        # Call the inner nn.Conv1d directly to avoid the CausalConv1d wrapper
+        # re-adding its own left-pad.
+        out = self.conv.conv(context[None, :, :]).squeeze(0)  # [n_out, C_out]
+        n_out = out.shape[0]
+
+        # Save the last (kernel - stride) inputs as state. After this call the
+        # next kernel window will start exactly at position `n_out * stride`
+        # within the current context, leaving `context.shape[0] - n_out*stride`
+        # samples as "leftover", which must be (kernel - stride) by construction
+        # when the input stream has been packed with no gaps.
+        if self._keep > 0:
+            # Guard: if leftover < keep (early edge), save all.
+            leftover = context.shape[0] - n_out * self.stride
+            if leftover <= 0:
+                self._state = None
+            elif leftover >= self._keep:
+                self._state = context[-self._keep :]
+            else:
+                self._state = context[-leftover:]
+        else:
+            self._state = None
+
+        return out
+
+
+class StreamingConvStem:
+    """Streaming version of AudioEncoder.conv_stem.
+
+    Reuses the conv layer weights of an existing AudioEncoder. Feeds mel
+    frames in as they arrive, returns the corresponding conv_out frames.
+
+    Parity contract with AudioEncoder.conv_stem(mel_all):
+        Concatenating the per-call outputs of step(mel_chunk) equals
+        conv_stem(full_mel) *before* the `trunc` truncation (which is
+        applied to the total at the caller level when alignment is known).
+
+    Note: the front-trunc by downsample_factor in conv_stem is NOT applied
+    here because streaming can't know the final count. Callers are expected
+    to arrange input sizes so the total is already aligned (the standard
+    Voxtral padding aligns audio to 1280 samples = 8 mel frames, which
+    makes conv_stem output naturally divisible by 4).
+    """
+
+    def __init__(self, encoder):
+        # Bypass the CausalConv1d wrappers' internal left-pad; manage it ourselves.
+        self._c0 = StreamingCausalConv1d(encoder.conv_layers_0_conv)
+        self._c1 = StreamingCausalConv1d(encoder.conv_layers_1_conv)
+
+    def step(self, mel_chunk: mx.array) -> mx.array:
+        """Process a mel chunk. mel_chunk: [mel_bins, n_frames]. Returns [n_out, dim]."""
+        if mel_chunk.shape[1] == 0:
+            # Empty -> empty output at the right type
+            return mx.zeros(
+                (0, self._c0.conv.conv.weight.shape[0]), dtype=mel_chunk.dtype
+            )
+        # Match batch: conv_stem takes mel.T[None, :, :] ([1, frames, 128])
+        x = mel_chunk.T  # [frames, 128]
+        x = self._c0.step(x)
+        x = nn.gelu(x)
+        x = self._c1.step(x)
+        x = nn.gelu(x)
+        return x  # [out_frames, dim]
+
+
+class StreamingEncoder:
+    """Streaming wrapper over AudioEncoder transformer layers.
+
+    Reuses encoder weights; maintains a RotatingKVCache (max_size=sw) per
+    layer and a running RoPE position. Each step() call processes a chunk
+    of conv_out and returns the corresponding post-norm encoder output.
+
+    Parity contract with AudioEncoder.encode_chunks(conv_out_all):
+        Concatenating the per-call outputs of step(conv_chunk) equals
+        concatenating the yields of encode_chunks(full_conv_out), for any
+        chunking of the inputs (including chunk sizes smaller than the
+        sliding window).
+    """
+
+    def __init__(self, encoder):
+        from mlx_lm.models.cache import RotatingKVCache
+
+        self.encoder = encoder
+        self._sw = encoder.config.sliding_window
+        self._caches = [
+            RotatingKVCache(max_size=self._sw, keep=0)
+            for _ in range(len(encoder.transformer_layers))
+        ]
+        self._pos = 0  # global position for RoPE
+
+    def step(self, conv_chunk: mx.array) -> mx.array:
+        """conv_chunk: [n_frames, dim] -> encoded: [n_frames, dim]."""
+        chunk_len = conv_chunk.shape[0]
+        if chunk_len == 0:
+            return conv_chunk
+
+        positions = mx.arange(self._pos, self._pos + chunk_len)
+        rope_cos, rope_sin = _compute_rope_freqs(
+            positions, self.encoder.config.head_dim, self.encoder.config.rope_theta
+        )
+
+        x = conv_chunk
+        for i, layer in enumerate(self.encoder.transformer_layers):
+            # Always materialize the mask as an array. SDPA's "causal" string
+            # shortcut is safe only when Q_len == K_len (full-chunk path);
+            # under streaming, K_len = Q_len + cache_size and we must provide
+            # an explicit mask aligned with the actual key count.
+            mask = self._caches[i].make_mask(
+                chunk_len, window_size=self._sw, return_array=True
+            )
+            x = layer(x, rope_cos, rope_sin, mask, cache=self._caches[i])
+
+        out = self.encoder.transformer_norm(x)
+        self._pos += chunk_len
+        return out
+
+
+class VoxtralStreamingSession:
+    """Stateful streaming transcription session.
+
+    Usage pattern:
+        sess = model.create_streaming_session(...)
+        # producer thread / async task
+        sess.feed(samples_np)          # cheap, thread-safe
+        sess.feed(more_samples)
+        sess.close()                   # end-of-stream
+
+        # consumer thread (MLX executor)
+        while not sess.done:
+            deltas = sess.step(max_decode_tokens=4)
+            for d in deltas: emit(d)
+
+    The split between ``feed`` (just queues raw samples) and ``step``
+    (does MLX work and returns a bounded number of deltas) lets the
+    caller release the MLX executor between ``step`` calls, so other
+    MLX-bound work can be interleaved.
+    """
+
+    def __init__(
+        self,
+        model,
+        *,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+        transcription_delay_ms: Optional[int] = None,
+    ) -> None:
+        from .voxtral_realtime import RAW_AUDIO_LENGTH_PER_TOK, _num_delay_tokens
+
+        self.model = model
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+
+        cfg = model.config
+        delay_ms = transcription_delay_ms or cfg.transcription_delay_ms
+        self._n_delay = _num_delay_tokens(delay_ms)
+        self._n_left = cfg.n_left_pad_tokens
+        self._prompt_len = 1 + self._n_left + self._n_delay
+        self._raw_tok = RAW_AUDIO_LENGTH_PER_TOK
+
+        model._ensure_ada_scales(transcription_delay_ms)
+
+        aec = cfg.audio_encoding_args
+        mel_filters = model._ensure_mel_filters()
+        self._smel = StreamingMel(
+            mel_filters,
+            window_size=aec.window_size,
+            hop_length=aec.hop_length,
+            global_log_mel_max=aec.global_log_mel_max,
+        )
+        self._mel_filters = mel_filters
+        self._aec = aec
+        self._sconv = StreamingConvStem(model.encoder)
+        self._senc = StreamingEncoder(model.encoder)
+        self._sproj = StreamingDownsampler(model.encoder)
+
+        self._audio_q: list[np.ndarray] = []
+        self._audio_lock = threading.Lock()
+        self._audio_closed = False
+        self._flushed_close = False
+
+        self._adapter_frames: list[mx.array] = []
+        self._prefilled = False
+        self._cache = None
+        self._next_tok: Optional[mx.array] = None
+        self._pos = self._prompt_len
+        self.generated: list[int] = []
+        self._prev_text = ""
+        self._trailing_after_close = 0
+        self._done = False
+        self._left_pad_seeded = False
+
+    @property
+    def done(self) -> bool:
+        return self._done
+
+    def feed(self, samples: np.ndarray) -> None:
+        """Queue raw audio samples; cheap and thread-safe.
+
+        No MLX work happens here — samples are just buffered. The actual
+        mel/encoder work runs inside ``step()``.
+        """
+        if samples is None:
+            return
+        if not isinstance(samples, np.ndarray):
+            samples = np.asarray(samples, dtype=np.float32)
+        if samples.dtype != np.float32:
+            samples = samples.astype(np.float32)
+        if samples.size == 0:
+            return
+        with self._audio_lock:
+            self._audio_q.append(samples.reshape(-1))
+
+    def close(self) -> None:
+        """Signal end-of-audio; safe to call from any thread."""
+        with self._audio_lock:
+            self._audio_closed = True
+
+    def step(self, *, max_decode_tokens: int = 4) -> list[str]:
+        """Run one unit of MLX work. Call from the MLX executor thread.
+
+        Drains pending audio into the encoder pipeline, runs prefill if
+        ready, then decodes up to ``max_decode_tokens`` tokens (stopping
+        early if we catch up to the available audio). Returns a list of
+        text deltas emitted during this call.
+        """
+        if self._done:
+            return []
+
+        self._ingest_pending()
+
+        if not self._prefilled:
+            if self._n_adapter() < self._prompt_len:
+                if self._flushed_close:
+                    # Closed before we could prefill anything.
+                    self._done = True
+                return []
+            self._do_prefill()
+            self._prefilled = True
+
+        return self._decode_some(max_decode_tokens)
+
+    def _ingest_pending(self) -> None:
+        """Drain audio queue; also seed left-pad and handle close flush."""
+        if not self._left_pad_seeded:
+            left_pad = np.zeros(self._n_left * self._raw_tok, dtype=np.float32)
+            self._ingest_mel(self._smel.append(left_pad))
+            self._left_pad_seeded = True
+
+        while True:
+            with self._audio_lock:
+                if not self._audio_q:
+                    closed = self._audio_closed
+                    break
+                chunk = self._audio_q.pop(0)
+            self._ingest_mel(self._smel.append(chunk))
+
+        if closed and not self._flushed_close:
+            self._flushed_close = True
+            right_pad_toks = (self._n_delay + 1) + 10
+            right_pad = np.zeros(right_pad_toks * self._raw_tok, dtype=np.float32)
+            self._ingest_mel(self._smel.append(right_pad))
+            self._ingest_mel(self._smel.close())
+
+    def _ingest_mel(self, mel_chunk: Optional[mx.array]) -> None:
+        if mel_chunk is None or mel_chunk.shape[1] == 0:
+            return
+        conv_out = self._sconv.step(mel_chunk)
+        if conv_out.shape[0] == 0:
+            return
+        encoded = self._senc.step(conv_out)
+        adapter = self._sproj.step(encoded)
+        if adapter.shape[0] > 0:
+            mx.eval(adapter)
+            self._adapter_frames.append(adapter)
+
+    def _n_adapter(self) -> int:
+        return sum(a.shape[0] for a in self._adapter_frames)
+
+    def _coalesce_adapter(self) -> mx.array:
+        if len(self._adapter_frames) > 1:
+            merged = mx.concatenate(self._adapter_frames, axis=0)
+            mx.eval(merged)
+            self._adapter_frames = [merged]
+        return self._adapter_frames[0]
+
+    def _adapter_at(self, pos: int) -> mx.array:
+        if len(self._adapter_frames) > 8:
+            self._coalesce_adapter()
+        offset = 0
+        for piece in self._adapter_frames:
+            if pos < offset + piece.shape[0]:
+                return piece[pos - offset]
+            offset += piece.shape[0]
+        raise IndexError(f"pos={pos} out of adapter range (have {offset})")
+
+    def _do_prefill(self) -> None:
+        adapter_concat = self._coalesce_adapter()
+        prompt_ids = [self.model.config.bos_token_id] + [
+            self.model.config.streaming_pad_token_id
+        ] * (self._n_left + self._n_delay)
+        prompt_ids_mx = mx.array(prompt_ids)
+        prompt_text_embeds = self.model.decoder.embed_tokens(prompt_ids_mx)
+        prefix_embeds = adapter_concat[: self._prompt_len] + prompt_text_embeds
+
+        h, self._cache = self.model.decoder.forward(prefix_embeds, start_pos=0)
+        logits = self.model.decoder.logits(h[-1])
+        cache_arrays = [t for lc in self._cache for t in lc[:2]]
+        mx.eval(logits, *cache_arrays)
+        self._next_tok = self.model._next_token_mx(logits, self.temperature)
+        mx.async_eval(self._next_tok)
+
+    def _decode_some(self, max_decode_tokens: int) -> list[str]:
+        deltas: list[str] = []
+        eos = self.model.config.eos_token_id
+
+        for _ in range(max_decode_tokens):
+            # Before consuming the pending token, make sure we'll be able
+            # to run a forward pass for it (which needs adapter[pos] while
+            # audio is still flowing). If neither adapter nor close is
+            # ready, return and let the caller feed more audio.
+            if self._n_adapter() <= self._pos and not self._flushed_close:
+                return deltas
+
+            token = int(self._next_tok.item())
+            self.generated.append(token)
+
+            text_so_far = self.model._tokenizer.decode(
+                [t for t in self.generated if t != eos]
+            )
+            if text_so_far != self._prev_text:
+                deltas.append(text_so_far[len(self._prev_text) :])
+                self._prev_text = text_so_far
+
+            if token == eos or len(self.generated) > self.max_tokens:
+                self._done = True
+                return deltas
+
+            if self._n_adapter() > self._pos:
+                embed = self._adapter_at(self._pos) + self.model.decoder.embed_token(
+                    token
+                )
+            else:
+                # Closed and out of audio: run a few trailing steps to
+                # let the decoder emit whatever is pending, then stop.
+                embed = self.model.decoder.embed_token(token)
+                self._trailing_after_close += 1
+                if self._trailing_after_close > 32:
+                    self._done = True
+                    return deltas
+
+            h, self._cache = self.model.decoder.forward(
+                embed[None, :], start_pos=self._pos, cache=self._cache
+            )
+            logits = self.model.decoder.logits(h.squeeze(0))
+            self._next_tok = self.model._next_token_mx(logits, self.temperature)
+            mx.async_eval(self._next_tok)
+            self._pos += 1
+            if len(self.generated) % 256 == 0:
+                mx.clear_cache()
+
+        return deltas
+
+
+class StreamingDownsampler:
+    """Buffers encoder output frames and emits adapter-projected frames in
+    downsample_factor-aligned groups.
+
+    Reuses audio_language_projection weights of an AudioEncoder.
+    """
+
+    def __init__(self, encoder):
+        self.encoder = encoder
+        self._ds = encoder.config.downsample_factor
+        self._dim = encoder.config.dim
+        self._buf: Optional[mx.array] = None  # [n, dim] pending frames
+
+    def step(self, encoded_chunk: mx.array) -> mx.array:
+        """encoded_chunk: [n_frames, dim]. Returns adapter frames [n_out, decoder_dim]."""
+        if encoded_chunk.shape[0] == 0:
+            return mx.zeros(
+                (0, self._dim), dtype=encoded_chunk.dtype
+            )  # dummy; caller ignores
+
+        if self._buf is not None and self._buf.shape[0] > 0:
+            x = mx.concatenate([self._buf, encoded_chunk], axis=0)
+        else:
+            x = encoded_chunk
+
+        n = x.shape[0]
+        usable = n - (n % self._ds)
+        if usable == 0:
+            self._buf = x
+            return self._empty_adapter(encoded_chunk.dtype)
+        to_project = x[:usable]
+        self._buf = x[usable:] if usable < n else None
+
+        projected = self.encoder.downsample_and_project(to_project)
+        return projected
+
+    def _empty_adapter(self, dtype) -> mx.array:
+        proj_out_dim = self.encoder.audio_language_projection_2.weight.shape[0]
+        return mx.zeros((0, proj_out_dim), dtype=dtype)

--- a/mlx_audio/stt/models/voxtral_realtime/voxtral_realtime.py
+++ b/mlx_audio/stt/models/voxtral_realtime/voxtral_realtime.py
@@ -341,6 +341,73 @@ class Model(nn.Module):
             generation_tps=len(generated) / decode_time if decode_time > 0 else 0,
         )
 
+    def create_streaming_session(
+        self,
+        *,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+        transcription_delay_ms: Optional[int] = None,
+    ):
+        """Create a stateful streaming session for this model.
+
+        Returns a ``VoxtralStreamingSession`` whose ``feed()`` is a cheap
+        thread-safe queue push (safe to call from an asyncio loop), and
+        whose ``step()`` / ``finalize_step()`` run one short unit of MLX
+        work. Call ``step()`` repeatedly from an executor thread between
+        audio feeds; between calls the executor is free for other work.
+        """
+        from .streaming import VoxtralStreamingSession
+
+        return VoxtralStreamingSession(
+            self,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            transcription_delay_ms=transcription_delay_ms,
+        )
+
+    def generate_streaming(
+        self,
+        source,
+        *,
+        max_tokens: int = 4096,
+        temperature: float = 0.0,
+        verbose: bool = False,
+        transcription_delay_ms: Optional[int] = None,
+    ):
+        """Yield text deltas while audio is streamed in from ``source``.
+
+        Thin wrapper around ``create_streaming_session`` that consumes the
+        ``StreamingAudioSource`` in the calling thread (held for the life
+        of the generation). For cooperative integrations that need to
+        interleave MLX work with other tasks, prefer building your own
+        loop on top of ``create_streaming_session`` instead.
+        """
+        sess = self.create_streaming_session(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            transcription_delay_ms=transcription_delay_ms,
+        )
+
+        start_time = time.time()
+        while True:
+            samples, closed = source.read()
+            if samples.size > 0:
+                sess.feed(samples)
+            if closed:
+                sess.close()
+            for delta in sess.step(max_decode_tokens=16):
+                yield delta
+            if sess.done:
+                break
+
+        if verbose:
+            total = time.time() - start_time
+            print(
+                f"Streaming generate: {len(sess.generated)} tokens in {total:.3f}s "
+                f"({len(sess.generated) / total:.0f} tok/s)"
+            )
+        mx.clear_cache()
+
     def _generate_stream(
         self, audio_np, max_tokens, temperature, verbose, transcription_delay_ms=None
     ):

--- a/mlx_audio/stt/models/voxtral_realtime/voxtral_realtime.py
+++ b/mlx_audio/stt/models/voxtral_realtime/voxtral_realtime.py
@@ -25,30 +25,19 @@ import numpy as np
 
 from ..base import STTOutput
 from .audio import compute_mel_filters, compute_mel_spectrogram
-from .config import ModelConfig
+from .config import (
+    AUDIO_LENGTH_PER_TOK,
+    FRAME_RATE,
+    HOP_LENGTH,
+    RAW_AUDIO_LENGTH_PER_TOK,
+    SAMPLE_RATE,
+    ModelConfig,
+    _num_audio_tokens,
+    _num_delay_tokens,
+)
 from .decoder import Decoder, compute_time_embedding
 from .encoder import AudioEncoder
 from .tokenizer import TekkenTokenizer
-
-# Derived streaming constants
-SAMPLE_RATE = 16000
-FRAME_RATE = 12.5
-RAW_AUDIO_LENGTH_PER_TOK = int(SAMPLE_RATE // FRAME_RATE)  # 1280
-HOP_LENGTH = 160
-AUDIO_LENGTH_PER_TOK = RAW_AUDIO_LENGTH_PER_TOK // HOP_LENGTH  # 8
-
-
-def _num_audio_tokens(audio_len):
-    if audio_len % HOP_LENGTH != 0:
-        audio_len = math.ceil(audio_len / HOP_LENGTH - 1)
-    else:
-        audio_len = audio_len // HOP_LENGTH
-    return math.ceil(audio_len / AUDIO_LENGTH_PER_TOK)
-
-
-def _num_delay_tokens(delay_ms):
-    delay_len = int(delay_ms / 1000.0 * SAMPLE_RATE)
-    return _num_audio_tokens(delay_len)
 
 
 def _pad_audio_streaming(audio_array, n_left_pad_tokens, n_right_pad_tokens):

--- a/mlx_audio/stt/models/voxtral_realtime/voxtral_realtime.py
+++ b/mlx_audio/stt/models/voxtral_realtime/voxtral_realtime.py
@@ -65,6 +65,9 @@ class Model(nn.Module):
         # Will be set in post_load_hook
         self._tokenizer = None
         self._mel_filters = None
+        # Sentinel so _ensure_ada_scales is callable even if post_load_hook
+        # has not run yet (e.g. unit tests that build Model directly).
+        self._ada_scale_delay = -1
 
     def _ensure_mel_filters(self):
         if self._mel_filters is None:
@@ -130,6 +133,10 @@ class Model(nn.Module):
             from .decoder import compute_time_embedding
 
             t_cond = compute_time_embedding(float(n_delay), self.config.decoder.dim)
+            # Match the dtype the AdaRMSNorm weights were demoted to so the
+            # matmul doesn't silently upcast (see post_load_hook).
+            ada_weight = self.decoder.layers[0].ada_rms_norm_t_cond.ada_down.weight
+            t_cond = t_cond.astype(ada_weight.dtype)
             self.decoder.precompute_ada_scales(t_cond)
             for scale in self.decoder._ada_scales:
                 if scale is not None:
@@ -208,7 +215,7 @@ class Model(nn.Module):
         prefill_start = time.time()
         h, cache = self.decoder.forward(prefix_embeds, start_pos=0)
         logits = self.decoder.logits(h[-1])
-        cache_arrays = [t for lc in cache for t in lc[:2]]
+        cache_arrays = [a for c in cache for a in (c.keys, c.values) if a is not None]
         mx.eval(logits, *cache_arrays)
 
         if verbose:
@@ -559,14 +566,16 @@ class Model(nn.Module):
         return new_weights
 
     def model_quant_predicate(self, p, m):
-        """Skip quantization on encoder norms, ada norms, embeddings."""
-        skip_patterns = [
-            "norm",
-            "ada_rms_norm",
-            "tok_embeddings",
-            "conv_layers",
-            "audio_language_projection",
-        ]
+        """Quantize all big linears; only skip the small ones that hurt quality.
+
+        Per-step memory bandwidth dominates decode time, so the tied
+        ``tok_embeddings`` matmul in ``decoder.logits`` and the audio adapter
+        projections MUST be quantized to match voxmlx's throughput. Only the
+        norms, the tiny AdaRMSNorm MLPs, and the conv stem (3×128 kernels) are
+        skipped — matmul kernels on those are negligible and quantizing them
+        would cost more in quality than it saves in bandwidth.
+        """
+        skip_patterns = ["norm", "ada_rms_norm", "conv_layers"]
         return not any(pat in p for pat in skip_patterns)
 
     @classmethod
@@ -580,9 +589,44 @@ class Model(nn.Module):
         # Precompute mel filters
         model._ensure_mel_filters()
 
-        # Precompute ada scales from time conditioning (tracked for runtime override)
+        # Late-quantize the tied ``tok_embeddings`` if it was shipped in fp16
+        # (older converted checkpoints did this because the predicate used to
+        # skip embeddings). Per-step logits go through ~768 MB of weight
+        # otherwise — ~6 ms of memory-bandwidth tax on every decode step on an
+        # M-series GPU. Quantizing in place matches voxmlx's footprint.
+        tok = model.decoder.tok_embeddings
+        if not isinstance(tok, nn.QuantizedEmbedding):
+            quant = getattr(model.config, "quantization", None)
+            bits = 4
+            group_size = 64
+            if isinstance(quant, dict):
+                bits = int(quant.get("bits", bits))
+                group_size = int(quant.get("group_size", group_size))
+            model.decoder.tok_embeddings = nn.QuantizedEmbedding.from_embedding(
+                tok, group_size=group_size, bits=bits
+            )
+
+        # The mlx-audio converter shipped (a) fp32 norm / ada-norm weights and
+        # (b) fp16 quantization scales/biases, where voxmlx's canonical
+        # T0mSIlver checkpoint uses bf16 everywhere. MLX's quantized_matmul
+        # kernel has fast paths that only kick in when activations and
+        # scales share a dtype — running fp16 scales against bf16 activations
+        # forces silent casts inside the kernel and costs ~30 % of per-step
+        # latency on the 4B decoder. Normalize everything non-4-bit to bf16.
+        def _normalize_to_bf16(module):
+            for _, child in module.named_modules():
+                for attr in ("weight", "bias", "scales", "biases"):
+                    x = getattr(child, attr, None)
+                    if isinstance(x, mx.array) and x.dtype in (mx.float32, mx.float16):
+                        setattr(child, attr, x.astype(mx.bfloat16))
+
+        _normalize_to_bf16(model)
+
+        # Precompute ada scales from time conditioning (tracked for runtime
+        # override). t_cond must match the (now bf16) AdaRMSNorm weight dtype.
         n_delay = _num_delay_tokens(model.config.transcription_delay_ms)
         t_cond = compute_time_embedding(float(n_delay), model.config.decoder.dim)
+        t_cond = t_cond.astype(mx.bfloat16)
         model.decoder.precompute_ada_scales(t_cond)
         model._ada_scale_delay = n_delay
         # Evaluate ada scales eagerly

--- a/mlx_audio/stt/tests/test_voxtral_realtime_streaming.py
+++ b/mlx_audio/stt/tests/test_voxtral_realtime_streaming.py
@@ -1,0 +1,288 @@
+"""Unit tests for Voxtral Realtime streaming ingestion primitives.
+
+Covers the pieces that do not require downloaded model weights:
+- StreamingAudioSource: thread-safe blocking queue of audio samples.
+- StreamingMel: parity with compute_mel_spectrogram under many
+  chunking regimes.
+- StreamingCausalConv1d: parity with CausalConv1d on a randomly
+  initialized module (no quantized checkpoint needed).
+
+The end-to-end (encoder + session) parity lives in a weight-gated
+test class that skips cleanly when the model checkpoint is absent.
+"""
+
+import os
+import threading
+import time
+import unittest
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_audio.stt.models.voxtral_realtime.audio import (
+    compute_mel_filters,
+    compute_mel_spectrogram,
+)
+from mlx_audio.stt.models.voxtral_realtime.encoder import CausalConv1d
+from mlx_audio.stt.models.voxtral_realtime.streaming import (
+    StreamingAudioSource,
+    StreamingCausalConv1d,
+    StreamingMel,
+)
+
+
+def _make_audio(n_samples: int, seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    t = np.arange(n_samples) / 16000.0
+    sig = (
+        0.3 * np.sin(2 * np.pi * 440.0 * t)
+        + 0.2 * np.sin(2 * np.pi * 1100.0 * t)
+        + 0.05 * rng.standard_normal(n_samples)
+    )
+    return sig.astype(np.float32)
+
+
+class TestStreamingAudioSource(unittest.TestCase):
+    def test_append_then_read_coalesces(self):
+        src = StreamingAudioSource()
+        src.append(np.ones(100, dtype=np.float32))
+        src.append(np.full(50, 2.0, dtype=np.float32))
+        samples, closed = src.read(timeout=0.1)
+        self.assertFalse(closed)
+        self.assertEqual(samples.shape, (150,))
+        self.assertTrue(np.allclose(samples[:100], 1.0))
+        self.assertTrue(np.allclose(samples[100:], 2.0))
+
+    def test_close_flushes_and_signals(self):
+        src = StreamingAudioSource()
+        src.append(np.arange(10, dtype=np.float32))
+        src.close()
+        samples, closed = src.read(timeout=0.1)
+        self.assertEqual(samples.shape, (10,))
+        self.assertTrue(closed)
+
+    def test_empty_append_is_noop(self):
+        src = StreamingAudioSource()
+        src.append(np.zeros(0, dtype=np.float32))
+        src.close()
+        samples, closed = src.read(timeout=0.1)
+        self.assertEqual(samples.size, 0)
+        self.assertTrue(closed)
+
+    def test_dtype_coerced_to_float32(self):
+        src = StreamingAudioSource()
+        src.append(np.arange(5, dtype=np.float64))
+        src.close()
+        samples, _ = src.read(timeout=0.1)
+        self.assertEqual(samples.dtype, np.float32)
+
+    def test_read_blocks_until_producer_appends(self):
+        src = StreamingAudioSource()
+        observed: list[tuple[np.ndarray, bool]] = []
+
+        def consumer():
+            observed.append(src.read(timeout=2.0))
+
+        t = threading.Thread(target=consumer)
+        t.start()
+        # Give the consumer a moment to block on the empty queue.
+        time.sleep(0.05)
+        src.append(np.ones(8, dtype=np.float32))
+        t.join(timeout=2.0)
+        self.assertFalse(t.is_alive())
+        self.assertEqual(len(observed), 1)
+        samples, closed = observed[0]
+        self.assertEqual(samples.shape, (8,))
+        self.assertFalse(closed)
+
+
+class TestStreamingMelParity(unittest.TestCase):
+    """StreamingMel ∘ close == compute_mel_spectrogram for any chunking."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mel_filters = mx.array(compute_mel_filters(), dtype=mx.float32)
+
+    def _batch(self, audio: np.ndarray) -> np.ndarray:
+        mel = compute_mel_spectrogram(mx.array(audio), self.mel_filters)
+        mx.eval(mel)
+        return np.array(mel)
+
+    def _streaming(self, audio: np.ndarray, chunk: int) -> np.ndarray:
+        sm = StreamingMel(self.mel_filters)
+        pieces: list[np.ndarray] = []
+        for start in range(0, len(audio), chunk):
+            out = sm.append(audio[start : start + chunk])
+            if out is not None:
+                pieces.append(np.array(out))
+        tail = sm.close()
+        if tail is not None:
+            pieces.append(np.array(tail))
+        if not pieces:
+            return np.zeros((128, 0), dtype=np.float32)
+        return np.concatenate(pieces, axis=1)
+
+    def test_parity_matrix(self):
+        cases = [
+            (16000, 160),
+            (16000, 800),
+            (16000, 3200),
+            (16001, 3200),
+            (1600, 200),
+            (24157, 1000),
+        ]
+        tol = 1e-4
+        for n_samples, chunk in cases:
+            with self.subTest(n_samples=n_samples, chunk=chunk):
+                audio = _make_audio(n_samples)
+                batch = self._batch(audio)
+                stream = self._streaming(audio, chunk)
+                self.assertEqual(batch.shape, stream.shape)
+                self.assertLess(float(np.abs(batch - stream).max()), tol)
+
+    def test_close_is_idempotent(self):
+        sm = StreamingMel(self.mel_filters)
+        sm.append(_make_audio(1000))
+        sm.close()
+        # Second close must be a no-op and must not raise.
+        self.assertIsNone(sm.close())
+
+
+class TestStreamingCausalConv1dParity(unittest.TestCase):
+    """Streaming wrapper matches the batch CausalConv1d it wraps."""
+
+    def _run_case(self, kernel_size: int, stride: int, n_in: int, chunk: int):
+        mx.random.seed(0)
+        in_channels, out_channels = 8, 12
+        conv = CausalConv1d(in_channels, out_channels, kernel_size, stride=stride)
+        # Force-initialize params (MLX Modules lazy init on first call).
+        _ = conv(mx.zeros((1, kernel_size, in_channels)))
+
+        x_np = (
+            np.random.default_rng(1)
+            .standard_normal((n_in, in_channels))
+            .astype(np.float32)
+        )
+        x = mx.array(x_np)
+
+        # Batch reference: CausalConv1d expects [batch, seq, channels].
+        batch_out = conv(x[None, :, :]).squeeze(0)
+        mx.eval(batch_out)
+        batch_np = np.array(batch_out)
+
+        # Streaming: feed chunks, concatenate outputs.
+        sc = StreamingCausalConv1d(conv)
+        pieces: list[mx.array] = []
+        for start in range(0, n_in, chunk):
+            piece = sc.step(x[start : start + chunk])
+            if piece.shape[0] > 0:
+                pieces.append(piece)
+        stream_out = (
+            mx.concatenate(pieces, axis=0) if pieces else mx.zeros((0, out_channels))
+        )
+        mx.eval(stream_out)
+        stream_np = np.array(stream_out)
+
+        self.assertEqual(batch_np.shape, stream_np.shape)
+        self.assertLess(float(np.abs(batch_np - stream_np).max()), 1e-5)
+
+    def test_stride_1(self):
+        for chunk in (1, 3, 8, 17):
+            with self.subTest(chunk=chunk):
+                self._run_case(kernel_size=5, stride=1, n_in=40, chunk=chunk)
+
+    def test_stride_2(self):
+        for chunk in (2, 4, 8, 16):
+            with self.subTest(chunk=chunk):
+                self._run_case(kernel_size=6, stride=2, n_in=40, chunk=chunk)
+
+    def test_kernel_equals_stride(self):
+        # Edge case: no state carried between calls.
+        for chunk in (4, 8, 12):
+            with self.subTest(chunk=chunk):
+                self._run_case(kernel_size=4, stride=4, n_in=40, chunk=chunk)
+
+
+def _voxtral_weights_path() -> str:
+    return os.environ.get(
+        "VOXTRAL_REALTIME_MODEL",
+        os.path.expanduser("~/.omlx/models/Voxtral-Mini-4B-Realtime-2602-4bit"),
+    )
+
+
+def _voxtral_weights_available() -> bool:
+    path = _voxtral_weights_path()
+    return os.path.isdir(path) and any(
+        f.endswith(".safetensors") for f in os.listdir(path)
+    )
+
+
+@unittest.skipUnless(
+    _voxtral_weights_available(),
+    "Voxtral Realtime weights not available (set VOXTRAL_REALTIME_MODEL to enable)",
+)
+class TestVoxtralStreamingEndToEnd(unittest.TestCase):
+    """Parity vs batch, using real quantized weights. Skipped in CI."""
+
+    @classmethod
+    def setUpClass(cls):
+        from mlx_audio.stt.utils import load_model
+
+        cls.model = load_model(_voxtral_weights_path())
+
+    def test_encoder_streaming_parity(self):
+        from mlx_audio.stt.models.voxtral_realtime.streaming import (
+            StreamingConvStem,
+            StreamingDownsampler,
+            StreamingEncoder,
+        )
+
+        encoder = self.model.encoder
+        rng = np.random.default_rng(0)
+        # 320 mel frames is divisible by 8 -> conv_stem out divisible by ds=4,
+        # which keeps the streaming output aligned with the batch output (no
+        # front-trunc mismatch).
+        mel = mx.array((rng.standard_normal((128, 320)) * 0.5).astype(np.float32))
+
+        batch_out = encoder(mel)
+        mx.eval(batch_out)
+
+        cs = StreamingConvStem(encoder)
+        enc = StreamingEncoder(encoder)
+        ds = StreamingDownsampler(encoder)
+        pieces: list[mx.array] = []
+        chunk = 40
+        for start in range(0, mel.shape[1], chunk):
+            mel_chunk = mel[:, start : start + chunk]
+            out = ds.step(enc.step(cs.step(mel_chunk)))
+            if out.shape[0] > 0:
+                pieces.append(out)
+        stream_out = mx.concatenate(pieces, axis=0)
+        mx.eval(stream_out)
+
+        self.assertEqual(tuple(batch_out.shape), tuple(stream_out.shape))
+        diff = float(mx.max(mx.abs(batch_out - stream_out)).item())
+        # Permissive: 4-bit quant + many ops. Scripts observe ~1e-2.
+        self.assertLess(diff, 2e-2)
+
+    def test_session_runs_to_completion(self):
+        """Drip-feed silence; session must terminate and yield str deltas."""
+        audio = np.zeros(16000 * 2, dtype=np.float32)
+
+        sess = self.model.create_streaming_session()
+        chunk = 3200  # 200 ms
+        for start in range(0, len(audio), chunk):
+            sess.feed(audio[start : start + chunk])
+        sess.close()
+
+        pieces: list[str] = []
+        steps = 0
+        while not sess.done:
+            pieces.extend(sess.step(max_decode_tokens=8))
+            steps += 1
+            self.assertLess(steps, 2000, "session.step made no progress")
+        self.assertTrue(all(isinstance(p, str) for p in pieces))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a live-input streaming path for Voxtral Realtime: audio is consumed incrementally as samples arrive and transcription deltas are emitted as soon as the encoder catches up. The existing batch `generate()` path is unchanged.

The session API (`feed()` / `step(max_decode_tokens=N)`) splits cheap thread-safe sample queueing from bounded units of MLX work, so the MLX executor is released between steps. This lets multiple streams — or a stream plus an LLM request — interleave cooperatively on a single-worker executor.

## What's new

**`mlx_audio/stt/models/voxtral_realtime/streaming.py`** (new module)
- `StreamingAudioSource` — thread-safe queue bridging producers (any thread / asyncio task) to the MLX consumer.
- `StreamingMel`, `StreamingCausalConv1d`, `StreamingConvStem` — per-chunk equivalents of the batch mel + conv stem. Bit-exact parity for the conv stem via explicit edge state; near-exact (1e-5) for mel.
- `StreamingEncoder` — transformer layers with a per-layer `RotatingKVCache` and a running RoPE position. Forces an explicit array mask so SDPA stays correct when `Q_len < K_len`.
- `StreamingDownsampler` — buffers encoder output and emits adapter-projected frames in `downsample_factor`-aligned groups.
- `VoxtralStreamingSession` — stateful session whose `feed()` is a cheap thread-safe queue push and whose `step(max_decode_tokens=N)` runs a bounded unit of MLX work.

**`mlx_audio/stt/models/voxtral_realtime/voxtral_realtime.py`**
- `Model.create_streaming_session(...)` → returns a `VoxtralStreamingSession`.
- `Model.generate_streaming(source, ...)` → thin convenience wrapper that drives a session from a `StreamingAudioSource`.

**Docs** — new "Live Input Streaming" section on `docs/models/stt/voxtral-realtime.md` with both the convenience wrapper and the lower-level session API.

**Tests** — `mlx_audio/stt/tests/test_voxtral_realtime_streaming.py`:
- `StreamingAudioSource` threading behavior (coalescing, close signal, blocking read, dtype coercion).
- `StreamingMel` parity vs `compute_mel_spectrogram` across multiple chunk sizes.
- `StreamingCausalConv1d` parity on a freshly-initialized `CausalConv1d` (no model weights required).
- Encoder + session parity behind a weight-gated `TestCase` that skips when `VOXTRAL_REALTIME_MODEL` is not set.

## Non-goals

- The existing `/v1/audio/transcriptions/realtime` WebSocket endpoint in `server.py` consumes a completed `mx.array` and streams deltas out; live-input is a different contract. Not wired in this PR — happy to follow up in a separate PR once the API surface is reviewed here.

## Test plan

- [x] `pytest mlx_audio/stt/tests/test_voxtral_realtime_streaming.py` — 12 passed (17 subtests)
- [x] `pre-commit run --files ...` on the changed files — black + isort clean
- [x] `mkdocs build --strict` — builds without new warnings
- [x] Manual parity check on a 113 s French clip (streaming vs batch) with `VOXTRAL_REALTIME_MODEL` set