### PR TITLE
feat(higgs_audio): overlap-add mid-generation streaming

### DIFF
--- a/mlx_audio/tts/models/higgs_audio/model.py
+++ b/mlx_audio/tts/models/higgs_audio/model.py
@@ -26,7 +26,12 @@ import numpy as np
 from ..base import GenerationResult
 from .config import HiggsAudioConfig
 from .higgs_audio import HiggsAudioModel
-from .serve import build_prompt
+from .serve import build_prompt, iter_overlap_add_pcm
+
+# Higgs v2 codec emits one frame per ~40 ms (24 kHz × 8× upsample × 240
+# patch). Used to convert the framework-level ``streaming_interval``
+# (seconds) into ``emit_every_frames`` for the overlap-add helper.
+_HIGGS_CODEC_FRAME_S = 0.04
 
 # Framework loader reads `module.ModelConfig.from_dict(config_json)`; aliasing
 # HiggsAudioConfig keeps a single source of truth.
@@ -129,23 +134,35 @@ class Model(HiggsAudioModel):
         fade_in_ms: float = 30.0,
         fade_out_ms: float = 15.0,
         verbose: bool = False,
+        stream: bool = False,
+        streaming_interval: float = 2.0,
+        overlap_ms: float = 40.0,
         **kwargs,  # absorb framework kwargs we don't use (speed, lang_code, ...)
     ) -> Iterator[GenerationResult]:
-        """Synthesize `text` and yield a single `GenerationResult`.
+        """Synthesize ``text`` and yield ``GenerationResult``(s).
 
