### PR TITLE
feat(irodori-tts): add v2 model support with VoiceDesign and chunked DACVAE decode

### DIFF
--- a/mlx_audio/tts/models/irodori_tts/README.md
+++ b/mlx_audio/tts/models/irodori_tts/README.md
@@ -1,39 +1,70 @@
 # Irodori TTS
 
-Japanese text-to-speech model based on Echo TTS architecture, ported to MLX.
-Uses Rectified Flow diffusion with a DiT (Diffusion Transformer) and DACVAE codec (48kHz).
+Flow Matching-based Japanese TTS model, ported to MLX.
+Uses a Rectified Flow DiT over continuous DACVAE latents (48kHz).
+Architecture and training follow [Echo-TTS](https://jordandarefsky.com/blog/2025/echo/).
 
-## Model
+Original: [Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS)
 
-Original: [Aratako/Irodori-TTS-500M](https://huggingface.co/Aratako/Irodori-TTS-500M) (500M parameters)
+## Models
+
+### v2 (recommended)
+
+| Model | HuggingFace | Conditioning |
+|---|---|---|
+| `mlx-community/Irodori-TTS-500M-v2-fp16` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-fp16) | Voice cloning (reference audio) |
+| `mlx-community/Irodori-TTS-500M-v2-8bit` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-8bit) | Voice cloning (reference audio) |
+| `mlx-community/Irodori-TTS-500M-v2-4bit` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-4bit) | Voice cloning (reference audio) |
+| `mlx-community/Irodori-TTS-500M-v2-VoiceDesign-fp16` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-VoiceDesign-fp16) | Voice design (text description) |
+| `mlx-community/Irodori-TTS-500M-v2-VoiceDesign-8bit` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-VoiceDesign-8bit) | Voice design (text description) |
+| `mlx-community/Irodori-TTS-500M-v2-VoiceDesign-4bit` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-VoiceDesign-4bit) | Voice design (text description) |
+
+### v1
+
+| Model | HuggingFace |
+|---|---|
+| `mlx-community/Irodori-TTS-500M-fp16` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-fp16) |
 
 ## Usage
 
-Python API:
+### Voice cloning
 
 ```python
-from mlx_audio.tts import load
+from mlx_audio.tts.generate import generate_audio
 
-model = load("mlx-community/Irodori-TTS-500M-fp16")
-result = next(model.generate("こんにちは、音声合成のテストです。"))
-audio = result.audio
-```
-
-With reference audio for voice cloning:
-
-```python
-result = next(model.generate(
-    "こんにちは、音声合成のテストです。",
+generate_audio(
+    model="mlx-community/Irodori-TTS-500M-v2-fp16",
+    text="今日はいい天気ですね。",
     ref_audio="speaker.wav",
-))
+    file_prefix="output",
+)
 ```
-
-CLI:
 
 ```bash
 python -m mlx_audio.tts.generate \
-  --model mlx-community/Irodori-TTS-500M-fp16 \
-  --text "こんにちは、音声合成のテストです。"
+  --model mlx-community/Irodori-TTS-500M-v2-fp16 \
+  --text "今日はいい天気ですね。" \
+  --ref_audio speaker.wav
+```
+
+### VoiceDesign
+
+Describe the desired voice in text instead of providing reference audio:
+
+```python
+generate_audio(
+    model="mlx-community/Irodori-TTS-500M-v2-VoiceDesign-fp16",
+    text="今日はいい天気ですね。",
+    instruct="落ち着いた、近い距離感の女性話者",
+    file_prefix="output",
+)
+```
+
+```bash
+python -m mlx_audio.tts.generate \
+  --model mlx-community/Irodori-TTS-500M-v2-VoiceDesign-fp16 \
+  --text "今日はいい天気ですね。" \
+  --instruct "落ち着いた、近い距離感の女性話者"
 ```
 
 ## Memory requirements
@@ -42,11 +73,13 @@ The default `sequence_length=750` requires approximately 24GB of unified memory.
 On 16GB machines, use reduced settings:
 
 ```python
-result = next(model.generate(
-    "こんにちは。",
-    sequence_length=300,       # ~9GB
-    cfg_guidance_mode="alternating",  # ~1/3 of independent mode memory
-))
+generate_audio(
+    model="mlx-community/Irodori-TTS-500M-v2-fp16",
+    text="こんにちは。",
+    sequence_length=300,
+    cfg_guidance_mode="alternating",
+    file_prefix="output",
+)
 ```
 
 Approximate memory usage with `cfg_guidance_mode="alternating"`:
@@ -61,12 +94,10 @@ With `cfg_guidance_mode="independent"` (default), multiply memory by ~3.
 
 ## Notes
 
