### PR TITLE
Improve performance of Parakeet TDT on longform content

### DIFF
--- a/mlx_audio/stt/models/parakeet/parakeet.py
+++ b/mlx_audio/stt/models/parakeet/parakeet.py
@@ -538,9 +538,9 @@ class ParakeetTDT(Model):
         cell_out = cell_out.astype(feature.dtype)
 
         joint_output = self.joint(feature, decoder_output)
-        pred_token = mx.argmax(
-            joint_output[0, 0, :, : self.blank_id + 1]
-        ).astype(mx.int32)
+        pred_token = mx.argmax(joint_output[0, 0, :, : self.blank_id + 1]).astype(
+            mx.int32
+        )
         decision = mx.argmax(joint_output[0, 0, :, self.blank_id + 1 :]).astype(
             mx.int32
         )

--- a/mlx_audio/stt/models/parakeet/parakeet.py
+++ b/mlx_audio/stt/models/parakeet/parakeet.py
@@ -181,7 +181,7 @@ class Model(nn.Module):
             chunk_duration: Optional chunk duration in seconds. Defaults to no
                 chunking for non-streaming and 5.0s for streaming.
             overlap_duration: Optional overlap between chunks in seconds.
-                Defaults to 15.0s for non-streaming chunking and 1.0s for
+                Defaults to 2.0s for non-streaming chunking and 1.0s for
                 streaming.
             chunk_callback: A function to call back when chunk is processed, called with (current_position, total_position)
             stream: If True, yields streaming results instead of returning final result
@@ -216,7 +216,7 @@ class Model(nn.Module):
         if chunk_duration is None:
             return self.decode_chunk(audio_data, verbose)
 
-        overlap_duration = 15.0 if overlap_duration is None else overlap_duration
+        overlap_duration = 2.0 if overlap_duration is None else overlap_duration
 
         if overlap_duration >= chunk_duration:
             raise ValueError(
@@ -499,6 +499,7 @@ class ParakeetTDT(Model):
 
         self.vocabulary = args.joint.vocabulary
         self.durations = args.decoding.durations
+        self.blank_id = len(self.vocabulary)
         self.max_symbols: int | None = (
             args.decoding.greedy.get("max_symbols", None)
             if args.decoding.greedy
@@ -508,6 +509,42 @@ class ParakeetTDT(Model):
         self.encoder = Conformer(args.encoder)
         self.decoder = PredictNetwork(args.decoder)
         self.joint = JointNetwork(args.joint)
+        self._compiled_tdt_step = mx.compile(self._tdt_step)
+
+    def _make_initial_decoder_state(
+        self, batch_size: int, dtype: mx.Dtype
+    ) -> tuple[mx.array, mx.array]:
+        dec_rnn = self.decoder.prediction["dec_rnn"]
+        shape = (dec_rnn.num_layers, batch_size, dec_rnn.hidden_size)
+        zeros = mx.zeros(shape, dtype=dtype)
+        return zeros, zeros
+
+    def _tdt_step(
+        self,
+        feature: mx.array,
+        current_token: mx.array,
+        hidden: mx.array,
+        cell: mx.array,
+    ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
+        embedded = self.decoder.prediction["embed"](current_token)
+        blank_mask = mx.expand_dims(current_token == self.blank_id, axis=-1)
+        embedded = mx.where(blank_mask, mx.zeros_like(embedded), embedded)
+
+        decoder_output, (hidden_out, cell_out) = self.decoder.prediction["dec_rnn"](
+            embedded, (hidden, cell)
+        )
+        decoder_output = decoder_output.astype(feature.dtype)
+        hidden_out = hidden_out.astype(feature.dtype)
+        cell_out = cell_out.astype(feature.dtype)
+
+        joint_output = self.joint(feature, decoder_output)
+        pred_token = mx.argmax(
+            joint_output[0, 0, :, : self.blank_id + 1]
+        ).astype(mx.int32)
+        decision = mx.argmax(joint_output[0, 0, :, self.blank_id + 1 :]).astype(
+            mx.int32
+        )
+        return pred_token, decision, hidden_out, cell_out
 
     def decode(self, mel: mx.array) -> list[AlignedResult]:
         """
@@ -527,44 +564,29 @@ class ParakeetTDT(Model):
             features = batch_features[b : b + 1]
             max_length = int(lengths[b])
 
-            last_token = len(
-                self.vocabulary
-            )  # In TDT, space token is always len(vocab)
+            last_token = self.blank_id
             hypothesis = []
 
             time = 0
             new_symbols = 0
-            decoder_hidden = None
+            decoder_hidden = self._make_initial_decoder_state(1, features.dtype)
 
             while time < max_length:
                 feature = features[:, time : time + 1]
 
-                current_token = (
-                    mx.array([[last_token]], dtype=mx.int32)
-                    if last_token != len(self.vocabulary)
-                    else None
+                current_token = mx.array([[last_token]], dtype=mx.int32)
+                pred_token, decision, hidden, cell = self._compiled_tdt_step(
+                    feature, current_token, decoder_hidden[0], decoder_hidden[1]
                 )
-                decoder_output, (hidden, cell) = self.decoder(
-                    current_token, decoder_hidden
-                )
+                mx.eval(pred_token, decision, hidden, cell)
 
-                # cast
-                decoder_output = decoder_output.astype(feature.dtype)
-                proposed_decoder_hidden = (
-                    hidden.astype(feature.dtype),
-                    cell.astype(feature.dtype),
-                )
+                pred_token_i = int(pred_token)
+                decision_i = int(decision)
+                duration_i = self.durations[decision_i]
 
-                joint_output = self.joint(feature, decoder_output)
-
-                pred_token = mx.argmax(
-                    joint_output[0, 0, :, : len(self.vocabulary) + 1]
-                )
-                decision = mx.argmax(joint_output[0, 0, :, len(self.vocabulary) + 1 :])
-
-                if pred_token != len(self.vocabulary):
-                    last_token = int(pred_token)
-                    decoder_hidden = proposed_decoder_hidden
+                if pred_token_i != self.blank_id:
+                    last_token = pred_token_i
+                    decoder_hidden = (hidden, cell)
                     if not tokenizer.is_special_token(last_token, self.vocabulary):
                         hypothesis.append(
                             AlignedToken(
@@ -573,7 +595,7 @@ class ParakeetTDT(Model):
                                 * self.encoder_config.subsampling_factor
                                 / self.preprocessor_config.sample_rate
                                 * self.preprocessor_config.hop_length,
-                                duration=self.durations[int(decision)]
+                                duration=duration_i
                                 * self.encoder_config.subsampling_factor
                                 / self.preprocessor_config.sample_rate
                                 * self.preprocessor_config.hop_length,
@@ -581,10 +603,10 @@ class ParakeetTDT(Model):
                             )
                         )
 
-                time += self.durations[int(decision)]
+                time += duration_i
                 new_symbols += 1
 
-                if self.durations[int(decision)] != 0:
+                if duration_i != 0:
                     new_symbols = 0
                 else:
                     if self.max_symbols is not None and self.max_symbols <= new_symbols:


### PR DESCRIPTION
Compile the TDT decode loop and adjust the overlap to a more reasonable value. This improves longform RTFx from `82.14x` to `163.87x` on my M5 Max for a one hour audio clip.