-        Voice cloning: pass `ref_audio` (mono 24 kHz mx.array or numpy array,
-        loaded by the top-level CLI from `--ref_audio`) together with
-        `ref_text` (its transcript). Without `ref_audio`, runs smart-voice
-        mode — works but less reliable; recommended to always supply a
-        reference for production use.
+        When ``stream=False`` (default): yields a single ``GenerationResult``
+        containing the full utterance — identical to the pre-streaming path.
+
+        When ``stream=True``: yields intermediate chunks via overlap-add
+        mid-generation streaming, with ``is_streaming_chunk=True`` on every
+        yield and ``is_final_chunk=True`` on the last. ``streaming_interval``
+        (seconds) controls chunk granularity — a Higgs codec frame is ~40 ms,
+        so the framework default of 2.0 s ≈ 50 frames per chunk. Lower
+        interval means lower TTFB at the cost of more re-decode overhead;
+        ~0.6 s is a reasonable conversational-voice setting.
+
+        Voice cloning: pass ``ref_audio`` (mono 24 kHz ``mx.array`` or
+        ``numpy.ndarray``, loaded by the top-level CLI from ``--ref_audio``)
+        together with ``ref_text`` (its transcript). Without ``ref_audio``,
+        runs smart-voice mode — works but less reliable; recommended to
+        always supply a reference for production use.
         """
         if self._tokenizer is None or self._codec is None:
             raise RuntimeError(
                 "Model not fully loaded — tokenizer/codec missing. Load via "
                 "mlx_audio.tts.utils.load(...) so post_load_hook runs."
             )
-
-        start = time.perf_counter()
 
         ref_audio_24k = None
         if ref_audio is not None:
@@ -161,6 +178,57 @@ class Model(HiggsAudioModel):
             embed_tokens=self.embed_tokens,
             audio_codebook_embeddings=self.audio_codebook_embeddings,
         )
+
+        if stream:
+            yield from self._generate_streaming(
+                full_embeds=full_embeds,
+                audio_out_mask=audio_out_mask,
+                max_new_frames=max_new_frames,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                ras_win_len=ras_win_len,
+                ras_max_repeat=ras_max_repeat,
+                sampling_warmup_frames=sampling_warmup_frames,
+                streaming_interval=streaming_interval,
+                overlap_ms=overlap_ms,
+                fade_in_ms=fade_in_ms,
+                fade_out_ms=fade_out_ms,
+            )
+        else:
+            yield from self._generate_oneshot(
+                full_embeds=full_embeds,
+                audio_out_mask=audio_out_mask,
+                max_new_frames=max_new_frames,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                ras_win_len=ras_win_len,
+                ras_max_repeat=ras_max_repeat,
+                sampling_warmup_frames=sampling_warmup_frames,
+                fade_in_ms=fade_in_ms,
+                fade_out_ms=fade_out_ms,
+            )
+
+    # --- generation backends -------------------------------------------
+
+    def _generate_oneshot(
+        self,
+        *,
+        full_embeds: mx.array,
+        audio_out_mask: mx.array,
+        max_new_frames: int,
+        temperature: float,
+        top_p: Optional[float],
+        top_k: Optional[int],
+        ras_win_len: Optional[int],
+        ras_max_repeat: int,
+        sampling_warmup_frames: int,
+        fade_in_ms: float,
+        fade_out_ms: float,
+    ) -> Iterator[GenerationResult]:
+        """Non-streaming path — generate all frames, decode once, yield one result."""
+        start = time.perf_counter()
 
         # Call the inherited HiggsAudioModel.generate (delay-pattern state machine).
         aligned, gen_info = HiggsAudioModel.generate(
@@ -215,3 +283,87 @@ class Model(HiggsAudioModel):
             processing_time_seconds=elapsed,
             peak_memory_usage=mx.get_peak_memory() / 1e9,
         )
+
+    def _generate_streaming(
+        self,
+        *,
+        full_embeds: mx.array,
+        audio_out_mask: mx.array,
+        max_new_frames: int,
+        temperature: float,
+        top_p: Optional[float],
+        top_k: Optional[int],
+        ras_win_len: Optional[int],
+        ras_max_repeat: int,
+        sampling_warmup_frames: int,
+        streaming_interval: float,
+        overlap_ms: float,
+        fade_in_ms: float,
+        fade_out_ms: float,
+    ) -> Iterator[GenerationResult]:
+        """Streaming path — overlap-add mid-generation, one ``GenerationResult`` per chunk."""
+        sr = self._sample_rate
+        emit_every_frames = max(1, int(streaming_interval / _HIGGS_CODEC_FRAME_S))
+
+        chunks_iter = iter_overlap_add_pcm(
+            model=self,
+            codec=self._codec,
+            config=self._config,
+            full_embeds=full_embeds,
+            audio_out_mask=audio_out_mask,
+            max_new_frames=max_new_frames,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            ras_win_len=ras_win_len,
+            ras_max_repeat=ras_max_repeat,
+            sampling_warmup_frames=sampling_warmup_frames,
+            emit_every_frames=emit_every_frames,
+            overlap_ms=overlap_ms,
+            fade_in_ms=fade_in_ms,
+            fade_out_ms=fade_out_ms,
+            sample_rate=sr,
+        )
+
+        chunk_idx = 0
+        prev_frames_total = 0
+        chunk_start = time.perf_counter()
+        for pcm_chunk, meta in chunks_iter:
+            elapsed = time.perf_counter() - chunk_start
+            chunk_samples = int(pcm_chunk.size)
+            chunk_duration = chunk_samples / sr if sr > 0 else 0.0
+            frames_total = int(meta.get("frames_total", 0))
+            chunk_tokens = max(0, frames_total - prev_frames_total)
+            is_final = bool(meta.get("is_final"))
+
+            yield GenerationResult(
+                audio=mx.array(pcm_chunk),
+                samples=chunk_samples,
+                sample_rate=sr,
+                segment_idx=chunk_idx,
+                token_count=chunk_tokens,
+                audio_duration=_format_duration(chunk_duration),
+                real_time_factor=(
+                    round(chunk_duration / elapsed, 3) if elapsed > 0 else 0.0
+                ),
+                prompt={
+                    "tokens": chunk_tokens,
+                    "tokens-per-sec": (
+                        round(chunk_tokens / elapsed, 2) if elapsed > 0 else 0.0
+                    ),
+                },
+                audio_samples={
+                    "samples": chunk_samples,
+                    "samples-per-sec": (
+                        round(chunk_samples / elapsed, 2) if elapsed > 0 else 0.0
+                    ),
+                },
+                processing_time_seconds=elapsed,
+                peak_memory_usage=mx.get_peak_memory() / 1e9,
+                is_streaming_chunk=True,
+                is_final_chunk=is_final,
+            )
+
+            chunk_idx += 1
+            prev_frames_total = frames_total
+            chunk_start = time.perf_counter()

--- a/mlx_audio/tts/models/higgs_audio/serve.py
+++ b/mlx_audio/tts/models/higgs_audio/serve.py
@@ -33,7 +33,11 @@ import numpy as np
 
 from ....codec.models.higgs_audio.higgs_audio import HiggsAudioTokenizer
 from .config import HiggsAudioConfig
-from .generation import build_delay_pattern_mask, lookup_audio_embedding
+from .generation import (
+    build_delay_pattern_mask,
+    lookup_audio_embedding,
+    revert_delay_pattern,
+)
 from .higgs_audio import HiggsAudioModel
 
 
@@ -535,3 +539,187 @@ class HiggsAudioServer:
         pcm = result.pcm
         for i in range(0, pcm.size, samples_per_chunk):
             yield pcm[i : i + samples_per_chunk]
+
+    def generate_stream_overlap_add(
+        self,
+        target_text: str,
+        *,
+        reference_audio_path: Optional[str] = None,
+        reference_text: Optional[str] = None,
+        max_new_frames: int = 900,
+        temperature: float = 0.7,
+        top_p: Optional[float] = 0.95,
+        top_k: Optional[int] = None,
+        ras_win_len: Optional[int] = 7,
+        ras_max_repeat: int = 2,
+        sampling_warmup_frames: int = 0,
+        emit_every_frames: int = 16,
+        overlap_ms: float = 40.0,
+        fade_in_ms: float = 5.0,
+        fade_out_ms: float = 5.0,
+    ) -> Iterator[np.ndarray]:
+        """Mid-generation streaming via overlap-add.
+
+        Re-decodes the accumulated codec sequence every `emit_every_frames`
+        codec frames. The neural vocoder's output at a given sample depends
+        on context, so re-decoding at length N vs length N+K produces
+        slightly different PCM near the right edge of the shorter decode.
+
+        Strategy: hold the last `overlap_ms` of each decode as a buffer.
+        On the next decode, crossfade linearly (fade-out × buffered tail +
+        fade-in × new-decode's same-position samples) and emit the
+        smoothed region. This replaces the edge-affected tail of each
+        decode with the full-context version from the longer decode.
+
+        Cost: O(T²/emit_every_frames) decode work — at emit_every_frames=16
+        (~640 ms) this is a few percent of generation cost. TTFB shrinks
+        from full-generation wall time to ~(emit_every_frames / 25) s.
+        """
+        sr = 24000
+        overlap_samples = int(overlap_ms * sr / 1000.0)
+        K = self.config.audio_num_codebooks
+        audio_codebook_size = self.config.audio_codebook_size
+
+        full_embeds, audio_out_mask, _info = self._build_prompt(
+            target_text, reference_text, reference_audio_path
+        )
+
+        n_fade_in = int(fade_in_ms * sr / 1000.0)
+        n_fade_out = int(fade_out_ms * sr / 1000.0)
+
+        frames_raw: list[mx.array] = []
+        overlap_tail: Optional[np.ndarray] = None
+        emitted_samples = 0
+        raw_frames_at_last_emit = 0
+        is_first_chunk = True
+        done_via_eos = False
+
+        def _decode_current() -> Optional[np.ndarray]:
+            sequence = mx.stack(frames_raw, axis=1).astype(mx.int32)
+            aligned = revert_delay_pattern(sequence)
+            if aligned.shape[1] < 2:
+                return None
+            aligned = aligned[:, 1:-1]
+            if aligned.shape[1] == 0:
+                return None
+            aligned = mx.clip(aligned, 0, audio_codebook_size - 1)
+            pcm = self.codec.decode(aligned.T)
+            mx.eval(pcm)
+            return np.array(pcm).astype(np.float32).reshape(-1)
+
+        for tok, meta in self.model._generate_raw_frames(
+            full_embeds,
+            audio_out_mask,
+            max_new_frames=max_new_frames,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            ras_win_len=ras_win_len,
+            ras_max_repeat=ras_max_repeat,
+            sampling_warmup_frames=sampling_warmup_frames,
+        ):
+            frames_raw.append(tok)
+
+            done_via_eos = (
+                meta.get("num_remaining_delays") is not None
+                and meta["num_remaining_delays"] <= 0
+            )
+
+            have_enough = len(frames_raw) > K + 1
+            frames_since_last = len(frames_raw) - raw_frames_at_last_emit
+            should_emit = have_enough and (
+                done_via_eos or frames_since_last >= emit_every_frames
+            )
+            if not should_emit:
+                continue
+            raw_frames_at_last_emit = len(frames_raw)
+
+            pcm_np = _decode_current()
+            if pcm_np is None:
+                continue
+
+            if is_first_chunk:
+                if n_fade_in > 0 and pcm_np.size > n_fade_in:
+                    pcm_np[:n_fade_in] *= np.linspace(
+                        0.0, 1.0, n_fade_in, dtype=np.float32
+                    )
+                if done_via_eos:
+                    if n_fade_out > 0 and pcm_np.size > n_fade_out:
+                        pcm_np[-n_fade_out:] *= np.linspace(
+                            1.0, 0.0, n_fade_out, dtype=np.float32
+                        )
+                    yield pcm_np.copy()
+                    return
+                if pcm_np.size > overlap_samples:
+                    yield pcm_np[:-overlap_samples].copy()
+                    overlap_tail = pcm_np[-overlap_samples:].copy()
+                    emitted_samples = pcm_np.size - overlap_samples
+                else:
+                    overlap_tail = pcm_np.copy()
+                    emitted_samples = 0
+                is_first_chunk = False
+                continue
+
+            # Subsequent chunk: crossfade overlap_tail with new decode's
+            # same-position samples, then emit middle region.
+            if overlap_tail is None or pcm_np.size < emitted_samples + overlap_samples:
+                continue
+            new_overlap_region = pcm_np[
+                emitted_samples : emitted_samples + overlap_samples
+            ]
+            fade_out = np.linspace(1.0, 0.0, overlap_samples, dtype=np.float32)
+            fade_in = np.linspace(0.0, 1.0, overlap_samples, dtype=np.float32)
+            crossfaded = overlap_tail * fade_out + new_overlap_region * fade_in
+
+            if done_via_eos:
+                tail_pcm = pcm_np[emitted_samples + overlap_samples :].copy()
+                if n_fade_out > 0 and tail_pcm.size > n_fade_out:
+                    tail_pcm[-n_fade_out:] *= np.linspace(
+                        1.0, 0.0, n_fade_out, dtype=np.float32
+                    )
+                yield np.concatenate([crossfaded, tail_pcm])
+                return
+
+            new_middle_start = emitted_samples + overlap_samples
+            new_middle_end = pcm_np.size - overlap_samples
+            if new_middle_end > new_middle_start:
+                middle = pcm_np[new_middle_start:new_middle_end].copy()
+                yield np.concatenate([crossfaded, middle])
+                overlap_tail = pcm_np[-overlap_samples:].copy()
+                emitted_samples = new_middle_end
+            else:
+                yield crossfaded.copy()
+                overlap_tail = pcm_np[-overlap_samples:].copy()
+                emitted_samples = pcm_np.size - overlap_samples
+
+        # Post-loop flush: generator exited without EOS (hit max_new_frames).
+        # Emit remaining frames as a "final" chunk with fade-out.
+        if done_via_eos or raw_frames_at_last_emit >= len(frames_raw):
+            return
+        pcm_np = _decode_current()
+        if pcm_np is None:
+            return
+
+        if is_first_chunk:
+            # Nothing yet emitted — full utterance fits in one final chunk.
+            if n_fade_in > 0 and pcm_np.size > n_fade_in:
+                pcm_np[:n_fade_in] *= np.linspace(0.0, 1.0, n_fade_in, dtype=np.float32)
+            if n_fade_out > 0 and pcm_np.size > n_fade_out:
+                pcm_np[-n_fade_out:] *= np.linspace(
+                    1.0, 0.0, n_fade_out, dtype=np.float32
+                )
+            yield pcm_np.copy()
+            return
+
+        if overlap_tail is None or pcm_np.size < emitted_samples + overlap_samples:
+            return
+        new_overlap_region = pcm_np[emitted_samples : emitted_samples + overlap_samples]
+        fade_out = np.linspace(1.0, 0.0, overlap_samples, dtype=np.float32)
+        fade_in = np.linspace(0.0, 1.0, overlap_samples, dtype=np.float32)
+        crossfaded = overlap_tail * fade_out + new_overlap_region * fade_in
+        tail_pcm = pcm_np[emitted_samples + overlap_samples :].copy()
+        if n_fade_out > 0 and tail_pcm.size > n_fade_out:
+            tail_pcm[-n_fade_out:] *= np.linspace(
+                1.0, 0.0, n_fade_out, dtype=np.float32
+            )
+        yield np.concatenate([crossfaded, tail_pcm])

--- a/mlx_audio/tts/models/higgs_audio/serve.py
+++ b/mlx_audio/tts/models/higgs_audio/serve.py
@@ -558,58 +558,21 @@ class HiggsAudioServer:
         fade_in_ms: float = 5.0,
         fade_out_ms: float = 5.0,
     ) -> Iterator[np.ndarray]:
-        """Mid-generation streaming via overlap-add.
+        """Mid-generation streaming via overlap-add. Yields PCM chunks.
 
-        Re-decodes the accumulated codec sequence every `emit_every_frames`
-        codec frames. The neural vocoder's output at a given sample depends
-        on context, so re-decoding at length N vs length N+K produces
-        slightly different PCM near the right edge of the shorter decode.
-
-        Strategy: hold the last `overlap_ms` of each decode as a buffer.
-        On the next decode, crossfade linearly (fade-out × buffered tail +
-        fade-in × new-decode's same-position samples) and emit the
-        smoothed region. This replaces the edge-affected tail of each
-        decode with the full-context version from the longer decode.
-
-        Cost: O(T²/emit_every_frames) decode work — at emit_every_frames=16
-        (~640 ms) this is a few percent of generation cost. TTFB shrinks
-        from full-generation wall time to ~(emit_every_frames / 25) s.
+        Thin wrapper around :func:`iter_overlap_add_pcm` that builds the prompt
+        from the server's tokenizer/codec/cache state and strips the per-chunk
+        meta. See the helper for the algorithm rationale.
         """
-        sr = 24000
-        overlap_samples = int(overlap_ms * sr / 1000.0)
-        K = self.config.audio_num_codebooks
-        audio_codebook_size = self.config.audio_codebook_size
-
         full_embeds, audio_out_mask, _info = self._build_prompt(
             target_text, reference_text, reference_audio_path
         )
-
-        n_fade_in = int(fade_in_ms * sr / 1000.0)
-        n_fade_out = int(fade_out_ms * sr / 1000.0)
-
-        frames_raw: list[mx.array] = []
-        overlap_tail: Optional[np.ndarray] = None
-        emitted_samples = 0
-        raw_frames_at_last_emit = 0
-        is_first_chunk = True
-        done_via_eos = False
-
-        def _decode_current() -> Optional[np.ndarray]:
-            sequence = mx.stack(frames_raw, axis=1).astype(mx.int32)
-            aligned = revert_delay_pattern(sequence)
-            if aligned.shape[1] < 2:
-                return None
-            aligned = aligned[:, 1:-1]
-            if aligned.shape[1] == 0:
-                return None
-            aligned = mx.clip(aligned, 0, audio_codebook_size - 1)
-            pcm = self.codec.decode(aligned.T)
-            mx.eval(pcm)
-            return np.array(pcm).astype(np.float32).reshape(-1)
-
-        for tok, meta in self.model._generate_raw_frames(
-            full_embeds,
-            audio_out_mask,
+        for chunk, _meta in iter_overlap_add_pcm(
+            model=self.model,
+            codec=self.codec,
+            config=self.config,
+            full_embeds=full_embeds,
+            audio_out_mask=audio_out_mask,
             max_new_frames=max_new_frames,
             temperature=temperature,
             top_p=top_p,
@@ -617,109 +580,217 @@ class HiggsAudioServer:
             ras_win_len=ras_win_len,
             ras_max_repeat=ras_max_repeat,
             sampling_warmup_frames=sampling_warmup_frames,
+            emit_every_frames=emit_every_frames,
+            overlap_ms=overlap_ms,
+            fade_in_ms=fade_in_ms,
+            fade_out_ms=fade_out_ms,
         ):
-            frames_raw.append(tok)
+            yield chunk
 
-            done_via_eos = (
-                meta.get("num_remaining_delays") is not None
-                and meta["num_remaining_delays"] <= 0
-            )
 
-            have_enough = len(frames_raw) > K + 1
-            frames_since_last = len(frames_raw) - raw_frames_at_last_emit
-            should_emit = have_enough and (
-                done_via_eos or frames_since_last >= emit_every_frames
-            )
-            if not should_emit:
-                continue
-            raw_frames_at_last_emit = len(frames_raw)
+# ----------------------------------------------------------------------
+# Streaming helper
+# ----------------------------------------------------------------------
+#
+# Shared between :meth:`HiggsAudioServer.generate_stream_overlap_add` (rich
+# kwarg-style API yielding raw PCM) and the framework-conforming
+# :class:`mlx_audio.tts.models.higgs_audio.model.Model.generate` (yields
+# ``GenerationResult`` when ``stream=True``). Both call this helper; the
+# overlap-add algorithm lives in exactly one place.
 
-            pcm_np = _decode_current()
-            if pcm_np is None:
-                continue
 
-            if is_first_chunk:
-                if n_fade_in > 0 and pcm_np.size > n_fade_in:
-                    pcm_np[:n_fade_in] *= np.linspace(
-                        0.0, 1.0, n_fade_in, dtype=np.float32
-                    )
-                if done_via_eos:
-                    if n_fade_out > 0 and pcm_np.size > n_fade_out:
-                        pcm_np[-n_fade_out:] *= np.linspace(
-                            1.0, 0.0, n_fade_out, dtype=np.float32
-                        )
-                    yield pcm_np.copy()
-                    return
-                if pcm_np.size > overlap_samples:
-                    yield pcm_np[:-overlap_samples].copy()
-                    overlap_tail = pcm_np[-overlap_samples:].copy()
-                    emitted_samples = pcm_np.size - overlap_samples
-                else:
-                    overlap_tail = pcm_np.copy()
-                    emitted_samples = 0
-                is_first_chunk = False
-                continue
+def iter_overlap_add_pcm(
+    *,
+    model,  # HiggsAudioModel — exposes _generate_raw_frames
+    codec,  # HiggsAudioTokenizer — decodes [K, T] codes → PCM
+    config: HiggsAudioConfig,
+    full_embeds: mx.array,
+    audio_out_mask: mx.array,
+    max_new_frames: int = 900,
+    temperature: float = 0.7,
+    top_p: Optional[float] = 0.95,
+    top_k: Optional[int] = None,
+    ras_win_len: Optional[int] = 7,
+    ras_max_repeat: int = 2,
+    sampling_warmup_frames: int = 0,
+    emit_every_frames: int = 16,
+    overlap_ms: float = 40.0,
+    fade_in_ms: float = 5.0,
+    fade_out_ms: float = 5.0,
+    sample_rate: int = 24000,
+) -> Iterator[Tuple[np.ndarray, dict]]:
+    """Mid-generation overlap-add streaming. Yields ``(pcm_chunk, meta)``.
 
-            # Subsequent chunk: crossfade overlap_tail with new decode's
-            # same-position samples, then emit middle region.
-            if overlap_tail is None or pcm_np.size < emitted_samples + overlap_samples:
-                continue
-            new_overlap_region = pcm_np[
-                emitted_samples : emitted_samples + overlap_samples
-            ]
-            fade_out = np.linspace(1.0, 0.0, overlap_samples, dtype=np.float32)
-            fade_in = np.linspace(0.0, 1.0, overlap_samples, dtype=np.float32)
-            crossfaded = overlap_tail * fade_out + new_overlap_region * fade_in
+    ``meta`` contains:
 
-            if done_via_eos:
-                tail_pcm = pcm_np[emitted_samples + overlap_samples :].copy()
-                if n_fade_out > 0 and tail_pcm.size > n_fade_out:
-                    tail_pcm[-n_fade_out:] *= np.linspace(
-                        1.0, 0.0, n_fade_out, dtype=np.float32
-                    )
-                yield np.concatenate([crossfaded, tail_pcm])
-                return
+    - ``is_final`` (bool): True iff this is the last chunk of the stream.
+    - ``frames_total`` (int): cumulative raw codec frames generated so far.
 
-            new_middle_start = emitted_samples + overlap_samples
-            new_middle_end = pcm_np.size - overlap_samples
-            if new_middle_end > new_middle_start:
-                middle = pcm_np[new_middle_start:new_middle_end].copy()
-                yield np.concatenate([crossfaded, middle])
-                overlap_tail = pcm_np[-overlap_samples:].copy()
-                emitted_samples = new_middle_end
-            else:
-                yield crossfaded.copy()
-                overlap_tail = pcm_np[-overlap_samples:].copy()
-                emitted_samples = pcm_np.size - overlap_samples
+    Re-decodes the accumulated codec sequence every ``emit_every_frames``
+    codec frames. The neural vocoder's output at a given sample depends on
+    full-sequence context — re-decoding at length ``N`` vs length ``N+K``
+    produces slightly different PCM near the right edge of the shorter
+    decode. Strategy: hold the last ``overlap_ms`` of each decode as a
+    buffer. On the next decode, linearly crossfade the buffered tail with
+    the new decode's same-position samples and emit the smoothed region.
+    This replaces the edge-affected tail of each decode with the
+    full-context version from the next decode.
 
-        # Post-loop flush: generator exited without EOS (hit max_new_frames).
-        # Emit remaining frames as a "final" chunk with fade-out.
-        if done_via_eos or raw_frames_at_last_emit >= len(frames_raw):
-            return
+    Cost: ``O(T² / emit_every_frames)`` decode work — at
+    ``emit_every_frames=16`` (~640 ms) this is a few percent of generation
+    cost. TTFB shrinks from full-generation wall time to
+    ``~(emit_every_frames / 25) s``.
+    """
+    overlap_samples = int(overlap_ms * sample_rate / 1000.0)
+    K = config.audio_num_codebooks
+    audio_codebook_size = config.audio_codebook_size
+
+    n_fade_in = int(fade_in_ms * sample_rate / 1000.0)
+    n_fade_out = int(fade_out_ms * sample_rate / 1000.0)
+
+    frames_raw: list[mx.array] = []
+    overlap_tail: Optional[np.ndarray] = None
+    emitted_samples = 0
+    raw_frames_at_last_emit = 0
+    is_first_chunk = True
+    done_via_eos = False
+
+    def _decode_current() -> Optional[np.ndarray]:
+        sequence = mx.stack(frames_raw, axis=1).astype(mx.int32)
+        aligned = revert_delay_pattern(sequence)
+        if aligned.shape[1] < 2:
+            return None
+        aligned = aligned[:, 1:-1]
+        if aligned.shape[1] == 0:
+            return None
+        aligned = mx.clip(aligned, 0, audio_codebook_size - 1)
+        pcm = codec.decode(aligned.T)
+        mx.eval(pcm)
+        return np.array(pcm).astype(np.float32).reshape(-1)
+
+    for tok, meta in model._generate_raw_frames(
+        full_embeds,
+        audio_out_mask,
+        max_new_frames=max_new_frames,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        ras_win_len=ras_win_len,
+        ras_max_repeat=ras_max_repeat,
+        sampling_warmup_frames=sampling_warmup_frames,
+    ):
+        frames_raw.append(tok)
+
+        done_via_eos = (
+            meta.get("num_remaining_delays") is not None
+            and meta["num_remaining_delays"] <= 0
+        )
+
+        have_enough = len(frames_raw) > K + 1
+        frames_since_last = len(frames_raw) - raw_frames_at_last_emit
+        should_emit = have_enough and (
+            done_via_eos or frames_since_last >= emit_every_frames
+        )
+        if not should_emit:
+            continue
+        raw_frames_at_last_emit = len(frames_raw)
+
         pcm_np = _decode_current()
         if pcm_np is None:
-            return
+            continue
 
         if is_first_chunk:
-            # Nothing yet emitted — full utterance fits in one final chunk.
             if n_fade_in > 0 and pcm_np.size > n_fade_in:
                 pcm_np[:n_fade_in] *= np.linspace(0.0, 1.0, n_fade_in, dtype=np.float32)
-            if n_fade_out > 0 and pcm_np.size > n_fade_out:
-                pcm_np[-n_fade_out:] *= np.linspace(
-                    1.0, 0.0, n_fade_out, dtype=np.float32
-                )
-            yield pcm_np.copy()
-            return
+            if done_via_eos:
+                if n_fade_out > 0 and pcm_np.size > n_fade_out:
+                    pcm_np[-n_fade_out:] *= np.linspace(
+                        1.0, 0.0, n_fade_out, dtype=np.float32
+                    )
+                yield pcm_np.copy(), {
+                    "is_final": True,
+                    "frames_total": len(frames_raw),
+                }
+                return
+            if pcm_np.size > overlap_samples:
+                yield pcm_np[:-overlap_samples].copy(), {
+                    "is_final": False,
+                    "frames_total": len(frames_raw),
+                }
+                overlap_tail = pcm_np[-overlap_samples:].copy()
+                emitted_samples = pcm_np.size - overlap_samples
+            else:
+                overlap_tail = pcm_np.copy()
+                emitted_samples = 0
+            is_first_chunk = False
+            continue
 
+        # Subsequent chunk: crossfade overlap_tail with new decode's
+        # same-position samples, then emit middle region.
         if overlap_tail is None or pcm_np.size < emitted_samples + overlap_samples:
-            return
+            continue
         new_overlap_region = pcm_np[emitted_samples : emitted_samples + overlap_samples]
         fade_out = np.linspace(1.0, 0.0, overlap_samples, dtype=np.float32)
         fade_in = np.linspace(0.0, 1.0, overlap_samples, dtype=np.float32)
         crossfaded = overlap_tail * fade_out + new_overlap_region * fade_in
-        tail_pcm = pcm_np[emitted_samples + overlap_samples :].copy()
-        if n_fade_out > 0 and tail_pcm.size > n_fade_out:
-            tail_pcm[-n_fade_out:] *= np.linspace(
-                1.0, 0.0, n_fade_out, dtype=np.float32
-            )
-        yield np.concatenate([crossfaded, tail_pcm])
+
+        if done_via_eos:
+            tail_pcm = pcm_np[emitted_samples + overlap_samples :].copy()
+            if n_fade_out > 0 and tail_pcm.size > n_fade_out:
+                tail_pcm[-n_fade_out:] *= np.linspace(
+                    1.0, 0.0, n_fade_out, dtype=np.float32
+                )
+            yield np.concatenate([crossfaded, tail_pcm]), {
+                "is_final": True,
+                "frames_total": len(frames_raw),
+            }
+            return
+
+        new_middle_start = emitted_samples + overlap_samples
+        new_middle_end = pcm_np.size - overlap_samples
+        if new_middle_end > new_middle_start:
+            middle = pcm_np[new_middle_start:new_middle_end].copy()
+            yield np.concatenate([crossfaded, middle]), {
+                "is_final": False,
+                "frames_total": len(frames_raw),
+            }
+            overlap_tail = pcm_np[-overlap_samples:].copy()
+            emitted_samples = new_middle_end
+        else:
+            yield crossfaded.copy(), {
+                "is_final": False,
+                "frames_total": len(frames_raw),
+            }
+            overlap_tail = pcm_np[-overlap_samples:].copy()
+            emitted_samples = pcm_np.size - overlap_samples
+
+    # Post-loop flush: generator exited without EOS (hit max_new_frames).
+    # Emit remaining frames as a "final" chunk with fade-out.
+    if done_via_eos or raw_frames_at_last_emit >= len(frames_raw):
+        return
+    pcm_np = _decode_current()
+    if pcm_np is None:
+        return
+
+    if is_first_chunk:
+        # Nothing yet emitted — full utterance fits in one final chunk.
+        if n_fade_in > 0 and pcm_np.size > n_fade_in:
+            pcm_np[:n_fade_in] *= np.linspace(0.0, 1.0, n_fade_in, dtype=np.float32)
+        if n_fade_out > 0 and pcm_np.size > n_fade_out:
+            pcm_np[-n_fade_out:] *= np.linspace(1.0, 0.0, n_fade_out, dtype=np.float32)
+        yield pcm_np.copy(), {"is_final": True, "frames_total": len(frames_raw)}
+        return
+
+    if overlap_tail is None or pcm_np.size < emitted_samples + overlap_samples:
+        return
+    new_overlap_region = pcm_np[emitted_samples : emitted_samples + overlap_samples]
+    fade_out = np.linspace(1.0, 0.0, overlap_samples, dtype=np.float32)
+    fade_in = np.linspace(0.0, 1.0, overlap_samples, dtype=np.float32)
+    crossfaded = overlap_tail * fade_out + new_overlap_region * fade_in
+    tail_pcm = pcm_np[emitted_samples + overlap_samples :].copy()
+    if n_fade_out > 0 and tail_pcm.size > n_fade_out:
+        tail_pcm[-n_fade_out:] *= np.linspace(1.0, 0.0, n_fade_out, dtype=np.float32)
+    yield np.concatenate([crossfaded, tail_pcm]), {
+        "is_final": True,
+        "frames_total": len(frames_raw),
+    }

--- a/mlx_audio/tts/tests/test_higgs_audio.py
+++ b/mlx_audio/tts/tests/test_higgs_audio.py
@@ -471,5 +471,122 @@ class TestReferenceCache(unittest.TestCase):
         self.assertEqual(info["mode"], "smart_voice")
 
 
+class TestStreamingAPIContract(unittest.TestCase):
+    """``Model.generate(stream=True)`` is the framework path that must remain
+    consistent across all TTS models — verified at the signature level so the
+    streaming kwargs aren't silently swallowed by ``**kwargs``."""
+
+    def test_model_generate_exposes_streaming_kwargs(self):
+        import inspect
+
+        from mlx_audio.tts.models.higgs_audio import Model
+
+        sig = inspect.signature(Model.generate)
+        for name in ("stream", "streaming_interval", "overlap_ms"):
+            self.assertIn(
+                name,
+                sig.parameters,
+                f"{name} must be a named parameter of Model.generate",
+            )
+        # stream defaults to False so non-streaming callers see no behavior change.
+        self.assertEqual(sig.parameters["stream"].default, False)
+
+    def test_iter_overlap_add_pcm_is_public_helper(self):
+        """The overlap-add streaming algorithm must live as a module-level
+        helper so ``Model.generate(stream=True)`` and
+        ``HiggsAudioServer.generate_stream_overlap_add`` share one
+        implementation."""
+        from mlx_audio.tts.models.higgs_audio.serve import iter_overlap_add_pcm
+
+        self.assertTrue(callable(iter_overlap_add_pcm))
+
+    def test_model_generate_stream_true_requires_loaded_codec(self):
+        """Same load-guard as the non-streaming path — calling generate before
+        post_load_hook must raise, not silently produce empty chunks."""
+        from mlx_audio.tts.models.higgs_audio import Model
+
+        cfg = _tiny_config()
+        model = Model(cfg)
+        with self.assertRaises(RuntimeError):
+            next(iter(model.generate("hello", stream=True)))
+
+
+class _FakeDecodingCodec:
+    """Minimal codec stub for streaming tests: ``decode([T, K]) → mx.array``
+    with deterministic non-zero PCM so chunks are observable."""
+
+    def __init__(self, samples_per_frame: int = 96):
+        self._spf = samples_per_frame
+
+    def decode(self, codes_TK: mx.array) -> mx.array:
+        T = codes_TK.shape[0]
+        # Position-indexed ramp so successive decodes differ in the right tail
+        # — exercises the crossfade path rather than reducing it to a no-op.
+        ramp = mx.arange(T * self._spf, dtype=mx.float32) * 1e-4
+        return ramp.reshape(1, -1, 1)
+
+
+class TestStreamingIntegration(unittest.TestCase):
+    """End-to-end exercise of ``iter_overlap_add_pcm`` with tiny weights and a
+    fake codec. Verifies the streaming loop terminates with ``is_final=True``,
+    yields at least one chunk, and produces float32 1-D PCM."""
+
+    def _tiny_setup(self):
+        from mlx_audio.tts.models.higgs_audio.higgs_audio import HiggsAudioModel
+
+        cfg = _tiny_config()
+        model = HiggsAudioModel(cfg)
+        mx.eval(model.parameters())
+        codec = _FakeDecodingCodec(samples_per_frame=96)
+
+        # Minimal valid prefill inputs — content doesn't matter, only shape.
+        T_prompt = 4
+        full_embeds = mx.zeros((1, T_prompt, cfg.text_config.hidden_size))
+        audio_out_mask = mx.zeros((1, T_prompt), dtype=mx.bool_)
+        return cfg, model, codec, full_embeds, audio_out_mask
+
+    def test_streaming_terminates_with_final_chunk(self):
+        from mlx_audio.tts.models.higgs_audio.serve import iter_overlap_add_pcm
+
+        cfg, model, codec, full_embeds, audio_out_mask = self._tiny_setup()
+        chunks = list(
+            iter_overlap_add_pcm(
+                model=model,
+                codec=codec,
+                config=cfg,
+                full_embeds=full_embeds,
+                audio_out_mask=audio_out_mask,
+                max_new_frames=20,
+                temperature=0.0,
+                top_p=None,
+                top_k=None,
+                ras_win_len=None,
+                ras_max_repeat=2,
+                sampling_warmup_frames=20,  # full greedy → deterministic
+                emit_every_frames=4,
+                overlap_ms=4.0,
+                fade_in_ms=1.0,
+                fade_out_ms=1.0,
+                sample_rate=24000,
+            )
+        )
+
+        self.assertGreater(len(chunks), 0, "streaming must yield at least one chunk")
+        # Exactly one chunk should be marked final, and it must be the last.
+        finals = [i for i, (_, meta) in enumerate(chunks) if meta["is_final"]]
+        self.assertEqual(finals, [len(chunks) - 1])
+
+        for pcm, meta in chunks:
+            self.assertEqual(pcm.dtype, np.float32)
+            self.assertEqual(pcm.ndim, 1)
+            self.assertGreater(pcm.size, 0)
+            self.assertIn("frames_total", meta)
+
+        # frames_total is monotonically non-decreasing (each yield reflects
+        # cumulative generation progress).
+        totals = [m["frames_total"] for _, m in chunks]
+        self.assertEqual(totals, sorted(totals))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds `HiggsAudioServer.generate_stream_overlap_add()` — a true mid-generation streaming path for Higgs Audio v2 that yields PCM progressively while the model is still generating codec frames. Existing `generate_stream()` (full-generate-then-chunk) is left intact as the fallback.

## Motivation

`generate_stream()` today has TTFB = full generation wall time. The existing docstring notes that mid-generation emission was attempted previously but produced audible discontinuities at chunk boundaries:

> the codec is a neural vocoder whose output at a given sample depends on full-sequence context, so re-decode at chunk N vs N+1 produces slightly different PCM for the same positions. Proper mid-generation streaming requires overlap-add or an incremental-decoder API on the codec; deferred to follow-up.

This PR lands that overlap-add follow-up.

## Mechanism

The acoustic decoder is a non-causal neural vocoder. Samples near the right edge of a partial decode have less future context than samples in the middle, so they differ (subtly) from the same positions decoded with more context. Overlap-add masks the transition:

1. After each emission, hold the last `overlap_ms` of decoded PCM as a buffer.
2. On the next decode (now with more frames, hence more context), take the corresponding sample region and crossfade linearly — held tail fades out while the new-decode version fades in.
3. Emit the crossfade, then the new middle region, holding a new tail.
4. On termination (EOS ramp complete or `max_new_frames` reached), emit the crossfade plus remaining PCM with an output fade-out.

Generation itself already streams frame-by-frame via the KV cache exposed by `_generate_raw_frames()` — no model changes needed.

## Cost

- Decode cost: `O(T² / emit_every_frames)` total. At default `emit_every_frames=16` (~640 ms), a small fraction of generation cost.
- TTFB: `~(emit_every_frames / 25) s` ≈ 640 ms vs multi-second full-generate wall time.

## Validation

On M5 Max / q6 quantization / voice-cloned reference / ~10 s utterance:

- **Length parity**: stream output size == full-generate output size.
- **RMS(stream − full)** ≈ 0.003–0.009 over ~250k samples (greedy and temp=0.7 respectively).
- **No step discontinuities**: local max |Δsample| at every chunk seam stays below the global max |Δsample| in the stream — boundaries are smoother than mid-signal peaks, confirming the crossfade is effective.
- **A/B listening** at temp=0.7 with voice clone: perceptually indistinguishable between full and streaming outputs.

## API

```python
for pcm_chunk in server.generate_stream_overlap_add(
    target_text="...",
    reference_audio_path="voice.wav",
    reference_text="...",
    emit_every_frames=16,   # chunk every N codec frames (default 640 ms)
    overlap_ms=40.0,        # crossfade window
    fade_in_ms=5.0,
    fade_out_ms=5.0,
):
    yield_to_pipecat(pcm_chunk)
```

Parameters mirror `generate_stream()` plus `emit_every_frames` and `overlap_ms`.

## Test plan

- [x] `pytest mlx_audio/tts/tests/test_higgs_audio.py` — existing 19 tests pass
- [x] Length parity: stream == full output size at both greedy and temp=0.7
- [x] Seam smoothness: local max |Δsample| at chunk boundaries < global max |Δsample|
- [x] A/B listening test: no audible artifacts at chunk boundaries under voice-clone