-- Input language: Japanese. Latin characters may not be pronounced correctly;
-  convert them to katakana beforehand (e.g. "MLX" → "エムエルエックス").
-- The DACVAE codec weights (`facebook/dacvae-watermarked`) are automatically
-  downloaded on first use.
+- v2 uses [Semantic-DACVAE-Japanese-32dim](https://huggingface.co/Aratako/Semantic-DACVAE-Japanese-32dim)
+  and is bundled in the converted model weights.
+- v1 uses `facebook/dacvae-watermarked`, downloaded automatically on first use.
 
 ## License
 
-Irodori-TTS weights are released under the [MIT License](https://opensource.org/licenses/MIT).
-See [Aratako/Irodori-TTS-500M](https://huggingface.co/Aratako/Irodori-TTS-500M) for details.
+MIT License. See [Aratako/Irodori-TTS-500M-v2](https://huggingface.co/Aratako/Irodori-TTS-500M-v2) for details.

--- a/mlx_audio/tts/models/irodori_tts/config.py
+++ b/mlx_audio/tts/models/irodori_tts/config.py
@@ -83,7 +83,9 @@ class IrodoriDiTConfig(BaseModelArgs):
 
     @property
     def caption_layers_resolved(self) -> int:
-        return self.caption_layers if self.caption_layers is not None else self.text_layers
+        return (
+            self.caption_layers if self.caption_layers is not None else self.text_layers
+        )
 
     @property
     def caption_heads_resolved(self) -> int:

--- a/mlx_audio/tts/models/irodori_tts/config.py
+++ b/mlx_audio/tts/models/irodori_tts/config.py
@@ -8,8 +8,8 @@ from mlx_audio.tts.models.base import BaseModelArgs
 
 @dataclass
 class IrodoriDiTConfig(BaseModelArgs):
-    # Audio latent dimensions (DACVAE: 128-dim, 48kHz)
-    latent_dim: int = 128
+    # Audio latent dimensions (v2: 32-dim Semantic-DACVAE, v1: 128-dim DACVAE)
+    latent_dim: int = 32
     latent_patch_size: int = 1
 
     # DiT backbone
@@ -38,6 +38,62 @@ class IrodoriDiTConfig(BaseModelArgs):
     timestep_embed_dim: int = 512
     adaln_rank: int = 192
     norm_eps: float = 1e-5
+
+    # Caption (Voice Design) conditioning — mutually exclusive with speaker
+    use_caption_condition: bool = False
+    caption_vocab_size: Optional[int] = None
+    caption_tokenizer_repo: Optional[str] = None
+    caption_add_bos: Optional[bool] = None
+    caption_dim: Optional[int] = None
+    caption_layers: Optional[int] = None
+    caption_heads: Optional[int] = None
+    caption_mlp_ratio: Optional[float] = None
+
+    @property
+    def use_speaker_condition(self) -> bool:
+        return not self.use_caption_condition
+
+    @property
+    def caption_vocab_size_resolved(self) -> int:
+        return (
+            self.caption_vocab_size
+            if self.caption_vocab_size is not None
+            else self.text_vocab_size
+        )
+
+    @property
+    def caption_tokenizer_repo_resolved(self) -> str:
+        return (
+            self.caption_tokenizer_repo
+            if self.caption_tokenizer_repo is not None
+            else self.text_tokenizer_repo
+        )
+
+    @property
+    def caption_add_bos_resolved(self) -> bool:
+        return (
+            self.caption_add_bos
+            if self.caption_add_bos is not None
+            else self.text_add_bos
+        )
+
+    @property
+    def caption_dim_resolved(self) -> int:
+        return self.caption_dim if self.caption_dim is not None else self.text_dim
+
+    @property
+    def caption_layers_resolved(self) -> int:
+        return self.caption_layers if self.caption_layers is not None else self.text_layers
+
+    @property
+    def caption_heads_resolved(self) -> int:
+        return self.caption_heads if self.caption_heads is not None else self.text_heads
+
+    @property
+    def caption_mlp_ratio_resolved(self) -> float:
+        if self.caption_mlp_ratio is not None:
+            return float(self.caption_mlp_ratio)
+        return self.text_mlp_ratio_resolved
 
     @property
     def patched_latent_dim(self) -> int:
@@ -69,6 +125,7 @@ class SamplerConfig(BaseModelArgs):
     num_steps: int = 40
     cfg_scale_text: float = 3.0
     cfg_scale_speaker: float = 5.0
+    cfg_scale_caption: float = 3.0
     cfg_guidance_mode: str = "independent"
     cfg_min_t: float = 0.5
     cfg_max_t: float = 1.0
@@ -88,11 +145,12 @@ class ModelConfig(BaseModelArgs):
     sample_rate: int = 48000
 
     max_text_length: int = 256
+    max_caption_length: int = 512
     max_speaker_latent_length: int = 6400
-    # DACVAE hop_length = 2*8*10*12 = 1920
+    # DACVAE hop_length = 2*8*10*12 = 1920 (48kHz)
     audio_downsample_factor: int = 1920
 
-    dacvae_repo: str = "Aratako/Irodori-TTS-500M"
+    dacvae_repo: str = "Aratako/Semantic-DACVAE-Japanese-32dim"
     model_path: Optional[str] = None
 
     dit: IrodoriDiTConfig = field(default_factory=IrodoriDiTConfig)
@@ -104,9 +162,12 @@ class ModelConfig(BaseModelArgs):
             model_type=config.get("model_type", "irodori_tts"),
             sample_rate=config.get("sample_rate", 48000),
             max_text_length=config.get("max_text_length", 256),
+            max_caption_length=config.get("max_caption_length", 512),
             max_speaker_latent_length=config.get("max_speaker_latent_length", 6400),
             audio_downsample_factor=config.get("audio_downsample_factor", 1920),
-            dacvae_repo=config.get("dacvae_repo", "Aratako/Irodori-TTS-500M"),
+            dacvae_repo=config.get(
+                "dacvae_repo", "Aratako/Semantic-DACVAE-Japanese-32dim"
+            ),
             model_path=config.get("model_path"),
             dit=IrodoriDiTConfig.from_dict(config.get("dit", {})),
             sampler=SamplerConfig.from_dict(config.get("sampler", {})),

--- a/mlx_audio/tts/models/irodori_tts/irodori_tts.py
+++ b/mlx_audio/tts/models/irodori_tts/irodori_tts.py
@@ -42,6 +42,7 @@ class Model(nn.Module):
         self.model = IrodoriDiT(config.dit)
         self.dacvae: DACVAE | None = None
         self._tokenizer = None
+        self._caption_tokenizer = None
 
     # ------------------------------------------------------------------
     # Properties
@@ -127,6 +128,18 @@ class Model(nn.Module):
             )
         return self._tokenizer
 
+    def _get_caption_tokenizer(self):
+        if self._caption_tokenizer is None:
+            from transformers import AutoTokenizer
+
+            repo = self.config.dit.caption_tokenizer_repo_resolved
+            # Reuse text tokenizer if repo is the same
+            if repo == self.config.dit.text_tokenizer_repo:
+                self._caption_tokenizer = self._get_tokenizer()
+            else:
+                self._caption_tokenizer = AutoTokenizer.from_pretrained(repo)
+        return self._caption_tokenizer
+
     def _prepare_text(
         self, text: str, max_length: Optional[int] = None
     ) -> tuple[mx.array, mx.array]:
@@ -144,6 +157,18 @@ class Model(nn.Module):
             tokenizer=self._get_tokenizer(),
             max_length=max_length,
             add_bos=self.config.dit.text_add_bos,
+        )
+
+    def _prepare_caption(
+        self, caption: str, max_length: Optional[int] = None
+    ) -> tuple[mx.array, mx.array]:
+        if max_length is None:
+            max_length = self.config.max_caption_length
+        return encode_text(
+            caption,
+            tokenizer=self._get_caption_tokenizer(),
+            max_length=max_length,
+            add_bos=self.config.dit.caption_add_bos_resolved,
         )
 
     # ------------------------------------------------------------------
@@ -191,15 +216,23 @@ class Model(nn.Module):
         text: str,
         ref_latent: Optional[mx.array] = None,
         ref_mask: Optional[mx.array] = None,
+        caption: Optional[str] = None,
         rng_seed: int = 0,
         **sampling_kwargs,
     ) -> mx.array:
         text_input_ids, text_mask = self._prepare_text(text)
 
-        if ref_latent is None:
-            ref_latent = mx.zeros((1, 1, self.config.dit.latent_dim))
-        if ref_mask is None:
-            ref_mask = mx.zeros((1, ref_latent.shape[1]), dtype=mx.bool_)
+        caption_input_ids: Optional[mx.array] = None
+        caption_mask: Optional[mx.array] = None
+
+        if self.config.dit.use_caption_condition:
+            cap = caption or ""
+            caption_input_ids, caption_mask = self._prepare_caption(cap)
+        else:
+            if ref_latent is None:
+                ref_latent = mx.zeros((1, 1, self.config.dit.latent_dim))
+            if ref_mask is None:
+                ref_mask = mx.zeros((1, ref_latent.shape[1]), dtype=mx.bool_)
 
         sampler_cfg = dict(self.config.sampler.__dict__)
         for k, v in sampling_kwargs.items():
@@ -212,6 +245,8 @@ class Model(nn.Module):
             text_mask=text_mask,
             ref_latent=ref_latent,
             ref_mask=ref_mask,
+            caption_input_ids=caption_input_ids,
+            caption_mask=caption_mask,
             rng_seed=rng_seed,
             latent_dim=self.config.dit.patched_latent_dim,
             **sampler_cfg,
@@ -226,9 +261,12 @@ class Model(nn.Module):
         text: str,
         voice: str | None = None,
         ref_audio: str | mx.array | None = None,
+        caption: str | None = None,
         stream: bool = False,
         **kwargs,
     ) -> Generator[GenerationResult, None, None]:
+        # instruct is an alias for caption (mlx-audio convention)
+        caption = caption or kwargs.pop("instruct", None)
         if stream:
             raise NotImplementedError("Irodori-TTS streaming is not yet implemented.")
 
@@ -262,15 +300,20 @@ class Model(nn.Module):
             text=text,
             ref_latent=ref_latent,
             ref_mask=ref_mask,
+            caption=caption,
             rng_seed=int(kwargs.get("rng_seed", 0)),
             **{k: v for k, v in kwargs.items() if k != "rng_seed"},
         )
 
         # Decode latent → waveform
-        # latent_out: (1, T, 128)
-        latent_for_decode = mx.transpose(latent_out, (0, 2, 1))  # (1, 128, T)
-        audio_out = self.dacvae.decode(latent_for_decode)  # (1, L, 1)
+        # latent_out: (1, T, latent_dim)
+        latent_for_decode = mx.transpose(latent_out, (0, 2, 1))  # (1, latent_dim, T)
+        # Use chunked decoding to avoid large ConvTranspose1d intermediates on
+        # 16 GB unified-memory systems (stride-8 block creates a ~17 GB tensor
+        # at T=750 in a single pass; 50-frame chunks keep it under ~1.2 GB).
+        audio_out = self.dacvae.decode(latent_for_decode, chunk_size=50)  # (1, L, 1)
         audio_out = audio_out[:, :, 0]  # (1, L)
+        mx.eval(audio_out)
 
         # Trim trailing silence
         silence_t = _find_silence_point(latent_out[0])

--- a/mlx_audio/tts/models/irodori_tts/model.py
+++ b/mlx_audio/tts/models/irodori_tts/model.py
@@ -200,9 +200,12 @@ class SelfAttention(nn.Module):
 
 class JointAttention(nn.Module):
     """
-    Joint attention over latent self-tokens, text context, and speaker context.
+    Joint attention over latent self-tokens, text context, and speaker/caption context.
     Uses half-RoPE: RoPE applied to the first half of head dimensions.
-    No latent KV cache (blockwise generation not needed for inference).
+
+    Exactly one of speaker_ctx_dim or caption_ctx_dim must be provided.
+    The corresponding weight keys (wk_speaker/wv_speaker or wk_caption/wv_caption)
+    are created accordingly so that loaded PyTorch weights map directly.
     """
 
     def __init__(
@@ -210,8 +213,9 @@ class JointAttention(nn.Module):
         dim: int,
         heads: int,
         text_ctx_dim: int,
-        speaker_ctx_dim: int,
+        speaker_ctx_dim: Optional[int],
         norm_eps: float,
+        caption_ctx_dim: Optional[int] = None,
     ):
         super().__init__()
         self.heads = heads
@@ -221,12 +225,21 @@ class JointAttention(nn.Module):
         self.wv = nn.Linear(dim, dim, bias=False)
         self.wk_text = nn.Linear(text_ctx_dim, dim, bias=False)
         self.wv_text = nn.Linear(text_ctx_dim, dim, bias=False)
-        self.wk_speaker = nn.Linear(speaker_ctx_dim, dim, bias=False)
-        self.wv_speaker = nn.Linear(speaker_ctx_dim, dim, bias=False)
         self.gate = nn.Linear(dim, dim, bias=False)
         self.wo = nn.Linear(dim, dim, bias=False)
         self.q_norm = RMSNorm((heads, self.head_dim), eps=norm_eps)
         self.k_norm = RMSNorm((heads, self.head_dim), eps=norm_eps)
+
+        if speaker_ctx_dim is not None:
+            self.wk_speaker = nn.Linear(speaker_ctx_dim, dim, bias=False)
+            self.wv_speaker = nn.Linear(speaker_ctx_dim, dim, bias=False)
+            self._context_mode = "speaker"
+        elif caption_ctx_dim is not None:
+            self.wk_caption = nn.Linear(caption_ctx_dim, dim, bias=False)
+            self.wv_caption = nn.Linear(caption_ctx_dim, dim, bias=False)
+            self._context_mode = "caption"
+        else:
+            raise ValueError("Either speaker_ctx_dim or caption_ctx_dim must be set")
 
     def _apply_rotary_half(self, y: mx.array, freqs_cis: RotaryCache) -> mx.array:
         """Apply RoPE to the first half of head dimensions only."""
@@ -256,14 +269,31 @@ class JointAttention(nn.Module):
         k = self.k_norm(k)
         return k, v
 
+    def get_kv_cache_caption(self, caption_state: mx.array) -> KVCache:
+        bsz = caption_state.shape[0]
+        k = self.wk_caption(caption_state).reshape(
+            bsz, caption_state.shape[1], self.heads, self.head_dim
+        )
+        v = self.wv_caption(caption_state).reshape(
+            bsz, caption_state.shape[1], self.heads, self.head_dim
+        )
+        k = self.k_norm(k)
+        return k, v
+
+    def get_kv_cache_context(self, context_state: mx.array) -> KVCache:
+        """Dispatch to speaker or caption KV cache based on model mode."""
+        if self._context_mode == "caption":
+            return self.get_kv_cache_caption(context_state)
+        return self.get_kv_cache_speaker(context_state)
+
     def __call__(
         self,
         x: mx.array,
         text_mask: mx.array,
-        speaker_mask: mx.array,
+        context_mask: mx.array,
         freqs_cis: RotaryCache,
         kv_cache_text: KVCache,
-        kv_cache_speaker: KVCache,
+        kv_cache_context: KVCache,
         start_pos: int = 0,
     ) -> mx.array:
         bsz, seq_len = x.shape[:2]
@@ -281,13 +311,13 @@ class JointAttention(nn.Module):
         k_self = self._apply_rotary_half(k_self, (q_cos, q_sin))
 
         k_text, v_text = kv_cache_text
-        k_speaker, v_speaker = kv_cache_speaker
+        k_ctx, v_ctx = kv_cache_context
 
-        k = mx.concatenate([k_self, k_text, k_speaker], axis=1)
-        v = mx.concatenate([v_self, v_text, v_speaker], axis=1)
+        k = mx.concatenate([k_self, k_text, k_ctx], axis=1)
+        v = mx.concatenate([v_self, v_text, v_ctx], axis=1)
 
         self_mask = mx.ones((bsz, seq_len), dtype=mx.bool_)
-        full_mask = mx.concatenate([self_mask, text_mask, speaker_mask], axis=1)
+        full_mask = mx.concatenate([self_mask, text_mask, context_mask], axis=1)
         full_mask = mx.broadcast_to(
             full_mask[:, None, :], (bsz, seq_len, full_mask.shape[1])
         )
@@ -333,6 +363,7 @@ class TextEncoder(nn.Module):
     """
     Text encoder: embedding + non-causal Transformer blocks.
     Applies mask zeroing after each block so fully-masked positions stay zero.
+    Used for both text and caption encoding.
     """
 
     def __init__(
@@ -426,13 +457,19 @@ class DiffusionBlock(nn.Module):
         heads: int,
         mlp_hidden_dim: int,
         text_ctx_dim: int,
-        speaker_ctx_dim: int,
+        speaker_ctx_dim: Optional[int],
         adaln_rank: int,
         norm_eps: float,
+        caption_ctx_dim: Optional[int] = None,
     ):
         super().__init__()
         self.attention = JointAttention(
-            dim, heads, text_ctx_dim, speaker_ctx_dim, norm_eps
+            dim,
+            heads,
+            text_ctx_dim,
+            speaker_ctx_dim,
+            norm_eps,
+            caption_ctx_dim=caption_ctx_dim,
         )
         self.mlp = SwiGLU(dim, mlp_hidden_dim)
         self.attention_adaln = LowRankAdaLN(dim, adaln_rank, norm_eps)
@@ -443,20 +480,20 @@ class DiffusionBlock(nn.Module):
         x: mx.array,
         cond_embed: mx.array,
         text_mask: mx.array,
-        speaker_mask: mx.array,
+        context_mask: mx.array,
         freqs_cis: RotaryCache,
         kv_cache_text: KVCache,
-        kv_cache_speaker: KVCache,
+        kv_cache_context: KVCache,
         start_pos: int = 0,
     ) -> mx.array:
         x_norm, attn_gate = self.attention_adaln(x, cond_embed)
         x = x + attn_gate * self.attention(
             x_norm,
             text_mask,
-            speaker_mask,
+            context_mask,
             freqs_cis,
             kv_cache_text,
-            kv_cache_speaker,
+            kv_cache_context,
             start_pos,
         )
         x_norm, mlp_gate = self.mlp_adaln(x, cond_embed)
@@ -472,6 +509,10 @@ class DiffusionBlock(nn.Module):
 class IrodoriDiT(nn.Module):
     """
     Irodori-TTS DiT model (MLX port of TextToLatentRFDiT).
+
+    Supports two conditioning modes (mutually exclusive):
+      - Speaker mode (use_speaker_condition=True): ref audio latent → speaker embedding
+      - Caption mode (use_caption_condition=True): style text → caption embedding
 
     Input x_t : (B, S, latent_dim * latent_patch_size)
     Output v_t : same shape — velocity prediction for Rectified Flow ODE.
@@ -490,17 +531,34 @@ class IrodoriDiT(nn.Module):
             mlp_ratio=cfg.text_mlp_ratio_resolved,
             norm_eps=cfg.norm_eps,
         )
-        # ReferenceLatentEncoder receives patched speaker latents
-        self.speaker_encoder = ReferenceLatentEncoder(
-            in_dim=cfg.speaker_patched_latent_dim,
-            dim=cfg.speaker_dim,
-            heads=cfg.speaker_heads,
-            num_layers=cfg.speaker_layers,
-            mlp_ratio=cfg.speaker_mlp_ratio_resolved,
-            norm_eps=cfg.norm_eps,
-        )
         self.text_norm = RMSNorm(cfg.text_dim, eps=cfg.norm_eps)
-        self.speaker_norm = RMSNorm(cfg.speaker_dim, eps=cfg.norm_eps)
+
+        if cfg.use_speaker_condition:
+            self.speaker_encoder = ReferenceLatentEncoder(
+                in_dim=cfg.speaker_patched_latent_dim,
+                dim=cfg.speaker_dim,
+                heads=cfg.speaker_heads,
+                num_layers=cfg.speaker_layers,
+                mlp_ratio=cfg.speaker_mlp_ratio_resolved,
+                norm_eps=cfg.norm_eps,
+            )
+            self.speaker_norm = RMSNorm(cfg.speaker_dim, eps=cfg.norm_eps)
+            context_dim = cfg.speaker_dim
+            speaker_ctx_dim: Optional[int] = cfg.speaker_dim
+            caption_ctx_dim: Optional[int] = None
+        else:
+            self.caption_encoder = TextEncoder(
+                vocab_size=cfg.caption_vocab_size_resolved,
+                dim=cfg.caption_dim_resolved,
+                heads=cfg.caption_heads_resolved,
+                num_layers=cfg.caption_layers_resolved,
+                mlp_ratio=cfg.caption_mlp_ratio_resolved,
+                norm_eps=cfg.norm_eps,
+            )
+            self.caption_norm = RMSNorm(cfg.caption_dim_resolved, eps=cfg.norm_eps)
+            context_dim = cfg.caption_dim_resolved
+            speaker_ctx_dim = None
+            caption_ctx_dim = cfg.caption_dim_resolved
 
         # Timestep → conditioning embedding (3 × model_dim for shift/scale/gate)
         self.cond_module = nn.Sequential(
@@ -519,51 +577,68 @@ class IrodoriDiT(nn.Module):
                 heads=cfg.num_heads,
                 mlp_hidden_dim=mlp_hidden,
                 text_ctx_dim=cfg.text_dim,
-                speaker_ctx_dim=cfg.speaker_dim,
+                speaker_ctx_dim=speaker_ctx_dim,
                 adaln_rank=cfg.adaln_rank,
                 norm_eps=cfg.norm_eps,
+                caption_ctx_dim=caption_ctx_dim,
             )
             for _ in range(cfg.num_layers)
         ]
         self.out_norm = RMSNorm(cfg.model_dim, eps=cfg.norm_eps)
         self.out_proj = nn.Linear(cfg.model_dim, cfg.patched_latent_dim, bias=True)
 
+        self._context_dim = context_dim
+
     # ------------------------------------------------------------------
-    # Condition encoding (text + speaker) — can be cached across steps
+    # Condition encoding (text + speaker/caption) — cached across steps
     # ------------------------------------------------------------------
 
     def encode_conditions(
         self,
         text_input_ids: mx.array,
         text_mask: mx.array,
-        ref_latent: mx.array,
-        ref_mask: mx.array,
+        ref_latent: Optional[mx.array] = None,
+        ref_mask: Optional[mx.array] = None,
+        caption_input_ids: Optional[mx.array] = None,
+        caption_mask: Optional[mx.array] = None,
     ) -> Tuple[mx.array, mx.array, mx.array, mx.array]:
         """
-        Encode text and reference latent into conditioning states.
-        Patches the reference latent before encoding.
-        Returns (text_state, text_mask, speaker_state, speaker_mask).
+        Encode text and context (speaker latent or caption) into conditioning states.
+        Returns (text_state, text_mask, context_state, context_mask).
         """
-        ref_latent, ref_mask = patch_sequence_with_mask(
-            ref_latent, ref_mask, self.cfg.speaker_patch_size
-        )
         text_state = self.text_norm(self.text_encoder(text_input_ids, text_mask))
-        speaker_state = self.speaker_norm(self.speaker_encoder(ref_latent, ref_mask))
-        return text_state, text_mask, speaker_state, ref_mask
+
+        if self.cfg.use_speaker_condition:
+            assert ref_latent is not None and ref_mask is not None
+            ref_latent_p, ref_mask_p = patch_sequence_with_mask(
+                ref_latent, ref_mask, self.cfg.speaker_patch_size
+            )
+            context_state = self.speaker_norm(
+                self.speaker_encoder(ref_latent_p, ref_mask_p)
+            )
+            context_mask = ref_mask_p
+        else:
+            assert caption_input_ids is not None and caption_mask is not None
+            context_state = self.caption_norm(
+                self.caption_encoder(caption_input_ids, caption_mask)
+            )
+            context_mask = caption_mask
+
+        return text_state, text_mask, context_state, context_mask
 
     def build_kv_cache(
         self,
         text_state: mx.array,
-        speaker_state: mx.array,
+        context_state: mx.array,
     ) -> Tuple[List[KVCache], List[KVCache]]:
-        """Pre-compute per-layer text/speaker KV projections for fast sampling."""
+        """Pre-compute per-layer text/context KV projections for fast sampling."""
         kv_text = [
             block.attention.get_kv_cache_text(text_state) for block in self.blocks
         ]
-        kv_speaker = [
-            block.attention.get_kv_cache_speaker(speaker_state) for block in self.blocks
+        kv_context = [
+            block.attention.get_kv_cache_context(context_state) for block in self.blocks
         ]
-        return kv_text, kv_speaker
+        return kv_text, kv_context
 
     # ------------------------------------------------------------------
     # Forward (with pre-encoded conditions)
@@ -581,6 +656,8 @@ class IrodoriDiT(nn.Module):
         kv_speaker: Optional[List[KVCache]] = None,
         start_pos: int = 0,
     ) -> mx.array:
+        # NOTE: speaker_state/speaker_mask/kv_speaker are the generic "context"
+        # (either speaker or caption depending on cfg.use_caption_condition).
         t_embed = get_timestep_embedding(t, self.cfg.timestep_embed_dim).astype(
             x_t.dtype
         )
@@ -598,7 +675,7 @@ class IrodoriDiT(nn.Module):
             kv_s = (
                 kv_speaker[i]
                 if kv_speaker is not None
-                else block.attention.get_kv_cache_speaker(speaker_state)
+                else block.attention.get_kv_cache_context(speaker_state)
             )
             x = block(
                 x,

--- a/mlx_audio/tts/models/irodori_tts/sampling.py
+++ b/mlx_audio/tts/models/irodori_tts/sampling.py
@@ -73,14 +73,15 @@ def sample_euler_cfg(
     model: IrodoriDiT,
     text_input_ids: mx.array,
     text_mask: mx.array,
-    ref_latent: mx.array,
-    ref_mask: mx.array,
+    ref_latent: Optional[mx.array],
+    ref_mask: Optional[mx.array],
     latent_dim: int,
     rng_seed: int = 0,
     sequence_length: int = 750,
     num_steps: int = 40,
     cfg_scale_text: float = 3.0,
     cfg_scale_speaker: float = 5.0,
+    cfg_scale_caption: float = 3.0,
     cfg_guidance_mode: str = "independent",
     cfg_scale: Optional[float] = None,
     cfg_min_t: float = 0.5,
@@ -92,15 +93,17 @@ def sample_euler_cfg(
     speaker_kv_scale: Optional[float] = None,
     speaker_kv_min_t: Optional[float] = None,
     speaker_kv_max_layers: Optional[int] = None,
+    caption_input_ids: Optional[mx.array] = None,
+    caption_mask: Optional[mx.array] = None,
     **_ignored,
 ) -> mx.array:
     """
     Euler sampler for Rectified Flow ODE with Classifier-Free Guidance.
 
     Supports three CFG modes:
-      independent : text and speaker guidance computed in a single 3x-batch forward pass.
-      joint       : single combined unconditional (both text and speaker zeroed).
-      alternating : text-uncond and speaker-uncond alternate each step.
+      independent : text and context guidance computed in a single 3x-batch forward pass.
+      joint       : single combined unconditional (both text and context zeroed).
+      alternating : text-uncond and context-uncond alternate each step.
 
     Returns latent of shape (batch, sequence_length, latent_dim).
     """
@@ -108,6 +111,12 @@ def sample_euler_cfg(
     if cfg_scale is not None:
         cfg_scale_text = float(cfg_scale)
         cfg_scale_speaker = float(cfg_scale)
+        cfg_scale_caption = float(cfg_scale)
+
+    # Resolve context CFG scale based on conditioning mode
+    cfg_scale_context = (
+        cfg_scale_caption if model.cfg.use_caption_condition else cfg_scale_speaker
+    )
 
     cfg_guidance_mode = cfg_guidance_mode.strip().lower()
     if cfg_guidance_mode not in {"independent", "joint", "alternating"}:
@@ -118,7 +127,7 @@ def sample_euler_cfg(
 
     batch_size = text_input_ids.shape[0]
     has_text_cfg = cfg_scale_text > 0
-    has_speaker_cfg = cfg_scale_speaker > 0
+    has_speaker_cfg = cfg_scale_context > 0
 
     # ---- encode conditions once ----
     text_state_cond, text_mask_cond, speaker_state_cond, speaker_mask_cond = (
@@ -127,6 +136,8 @@ def sample_euler_cfg(
             text_mask=text_mask,
             ref_latent=ref_latent,
             ref_mask=ref_mask,
+            caption_input_ids=caption_input_ids,
+            caption_mask=caption_mask,
         )
     )
     mx.eval(text_state_cond, speaker_state_cond)
@@ -260,7 +271,7 @@ def sample_euler_cfg(
                     v_pred = (
                         v_cond
                         + cfg_scale_text * (v_cond - v_uncond_text)
-                        + cfg_scale_speaker * (v_cond - v_uncond_speaker)
+                        + cfg_scale_context * (v_cond - v_uncond_speaker)
                     )
 
                 elif has_text_cfg:
@@ -309,18 +320,18 @@ def sample_euler_cfg(
                         kv_speaker=kv_speaker_cfg,
                     )
                     v_cond, v_uncond_speaker = mx.split(v_out, 2, axis=0)
-                    v_pred = v_cond + cfg_scale_speaker * (v_cond - v_uncond_speaker)
+                    v_pred = v_cond + cfg_scale_context * (v_cond - v_uncond_speaker)
 
             elif cfg_guidance_mode == "joint":
                 if has_text_cfg and has_speaker_cfg:
-                    if abs(cfg_scale_text - cfg_scale_speaker) > 1e-6:
+                    if abs(cfg_scale_text - cfg_scale_context) > 1e-6:
                         raise ValueError(
                             "cfg_guidance_mode='joint' requires equal text/speaker scales. "
                             "Use cfg_scale or set both to the same value."
                         )
                     joint_scale = cfg_scale_text
                 else:
-                    joint_scale = cfg_scale_text if has_text_cfg else cfg_scale_speaker
+                    joint_scale = cfg_scale_text if has_text_cfg else cfg_scale_context
 
                 v_cond = model.forward_with_conditions(
                     x_t=x_t,
@@ -381,7 +392,7 @@ def sample_euler_cfg(
                         kv_text=kv_text_cond,
                         kv_speaker=kv_speaker_uncond_alt,
                     )
-                    v_pred = v_cond + cfg_scale_speaker * (v_cond - v_uncond)
+                    v_pred = v_cond + cfg_scale_context * (v_cond - v_uncond)
 
         else:
             # no CFG this step

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -3981,11 +3981,18 @@ class TestIrodoriVoiceDesignShapes(unittest.TestCase):
         caption_mask = mx.ones((B, 5), dtype=mx.bool_)
 
         text_state, text_mask_out, ctx_state, ctx_mask = self.model.encode_conditions(
-            text_ids, text_mask,
-            caption_input_ids=caption_ids, caption_mask=caption_mask,
+            text_ids,
+            text_mask,
+            caption_input_ids=caption_ids,
+            caption_mask=caption_mask,
         )
         out = self.model.forward_with_conditions(
-            x_t, t, text_state, text_mask_out, ctx_state, ctx_mask,
+            x_t,
+            t,
+            text_state,
+            text_mask_out,
+            ctx_state,
+            ctx_mask,
         )
         mx.eval(out)
         self.assertEqual(tuple(out.shape), (B, S, self.cfg.patched_latent_dim))

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -3617,7 +3617,7 @@ class _FakeDACVAE:
         T = max(1, int(audio_in.shape[1]) // self.downsample_factor)
         return mx.zeros((B, self.latent_dim, T), dtype=mx.float32)
 
-    def decode(self, latent: mx.array) -> mx.array:
+    def decode(self, latent: mx.array, **kwargs) -> mx.array:
         B, _D, T = latent.shape
         return mx.zeros((B, T * self.downsample_factor, 1), dtype=mx.float32)
 
@@ -3913,6 +3913,116 @@ class TestIrodoriGenerateSmoke(unittest.TestCase):
         self.assertGreater(result.token_count, 0)
         self.assertIsNotNone(result.audio_duration)
         self.assertGreater(result.real_time_factor, 0.0)
+
+
+def _small_irodori_dit_config_voicedesign(**overrides):
+    defaults = dict(
+        latent_dim=8,
+        latent_patch_size=1,
+        model_dim=32,
+        num_layers=2,
+        num_heads=4,
+        mlp_ratio=2.0,
+        text_mlp_ratio=2.0,
+        text_vocab_size=64,
+        text_dim=32,
+        text_layers=1,
+        text_heads=4,
+        speaker_dim=32,
+        speaker_layers=1,
+        speaker_heads=4,
+        speaker_patch_size=1,
+        timestep_embed_dim=16,
+        adaln_rank=8,
+        norm_eps=1e-5,
+        use_caption_condition=True,
+        caption_vocab_size=64,
+        caption_dim=32,
+        caption_layers=1,
+        caption_heads=4,
+        caption_mlp_ratio=2.0,
+    )
+    defaults.update(overrides)
+    from mlx_audio.tts.models.irodori_tts.config import IrodoriDiTConfig
+
+    return IrodoriDiTConfig(**defaults)
+
+
+def _small_irodori_model_config_voicedesign(**sampler_overrides):
+    from mlx_audio.tts.models.irodori_tts.config import ModelConfig, SamplerConfig
+
+    sampler_defaults = dict(
+        num_steps=1,
+        cfg_scale_text=1.0,
+        cfg_scale_caption=1.0,
+        sequence_length=4,
+    )
+    sampler_defaults.update(sampler_overrides)
+    return ModelConfig(
+        dit=_small_irodori_dit_config_voicedesign(),
+        sampler=SamplerConfig(**sampler_defaults),
+    )
+
+
+class TestIrodoriVoiceDesignShapes(unittest.TestCase):
+    def setUp(self):
+        from mlx_audio.tts.models.irodori_tts.model import IrodoriDiT
+
+        self.cfg = _small_irodori_dit_config_voicedesign()
+        self.model = IrodoriDiT(self.cfg)
+
+    def test_forward_shape(self):
+        B, S = 1, 6
+        x_t = mx.random.normal((B, S, self.cfg.patched_latent_dim))
+        t = mx.array([0.5], dtype=mx.float32)
+        text_ids = mx.zeros((B, 5), dtype=mx.int32)
+        text_mask = mx.ones((B, 5), dtype=mx.bool_)
+        caption_ids = mx.zeros((B, 5), dtype=mx.int32)
+        caption_mask = mx.ones((B, 5), dtype=mx.bool_)
+
+        text_state, text_mask_out, ctx_state, ctx_mask = self.model.encode_conditions(
+            text_ids, text_mask,
+            caption_input_ids=caption_ids, caption_mask=caption_mask,
+        )
+        out = self.model.forward_with_conditions(
+            x_t, t, text_state, text_mask_out, ctx_state, ctx_mask,
+        )
+        mx.eval(out)
+        self.assertEqual(tuple(out.shape), (B, S, self.cfg.patched_latent_dim))
+
+
+class TestIrodoriVoiceDesignGenerate(unittest.TestCase):
+    def _make_model(self):
+        from mlx_audio.tts.models.irodori_tts.irodori_tts import Model
+
+        cfg = _small_irodori_model_config_voicedesign()
+        model = Model(cfg)
+        model.dacvae = _FakeDACVAE(
+            latent_dim=cfg.dit.latent_dim,
+            downsample_factor=cfg.audio_downsample_factor,
+        )
+        model._tokenizer = _MockTokenizer()
+        model._caption_tokenizer = _MockTokenizer()
+        return model
+
+    def test_generate_with_caption(self):
+        model = self._make_model()
+        results = list(model.generate("こんにちは", caption="穏やかな声", rng_seed=0))
+        self.assertEqual(len(results), 1)
+        self.assertGreater(results[0].samples, 0)
+
+    def test_generate_with_instruct_alias(self):
+        model = self._make_model()
+        results = list(model.generate("こんにちは", instruct="明るい声", rng_seed=0))
+        self.assertEqual(len(results), 1)
+        self.assertGreater(results[0].samples, 0)
+
+    def test_generate_instruct_takes_priority_over_none_caption(self):
+        model = self._make_model()
+        # instruct should be used when caption is not provided
+        results = list(model.generate("テスト", instruct="低い声", rng_seed=0))
+        self.assertEqual(len(results), 1)
+        self.assertGreater(results[0].samples, 0)
 
 
 class TestKugelAudioModel(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add Irodori-TTS v2 support (latent_dim=32, Semantic-DACVAE) alongside existing v1
- Add VoiceDesign variant: caption/voice-description conditioning instead of reference audio
- Accept `instruct` kwarg as alias for `caption` (mlx-audio convention)
- Use chunked DACVAE decoding (`chunk_size=50`) to stay within 16 GB memory limits on Apple Silicon

## Uploaded models

| Model | HuggingFace |
|---|---|
| fp16 | [mlx-community/Irodori-TTS-500M-v2-fp16](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-fp16) |
| 8bit | [mlx-community/Irodori-TTS-500M-v2-8bit](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-8bit) |
| 4bit | [mlx-community/Irodori-TTS-500M-v2-4bit](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-4bit) |
| VoiceDesign fp16 | [mlx-community/Irodori-TTS-500M-v2-VoiceDesign-fp16](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-VoiceDesign-fp16) |
| VoiceDesign 8bit | [mlx-community/Irodori-TTS-500M-v2-VoiceDesign-8bit](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-VoiceDesign-8bit) |
| VoiceDesign 4bit | [mlx-community/Irodori-TTS-500M-v2-VoiceDesign-4bit](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-VoiceDesign-4bit) |

## Audio comparison

Text: 「その森には、古い言い伝えがありました。月が最も高く昇る夜、静かに耳を澄ませば、風の歌声が聞こえるというのです。私は半信半疑でしたが、その夜、確かに誰かが私を呼ぶ声を聞いたのです。」

| | Audio |
|---|---|
| **Original** (Aratako/Irodori-TTS-500M-v2, PyTorch) | [standard_sample2.wav](https://huggingface.co/Aratako/Irodori-TTS-500M-v2/resolve/main/samples/standard_sample2.wav) |
| **MLX port** (fp16) | [standard_sample2_mlx.wav](https://huggingface.co/mlx-community/Irodori-TTS-500M-v2-fp16/resolve/main/samples/standard_sample2_mlx.wav) |

## Usage

### Standard (voice cloning)
```python
from mlx_audio.tts.generate import generate_audio

generate_audio(
    model="mlx-community/Irodori-TTS-500M-v2-fp16",
    text="こんにちは、テストです。",
    ref_audio="path/to/reference.wav",
    file_prefix="output",
)
```

### VoiceDesign (voice description)
```python
generate_audio(
    model="mlx-community/Irodori-TTS-500M-v2-VoiceDesign-fp16",
    text="こんにちは、テストです。",
    instruct="穏やかで落ち着いた女性の声。ゆっくりと話す。",
    file_prefix="output",
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)