### PR TITLE
Add a standard model loading path for STS models

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,8 @@ jobs:
             path: mlx_audio/stt/tests
           - name: STS
             path: mlx_audio/sts/tests
+          - name: LID
+            path: mlx_audio/lid/tests
           - name: Codec
             path: mlx_audio/codec/tests
           - name: VAD

--- a/docs/models/sts/index.md
+++ b/docs/models/sts/index.md
@@ -20,8 +20,11 @@ MLX Audio provides speech-to-speech models for audio source separation, speech e
 
 [SAM-Audio](https://github.com/facebookresearch/sam-audio) (Segment Anything Model for Audio) is Meta's foundation model for audio source separation using text prompts. Describe what you want to extract, and SAM-Audio separates it from the mix.
 
-!!! note "Gated model"
-    SAM-Audio weights are gated on HuggingFace. Request access at [facebook/sam-audio-large](https://huggingface.co/facebook/sam-audio-large).
+```python
+from mlx_audio.sts import load
+
+model = load("mlx-community/sam-audio-large")
+```
 
 ### Quick Start
 
@@ -136,6 +139,12 @@ Control the quality vs speed tradeoff:
 |-------|-----------|------|
 | **LFM2.5-Audio 4bit** | 4-bit quantized | [mlx-community/LFM2.5-Audio-1.5B-4bit](https://huggingface.co/mlx-community/LFM2.5-Audio-1.5B-4bit) |
 | **LFM2.5-Audio 8bit** | 8-bit quantized | [mlx-community/LFM2.5-Audio-1.5B-8bit](https://huggingface.co/mlx-community/LFM2.5-Audio-1.5B-8bit) |
+
+```python
+from mlx_audio.sts import load
+
+model = load("mlx-community/LFM2.5-Audio-1.5B-4bit")
+```
 
 ### Text-to-Speech
 
@@ -284,14 +293,20 @@ config = GenerationConfig(
 | **moshiko q8** | 8-bit quantized | -- | [kyutai/moshiko-mlx-q8](https://huggingface.co/kyutai/moshiko-mlx-q8) |
 | **moshiko q4** | 4-bit quantized | ~8GB | [kyutai/moshiko-mlx-q4](https://huggingface.co/kyutai/moshiko-mlx-q4) |
 
+```python
+from mlx_audio.sts import load
+
+model = load("kyutai/moshiko-mlx-q4")
+```
+
 ### Usage
 
 ```python
-from mlx_audio.sts import load
+from mlx_audio.sts.models.moshi import MoshiSTSModel
 import sounddevice as sd
 import numpy as np
 
-model = load("kyutai/moshiko-mlx-q4", quantized=4)
+model = MoshiSTSModel.from_pretrained("kyutai/moshiko-mlx-q4", quantized=4)
 
 stream = sd.OutputStream(samplerate=24000, channels=1, dtype=np.float32)
 stream.start()
@@ -325,6 +340,12 @@ stream.close()
 | **MossFormer2 SE** | fp32 | [starkdmi/MossFormer2_SE_48K_MLX](https://huggingface.co/starkdmi/MossFormer2_SE_48K_MLX) |
 | **MossFormer2 SE 8bit** | int8 | [starkdmi/MossFormer2_SE_48K_MLX-8bit](https://huggingface.co/starkdmi/MossFormer2_SE_48K_MLX-8bit) |
 | **MossFormer2 SE 4bit** | int4 | [starkdmi/MossFormer2_SE_48K_MLX-4bit](https://huggingface.co/starkdmi/MossFormer2_SE_48K_MLX-4bit) |
+
+```python
+from mlx_audio.sts import load
+
+model = load("starkdmi/MossFormer2_SE_48K_MLX")
+```
 
 ### Usage
 
@@ -370,6 +391,14 @@ stream.close()
 ## DeepFilterNet
 
 [DeepFilterNet](https://github.com/Rikorose/DeepFilterNet) is a speech enhancement model for noise suppression, available in versions 1, 2, and 3. The MLX port supports all three versions with stateful streaming processing.
+
+The standard STS loader defaults to `v3`:
+
+```python
+from mlx_audio.sts import load
+
+model = load("mlx-community/DeepFilterNet-mlx")
+```
 
 ### Usage
 

--- a/mlx_audio/sts/__init__.py
+++ b/mlx_audio/sts/__init__.py
@@ -1,47 +1,81 @@
-from .models.deepfilternet import (
-    DeepFilterNet2Config,
-    DeepFilterNet3Config,
-    DeepFilterNetConfig,
-    DeepFilterNetModel,
-    DeepFilterNetStreamer,
-    DeepFilterNetStreamingConfig,
-)
-from .models.mossformer2_se import (
-    MossFormer2SE,
-    MossFormer2SEConfig,
-    MossFormer2SEModel,
-)
-from .models.sam_audio import (
-    Batch,
-    SAMAudio,
-    SAMAudioConfig,
-    SAMAudioProcessor,
-    SeparationResult,
-    save_audio,
-)
+import importlib
 
-try:
-    from .voice_pipeline import VoicePipeline
-except ImportError:
-    VoicePipeline = None
+from .utils import load, load_model
+
+_LAZY_EXPORTS = {
+    "DeepFilterNet2Config": (
+        "mlx_audio.sts.models.deepfilternet",
+        "DeepFilterNet2Config",
+    ),
+    "DeepFilterNet3Config": (
+        "mlx_audio.sts.models.deepfilternet",
+        "DeepFilterNet3Config",
+    ),
+    "DeepFilterNetConfig": (
+        "mlx_audio.sts.models.deepfilternet",
+        "DeepFilterNetConfig",
+    ),
+    "DeepFilterNetModel": ("mlx_audio.sts.models.deepfilternet", "DeepFilterNetModel"),
+    "DeepFilterNetStreamer": (
+        "mlx_audio.sts.models.deepfilternet",
+        "DeepFilterNetStreamer",
+    ),
+    "DeepFilterNetStreamingConfig": (
+        "mlx_audio.sts.models.deepfilternet",
+        "DeepFilterNetStreamingConfig",
+    ),
+    "MossFormer2SE": ("mlx_audio.sts.models.mossformer2_se", "MossFormer2SE"),
+    "MossFormer2SEConfig": (
+        "mlx_audio.sts.models.mossformer2_se",
+        "MossFormer2SEConfig",
+    ),
+    "MossFormer2SEModel": (
+        "mlx_audio.sts.models.mossformer2_se",
+        "MossFormer2SEModel",
+    ),
+    "Batch": ("mlx_audio.sts.models.sam_audio", "Batch"),
+    "SAMAudio": ("mlx_audio.sts.models.sam_audio", "SAMAudio"),
+    "SAMAudioConfig": ("mlx_audio.sts.models.sam_audio", "SAMAudioConfig"),
+    "SAMAudioProcessor": ("mlx_audio.sts.models.sam_audio", "SAMAudioProcessor"),
+    "SeparationResult": ("mlx_audio.sts.models.sam_audio", "SeparationResult"),
+    "save_audio": ("mlx_audio.sts.models.sam_audio", "save_audio"),
+}
 
 __all__ = [
-    "SAMAudio",
-    "SAMAudioProcessor",
-    "SeparationResult",
     "Batch",
-    "save_audio",
-    "SAMAudioConfig",
-    "VoicePipeline",
-    # DeepFilterNet
-    "DeepFilterNetModel",
-    "DeepFilterNetConfig",
     "DeepFilterNet2Config",
     "DeepFilterNet3Config",
+    "DeepFilterNetConfig",
+    "DeepFilterNetModel",
     "DeepFilterNetStreamer",
     "DeepFilterNetStreamingConfig",
-    # MossFormer2 SE
     "MossFormer2SE",
     "MossFormer2SEConfig",
     "MossFormer2SEModel",
+    "SAMAudio",
+    "SAMAudioConfig",
+    "SAMAudioProcessor",
+    "SeparationResult",
+    "VoicePipeline",
+    "load",
+    "load_model",
+    "save_audio",
 ]
+
+
+def __getattr__(name):
+    if name == "VoicePipeline":
+        try:
+            from .voice_pipeline import VoicePipeline
+        except ImportError:
+            VoicePipeline = None
+        globals()[name] = VoicePipeline
+        return VoicePipeline
+
+    if name in _LAZY_EXPORTS:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+        value = getattr(importlib.import_module(module_name), attr_name)
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mlx_audio/sts/models/deepfilternet/README.md
+++ b/mlx_audio/sts/models/deepfilternet/README.md
@@ -7,6 +7,17 @@ Pretrained weights: [mlx-community/DeepFilterNet-mlx](https://huggingface.co/mlx
 ## Quick Start
 
 ```python
+from mlx_audio.sts import load
+
+# Load v3 (default) through the standard STS loader
+model = load("mlx-community/DeepFilterNet-mlx")
+model.enhance_file("noisy.wav", "clean.wav")
+```
+
+Or use the model-specific initializer directly when you need explicit version
+selection:
+
+```python
 from mlx_audio.sts.models.deepfilternet import DeepFilterNetModel
 
 # Load v3 (default)

--- a/mlx_audio/sts/models/deepfilternet/config.py
+++ b/mlx_audio/sts/models/deepfilternet/config.py
@@ -35,6 +35,7 @@ class DeepFilterNetConfig:
     """
 
     # Audio parameters
+    model_version: str = "DeepFilterNet3"
     sample_rate: int = 48000
 
     # STFT parameters
@@ -116,6 +117,7 @@ class DeepFilterNetConfig:
         """Convert config to dictionary."""
         return {
             "sample_rate": self.sample_rate,
+            "model_version": self.model_version,
             "fft_size": self.fft_size,
             "hop_size": self.hop_size,
             "nb_erb": self.nb_erb,
@@ -170,6 +172,7 @@ class DeepFilterNet2Config(DeepFilterNetConfig):
     DeepFilterNet2 is optimized for embedded devices while maintaining quality.
     """
 
+    model_version: str = "DeepFilterNet2"
     conv_ch: int = 16
     emb_hidden_dim: int = 256
     df_hidden_dim: int = 256
@@ -184,6 +187,7 @@ class DeepFilterNet3Config(DeepFilterNetConfig):
     DeepFilterNet3 adds perceptually motivated improvements.
     """
 
+    model_version: str = "DeepFilterNet3"
     conv_ch: int = 16
     emb_hidden_dim: int = 256
     df_hidden_dim: int = 256

--- a/mlx_audio/sts/models/deepfilternet/model.py
+++ b/mlx_audio/sts/models/deepfilternet/model.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import mlx.core as mx
+import mlx.nn as nn
 import numpy as np
 from huggingface_hub import hf_hub_download
 
@@ -42,19 +43,27 @@ DEFAULT_CONFIGS = {
 }
 
 
-class DeepFilterNetModel:
+class DeepFilterNetModel(nn.Module):
     """Pure-MLX DeepFilterNet inference runtime."""
 
     def __init__(
         self,
-        model: DfNet,
         config: DeepFilterNetConfig,
-        model_dir: Path,
-        model_version: str = "DeepFilterNet3",
+        model: Optional[Union[DfNet, DfNetV1]] = None,
+        model_dir: Optional[Path] = None,
+        model_version: Optional[str] = None,
     ):
+        super().__init__()
+        if model_version is None:
+            model_version = getattr(config, "model_version", "DeepFilterNet3")
+        if model is None:
+            model = (
+                DfNetV1(config) if model_version == "DeepFilterNet" else DfNet(config)
+            )
+
         self.model = model
         self.config = config
-        self.model_dir = model_dir
+        self.model_dir = Path(model_dir) if model_dir is not None else None
         self.model_version = model_version
 
         # From libDF: wnorm = 1 / (fft_size^2 / (2 * hop_size))
@@ -72,6 +81,19 @@ class DeepFilterNetModel:
             and self.erb_fb.shape[0] == (self.config.fft_size // 2 + 1)
             and self.erb_fb.shape[1] == self.config.nb_erb
         )
+
+    def load_weights(self, weights, strict: bool = False):
+        weight_dict = dict(weights)
+        loaded = load_df_weights(self.model, weight_dict)
+        if strict and loaded != len(weight_dict):
+            raise ValueError(
+                f"Loaded {loaded} of {len(weight_dict)} DeepFilterNet tensors"
+            )
+        return self
+
+    def post_load_hook(self, model_path: Path) -> "DeepFilterNetModel":
+        self.model_dir = Path(model_path)
+        return self
 
     @classmethod
     def from_pretrained(

--- a/mlx_audio/sts/models/lfm_audio/model.py
+++ b/mlx_audio/sts/models/lfm_audio/model.py
@@ -299,13 +299,6 @@ class LFM2AudioModel(nn.Module):
 
         weights = model.sanitize(weights)
 
-        for key, value in weights.items():
-            if value.dtype == mx.float32:
-                if "conv" in key or "norm" in key:
-                    continue
-                else:
-                    weights[key] = value.astype(mx.float16)
-
         if quantization:
             from ....convert import build_quant_predicate
 
@@ -461,6 +454,10 @@ class LFM2AudioModel(nn.Module):
                 sanitized[key] = (
                     value if check_array_shape(value) else value.transpose(0, 2, 3, 1)
                 )  # NCHW -> NHWC
+
+        for key, value in list(sanitized.items()):
+            if value.dtype == mx.float32 and "conv" not in key and "norm" not in key:
+                sanitized[key] = value.astype(mx.float16)
 
         return sanitized
 

--- a/mlx_audio/sts/models/moshi/README.md
+++ b/mlx_audio/sts/models/moshi/README.md
@@ -2,6 +2,12 @@
 
 MLX implementation of [Moshi](https://github.com/kyutai-labs/moshi) from Kyutai Labs. Moshi is a full-duplex speech-to-speech foundation model that can listen and talk at the same time in real-time.
 
+```python
+from mlx_audio.sts import load
+
+model = load("kyutai/moshiko-mlx-q4")
+```
+
 ## Features
 
 - Full-duplex: Handles concurrent input and output audio streams
@@ -12,12 +18,12 @@ MLX implementation of [Moshi](https://github.com/kyutai-labs/moshi) from Kyutai 
 ## Usage
 
 ```python
-from mlx_audio.sts import load
+from mlx_audio.sts.models.moshi import MoshiSTSModel
 import sounddevice as sd
 import numpy as np
 
 # Load quantized model directly from HuggingFace
-model = load("kyutai/moshiko-mlx-q4", quantized=4)
+model = MoshiSTSModel.from_pretrained("kyutai/moshiko-mlx-q4", quantized=4)
 
 # Open audio output stream
 stream = sd.OutputStream(samplerate=24000, channels=1, dtype=np.float32)

--- a/mlx_audio/sts/models/moshi/moshi.py
+++ b/mlx_audio/sts/models/moshi/moshi.py
@@ -42,12 +42,22 @@ class MoshiSTSModel:
 
     @classmethod
     def from_pretrained(
-        cls, model_name_or_path: str, quantized: Optional[int] = None
+        cls,
+        model_name_or_path: str,
+        quantized: Optional[int] = None,
+        revision: Optional[str] = None,
+        force_download: bool = False,
     ) -> "MoshiSTSModel":
         if Path(model_name_or_path).exists():
             model_path = Path(model_name_or_path)
         else:
-            model_path = Path(snapshot_download(model_name_or_path))
+            model_path = Path(
+                snapshot_download(
+                    model_name_or_path,
+                    revision=revision,
+                    force_download=force_download,
+                )
+            )
 
         config = MoshiConfig(hf_repo=model_name_or_path, quantized=quantized)
         model = cls(config)

--- a/mlx_audio/sts/models/mossformer2_se/README.md
+++ b/mlx_audio/sts/models/mossformer2_se/README.md
@@ -14,6 +14,22 @@ enables efficient inference on Apple Silicon.
 ## Quick Start
 
 ```python
+from mlx_audio.sts import load
+from mlx_audio.sts.models.mossformer2_se import save_audio
+
+# Standard STS loader
+model = load("starkdmi/MossFormer2_SE_48K_MLX")
+
+# Enhance audio
+enhanced = model.enhance("noisy.wav")
+
+# Save result
+save_audio(enhanced, "enhanced.wav", 48000)
+```
+
+Or use the model-specific initializer directly:
+
+```python
 from mlx_audio.sts.models.mossformer2_se import (
     MossFormer2SEModel,
     save_audio,

--- a/mlx_audio/sts/models/mossformer2_se/__init__.py
+++ b/mlx_audio/sts/models/mossformer2_se/__init__.py
@@ -11,10 +11,15 @@ from .config import MossFormer2SEConfig
 from .model import MossFormer2SEModel
 from .mossformer2_se_wrapper import MossFormer2SE
 
+Model = MossFormer2SEModel
+ModelConfig = MossFormer2SEConfig
+
 __all__ = [
     "MossFormer2SEConfig",
     "MossFormer2SE",
     "MossFormer2SEModel",
+    "Model",
+    "ModelConfig",
     "load_audio",
     "save_audio",
 ]

--- a/mlx_audio/sts/models/mossformer2_se/model.py
+++ b/mlx_audio/sts/models/mossformer2_se/model.py
@@ -32,7 +32,7 @@ MAX_WAV_VALUE = 32768.0
 DEFAULT_REPO = "starkdmi/MossFormer2_SE_48K_MLX"
 
 
-class MossFormer2SEModel:
+class MossFormer2SEModel(nn.Module):
     """MossFormer2 SE speech enhancement model.
 
     Handles model loading, audio processing, and enhancement.
@@ -45,20 +45,32 @@ class MossFormer2SEModel:
 
     def __init__(
         self,
-        model,
         config: MossFormer2SEConfig,
+        model: Optional[MossFormer2SE] = None,
     ):
         """Initialize model.
 
         Args:
-            model: Loaded MossFormer2 model (TestNet)
             config: Model configuration
+            model: Loaded MossFormer2 model wrapper
         """
-        self.model = model
+        super().__init__()
+        self._enable_fast_layer_norm()
+        self.model = model if model is not None else MossFormer2SE(config)
         self.config = config
         self._istft_cache = ISTFTCache()
         self._window = None
         self._warmed_up = False
+
+    @staticmethod
+    def _enable_fast_layer_norm() -> None:
+        nn.LayerNorm.__call__ = lambda self, x: mx.fast.layer_norm(
+            x, self.weight, self.bias, self.eps
+        )
+
+    def load_weights(self, weights, strict: bool = False):
+        self.model.update(tree_unflatten(list(weights)))
+        return self
 
     @classmethod
     def from_pretrained(
@@ -102,10 +114,7 @@ class MossFormer2SEModel:
 
         print(f"Loading MossFormer2 SE 48K ({precision})...")
 
-        # Enable fast LayerNorm
-        nn.LayerNorm.__call__ = lambda self, x: mx.fast.layer_norm(
-            x, self.weight, self.bias, self.eps
-        )
+        cls._enable_fast_layer_norm()
 
         config = MossFormer2SEConfig.from_dict(config_dict)
         model = MossFormer2SE(config)
@@ -130,7 +139,7 @@ class MossFormer2SEModel:
         total_params = sum(v.size for v in weights.values() if hasattr(v, "size"))
         print(f"Model loaded: {total_params:,} parameters")
 
-        return cls(model=model.model, config=config)
+        return cls(config=config, model=model)
 
     def warmup(self, chunked: bool = False) -> None:
         """Warm up model for optimal performance.

--- a/mlx_audio/sts/models/sam_audio/README.md
+++ b/mlx_audio/sts/models/sam_audio/README.md
@@ -2,6 +2,13 @@
 
 MLX implementation of [SAM-Audio](https://github.com/facebookresearch/sam-audio) (Segment Anything Model for Audio) - a foundation model for audio source separation using text prompts.
 
+For the MLX-converted `mlx-community/sam-audio-large` repo, the generic STS loader now works:
+
+```python
+from mlx_audio.sts import load
+
+model = load("mlx-community/sam-audio-large")
+```
 
 ## Installation
 
@@ -406,4 +413,3 @@ for chunk, is_last in model.audio_codec.decode_streaming(
 
 SAM-Audio models are gated on HuggingFace. Request access at:
 https://huggingface.co/facebook/sam-audio-large
-

--- a/mlx_audio/sts/models/sam_audio/__init__.py
+++ b/mlx_audio/sts/models/sam_audio/__init__.py
@@ -4,6 +4,9 @@ from .config import DACVAEConfig, SAMAudioConfig, T5EncoderConfig, TransformerCo
 from .model import SAMAudio, SeparationResult
 from .processor import Batch, SAMAudioProcessor, save_audio
 
+Model = SAMAudio
+ModelConfig = SAMAudioConfig
+
 __all__ = [
     "SAMAudio",
     "SAMAudioProcessor",
@@ -14,4 +17,6 @@ __all__ = [
     "DACVAEConfig",
     "T5EncoderConfig",
     "TransformerConfig",
+    "Model",
+    "ModelConfig",
 ]

--- a/mlx_audio/sts/models/sam_audio/model.py
+++ b/mlx_audio/sts/models/sam_audio/model.py
@@ -260,6 +260,64 @@ class SAMAudio(nn.Module):
 
         return sanitized
 
+    def load_weights(self, weights, strict: bool = False):
+        # Match weights to MLX parameter shapes, transposing where PyTorch and
+        # MLX store equivalent tensors differently.
+        mlx_params = dict(nn.utils.tree_flatten(self.parameters()))
+
+        new_weights = []
+        loaded_keys = set()
+
+        for key, value in weights:
+            if key not in mlx_params:
+                continue
+
+            target_shape = mlx_params[key].shape
+            value_shape = value.shape
+
+            if value_shape != target_shape:
+                if len(value_shape) == 2 and value_shape == target_shape[::-1]:
+                    value = mx.transpose(value)
+                elif len(value_shape) == 3 and len(target_shape) == 3:
+                    if value_shape == (
+                        target_shape[0],
+                        target_shape[2],
+                        target_shape[1],
+                    ):
+                        value = mx.transpose(value, (0, 2, 1))
+                    elif value_shape == (
+                        target_shape[2],
+                        target_shape[0],
+                        target_shape[1],
+                    ):
+                        value = mx.transpose(value, (1, 2, 0))
+                    elif (
+                        value_shape[1:] == (1, 1) and value_shape[0] == target_shape[2]
+                    ):
+                        value = mx.transpose(value, (1, 2, 0))
+                    elif value_shape != target_shape:
+                        continue
+                elif value_shape != target_shape:
+                    continue
+
+            new_weights.append((key, value))
+            loaded_keys.add(key)
+
+        missing = {k for k in mlx_params.keys() - loaded_keys if "wm_model" not in k}
+        if strict and missing:
+            raise ValueError(
+                f"Missing {len(missing)} SAM-Audio parameters after load: "
+                f"{', '.join(sorted(missing)[:10])}"
+            )
+        if 0 < len(missing) < 50:
+            import warnings
+
+            warnings.warn(
+                f"Missing {len(missing)} parameters: {', '.join(sorted(missing)[:10])}..."
+            )
+
+        return super().load_weights(new_weights, strict=strict)
+
     def align_inputs(
         self,
         noisy_audio: mx.array,
@@ -1177,55 +1235,8 @@ class SAMAudio(nn.Module):
 
 def _load_weights(model: SAMAudio, weights: dict, strict: bool = False) -> SAMAudio:
     """Load PyTorch weights into MLX model."""
-    import mlx.nn as nn
-
-    # Sanitize weights (remove unwanted keys, combine LSTM biases, rename)
     sanitized = model.sanitize(weights)
-
-    # Get MLX parameter names and shapes
-    mlx_params = dict(nn.utils.tree_flatten(model.parameters()))
-
-    # Match weights to parameters, transposing as needed
-    new_weights = []
-    loaded_keys = set()
-
-    for key, value in sanitized.items():
-        if key not in mlx_params:
-            continue
-
-        target_shape = mlx_params[key].shape
-        v, t = value.shape, target_shape
-
-        if v != t:
-            # 2D: Linear layers
-            if len(v) == 2 and v == t[::-1]:
-                value = mx.transpose(value)
-            # 3D: Conv layers
-            elif len(v) == 3 and len(t) == 3:
-                if (v[0], v[1], v[2]) == (t[0], t[2], t[1]):  # Conv1d
-                    value = mx.transpose(value, (0, 2, 1))
-                elif (v[0], v[1], v[2]) == (t[2], t[0], t[1]):  # ConvTranspose1d
-                    value = mx.transpose(value, (1, 2, 0))
-                elif v[1:] == (1, 1) and v[0] == t[2]:  # Weight norm (N,1,1)->(1,1,N)
-                    value = mx.transpose(value, (1, 2, 0))
-                elif v != t:
-                    continue
-            elif v != t:
-                continue
-
-        new_weights.append((key, value))
-        loaded_keys.add(key)
-
-    # Warn about missing params (exclude wm_model since watermarking is disabled)
-    missing = {k for k in mlx_params.keys() - loaded_keys if "wm_model" not in k}
-    if 0 < len(missing) < 50:
-        import warnings
-
-        warnings.warn(
-            f"Missing {len(missing)} parameters: {', '.join(sorted(missing)[:10])}..."
-        )
-
-    model.load_weights(new_weights, strict=strict)
+    model.load_weights(list(sanitized.items()), strict=strict)
     mx.eval(model.parameters())
     model.eval()
     return model

--- a/mlx_audio/sts/tests/test_voice_pipeline.py
+++ b/mlx_audio/sts/tests/test_voice_pipeline.py
@@ -1,7 +1,7 @@
+import asyncio
 from unittest import mock
 
 import numpy as np
-import pytest
 
 from mlx_audio.sts.voice_pipeline import VoicePipeline
 
@@ -48,11 +48,10 @@ class TestVoicePipeline:
         assert pipeline.llm_model == "custom/llm"
         assert pipeline.tts_model == "custom/tts"
 
-    @pytest.mark.asyncio
     @mock.patch("mlx_audio.sts.voice_pipeline.load_llm")
     @mock.patch("mlx_audio.sts.voice_pipeline.load_tts")
     @mock.patch("mlx_audio.sts.voice_pipeline.Whisper.from_pretrained")
-    async def test_init_models(self, mock_whisper_load, mock_tts_load, mock_llm_load):
+    def test_init_models(self, mock_whisper_load, mock_tts_load, mock_llm_load):
         """
         Test that the init_models method initializes the models correctly.
         """
@@ -69,7 +68,7 @@ class TestVoicePipeline:
         mock_stt = mock.AsyncMock()
         mock_whisper_load.return_value = mock_stt
 
-        await pipeline.init_models()
+        asyncio.run(pipeline.init_models())
 
         mock_llm_load.assert_called_once_with(pipeline.llm_model)
         mock_tts_load.assert_called_once_with(pipeline.tts_model)

--- a/mlx_audio/sts/utils.py
+++ b/mlx_audio/sts/utils.py
@@ -1,0 +1,173 @@
+from pathlib import Path
+from typing import Optional, Union
+
+import mlx.nn as nn
+
+from mlx_audio.utils import (
+    base_load_model,
+    get_model_name_parts,
+    get_model_path,
+    load_config,
+)
+
+MODEL_REMAPPING = {
+    "deepfilter": "deepfilternet",
+    "deepfilternet": "deepfilternet",
+    "deepfilternet3": "deepfilternet",
+    "lfm_audio": "lfm_audio",
+    "lfm2_audio": "lfm_audio",
+    "lfm2.5": "lfm_audio",
+    "moshi": "moshi",
+    "moshiko": "moshi",
+    "mossformer2": "mossformer2_se",
+    "mossformer2_se": "mossformer2_se",
+    "sam_audio": "sam_audio",
+    "samaudio": "sam_audio",
+}
+
+
+def infer_model_type_from_config(config: dict) -> Optional[str]:
+    if not config:
+        return None
+
+    model_type = config.get("model_type", None)
+    if model_type is None:
+        model_type = config.get("architecture", None)
+
+    if model_type is not None:
+        return MODEL_REMAPPING.get(model_type, model_type)
+
+    if str(config.get("model_version", "")).startswith("DeepFilterNet"):
+        return "deepfilternet"
+
+    if {
+        "audio_codec",
+        "text_encoder",
+        "transformer",
+    }.issubset(config):
+        return "sam_audio"
+
+    if {
+        "win_len",
+        "win_inc",
+        "num_mels",
+        "out_channels_final",
+    }.issubset(config):
+        return "mossformer2_se"
+
+    return None
+
+
+def _resolve_model_type(model_path: Union[str, Path], **kwargs) -> Optional[str]:
+    try:
+        config = load_config(model_path, **kwargs)
+    except FileNotFoundError:
+        config = {}
+
+    model_type = infer_model_type_from_config(config)
+    if model_type is not None:
+        return MODEL_REMAPPING.get(model_type, model_type)
+
+    for hint in get_model_name_parts(model_path):
+        if hint in MODEL_REMAPPING:
+            return MODEL_REMAPPING[hint]
+        if hint in MODEL_REMAPPING.values():
+            return hint
+
+    return None
+
+
+def _resolve_deepfilternet_model_path(
+    model_path: Union[str, Path],
+    **kwargs,
+) -> Path:
+    model_dir = (
+        model_path.expanduser()
+        if isinstance(model_path, Path)
+        else get_model_path(str(model_path), **kwargs)
+    )
+
+    if (model_dir / "config.json").exists():
+        return model_dir
+
+    default_subfolder = model_dir / "v3"
+    if (default_subfolder / "config.json").exists():
+        return default_subfolder
+
+    raise FileNotFoundError(
+        f"Could not find DeepFilterNet weights in {model_dir} or {default_subfolder}"
+    )
+
+
+def _infer_moshi_quantization(model_path: Union[str, Path]) -> Optional[int]:
+    for hint in get_model_name_parts(model_path):
+        if hint in {"q4", "4bit"}:
+            return 4
+        if hint in {"q8", "8bit"}:
+            return 8
+
+    return None
+
+
+def load_model(
+    model_path: Union[str, Path],
+    lazy: bool = False,
+    strict: bool = False,
+    **kwargs,
+) -> nn.Module:
+    """Load an STS model from a local path or HuggingFace repository.
+
+    This loader supports STS models that can be expressed through the shared
+    MLX Audio loading contract with sensible defaults. Model-specific
+    ``from_pretrained(...)`` paths remain available for custom behavior.
+    """
+    model_type = _resolve_model_type(model_path, **kwargs)
+    if model_type == "moshi":
+        from mlx_audio.sts.models.moshi import MoshiSTSModel
+
+        return MoshiSTSModel.from_pretrained(
+            str(model_path),
+            quantized=_infer_moshi_quantization(model_path),
+            revision=kwargs.get("revision"),
+            force_download=kwargs.get("force_download", False),
+        )
+
+    if model_type in {
+        "lfm_audio",
+        "mossformer2_se",
+        "deepfilternet",
+        "sam_audio",
+    }:
+        resolved_model_path = model_path
+        if model_type == "deepfilternet":
+            resolved_model_path = _resolve_deepfilternet_model_path(
+                model_path, **kwargs
+            )
+
+        load_kwargs = {
+            "model_path": resolved_model_path,
+            "category": "sts",
+            "model_remapping": MODEL_REMAPPING,
+            "model_type": model_type,
+            "model_name_parts": get_model_name_parts(model_path),
+            "lazy": lazy,
+            "strict": strict,
+            **kwargs,
+        }
+        return base_load_model(**load_kwargs)
+
+    raise ValueError(
+        f"STS model type '{model_type}' is not supported by the generic STS "
+        "loader yet. Use the model-specific from_pretrained(...) initializer "
+        "for custom STS model families."
+    )
+
+
+def load(
+    model_path: Union[str, Path],
+    lazy: bool = False,
+    strict: bool = False,
+    **kwargs,
+) -> nn.Module:
+    """Alias for :func:`load_model`."""
+    return load_model(model_path, lazy=lazy, strict=strict, **kwargs)

--- a/mlx_audio/tests/test_dsp.py
+++ b/mlx_audio/tests/test_dsp.py
@@ -60,7 +60,7 @@ def test_dsp_all_exports():
 
 
 def test_utils_lazy_imports():
-    """Verify utils.py uses lazy imports for TTS/STT.
+    """Verify utils.py uses lazy imports for TTS/STT/STS.
 
     Runs in subprocess to avoid interference with other tests.
     """
@@ -69,6 +69,7 @@ import sys
 from mlx_audio.utils import stft
 assert "mlx_audio.tts.utils" not in sys.modules, "TTS utils was imported"
 assert "mlx_audio.stt.utils" not in sys.modules, "STT utils was imported"
+assert "mlx_audio.sts.utils" not in sys.modules, "STS utils was imported"
 print("OK")
 """
     result = subprocess.run(

--- a/mlx_audio/tests/test_lazy_imports.py
+++ b/mlx_audio/tests/test_lazy_imports.py
@@ -42,6 +42,23 @@ print("OK")
     assert result.returncode == 0, f"TTS lazy import failed: {result.stderr}"
 
 
+def test_sts_utils_no_eager_imports():
+    """Importing sts.utils should not import transformers or mlx_lm."""
+    code = """
+import sys
+import mlx_audio.sts.utils
+assert "transformers" not in sys.modules, f"transformers was eagerly imported"
+assert "mlx_lm" not in sys.modules, f"mlx_lm was eagerly imported"
+print("OK")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"STS lazy import failed: {result.stderr}"
+
+
 def test_codec_no_eager_imports():
     """Importing codec should not import miniaudio."""
     code = """

--- a/mlx_audio/tests/test_sts_loading.py
+++ b/mlx_audio/tests/test_sts_loading.py
@@ -1,0 +1,275 @@
+import sys
+import types
+
+import pytest
+
+
+def test_get_model_category_detects_sts():
+    from mlx_audio.utils import get_model_category
+
+    category = get_model_category("lfm_audio", ["lfm2.5", "audio", "1.5b", "4bit"])
+    assert category == "sts"
+
+
+def test_get_model_name_parts_splits_underscore_sts_repo_names():
+    from mlx_audio.utils import get_model_name_parts
+
+    parts = get_model_name_parts("starkdmi/MossFormer2_SE_48K_MLX-4bit")
+
+    assert "mossformer2_se_48k_mlx" in parts
+    assert "mossformer2" in parts
+    assert "se" in parts
+    assert "4bit" in parts
+
+
+def test_get_model_name_parts_combines_dash_separated_sts_repo_names():
+    from mlx_audio.utils import get_model_name_parts
+
+    parts = get_model_name_parts("mlx-community/sam-audio-large")
+
+    assert "sam" in parts
+    assert "audio" in parts
+    assert "sam_audio" in parts
+    assert "samaudio" in parts
+
+
+def test_top_level_load_model_routes_sts(monkeypatch):
+    import mlx_audio.utils as utils
+
+    sentinel = object()
+    empty_utils = types.SimpleNamespace(MODEL_REMAPPING={}, load_model=lambda _: None)
+    sts_utils = types.SimpleNamespace(
+        MODEL_REMAPPING={"lfm_audio": "lfm_audio"},
+        load_model=lambda model_name: sentinel,
+    )
+
+    monkeypatch.setattr(
+        utils,
+        "load_config",
+        lambda model_name: {"model_type": "lfm_audio"},
+    )
+    monkeypatch.setattr(utils, "_get_tts_utils", lambda: empty_utils)
+    monkeypatch.setattr(utils, "_get_stt_utils", lambda: empty_utils)
+    monkeypatch.setattr(utils, "_get_sts_utils", lambda: sts_utils)
+    monkeypatch.setattr(utils, "_get_lid_utils", lambda: empty_utils)
+    monkeypatch.setattr(utils, "_get_vad_utils", lambda: empty_utils)
+
+    result = utils.load_model("mlx-community/LFM2.5-Audio-1.5B-4bit")
+    assert result is sentinel
+
+
+def test_sts_load_model_dispatches_lfm_audio(monkeypatch):
+    import mlx_audio.sts.utils as sts_utils
+
+    sentinel = object()
+    captured = {}
+
+    monkeypatch.setattr(
+        sts_utils,
+        "load_config",
+        lambda model_path, **kwargs: {"model_type": "lfm_audio"},
+    )
+
+    def fake_base_load_model(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(sts_utils, "base_load_model", fake_base_load_model)
+
+    result = sts_utils.load_model("mlx-community/LFM2.5-Audio-1.5B-4bit")
+    assert result is sentinel
+    assert captured["model_path"] == "mlx-community/LFM2.5-Audio-1.5B-4bit"
+    assert captured["category"] == "sts"
+    assert captured["model_remapping"] is sts_utils.MODEL_REMAPPING
+
+
+def test_sts_load_model_dispatches_mossformer2_se_via_base_load_model(monkeypatch):
+    import mlx_audio.sts.utils as sts_utils
+
+    sentinel = object()
+    captured = {}
+
+    def raise_missing_config(model_path, **kwargs):
+        raise FileNotFoundError("config missing at repo root")
+
+    monkeypatch.setattr(sts_utils, "load_config", raise_missing_config)
+
+    def fake_base_load_model(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(sts_utils, "base_load_model", fake_base_load_model)
+
+    result = sts_utils.load_model("starkdmi/MossFormer2_SE_48K_MLX-4bit")
+    assert result is sentinel
+    assert captured["model_path"] == "starkdmi/MossFormer2_SE_48K_MLX-4bit"
+    assert captured["model_type"] == "mossformer2_se"
+    assert captured["category"] == "sts"
+
+
+def test_sts_load_model_dispatches_deepfilternet_via_base_load_model(monkeypatch):
+    import mlx_audio.sts.utils as sts_utils
+
+    sentinel = object()
+    captured = {}
+    resolved_path = "/tmp/deepfilter/v3"
+
+    def raise_missing_config(model_path, **kwargs):
+        raise FileNotFoundError("config missing at repo root")
+
+    monkeypatch.setattr(sts_utils, "load_config", raise_missing_config)
+
+    def fake_resolve_model_path(model_path, **kwargs):
+        assert model_path == "mlx-community/DeepFilterNet-mlx"
+        return resolved_path
+
+    def fake_base_load_model(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        sts_utils, "_resolve_deepfilternet_model_path", fake_resolve_model_path
+    )
+    monkeypatch.setattr(sts_utils, "base_load_model", fake_base_load_model)
+
+    result = sts_utils.load_model("mlx-community/DeepFilterNet-mlx")
+    assert result is sentinel
+    assert captured["model_path"] == resolved_path
+    assert captured["model_type"] == "deepfilternet"
+    assert captured["category"] == "sts"
+
+
+def test_sts_load_model_dispatches_sam_audio_via_base_load_model(monkeypatch):
+    import mlx_audio.sts.utils as sts_utils
+
+    sentinel = object()
+    captured = {}
+
+    monkeypatch.setattr(
+        sts_utils,
+        "load_config",
+        lambda model_path, **kwargs: {
+            "audio_codec": {},
+            "text_encoder": {},
+            "transformer": {},
+        },
+    )
+
+    def fake_base_load_model(**kwargs):
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(sts_utils, "base_load_model", fake_base_load_model)
+
+    result = sts_utils.load_model("mlx-community/sam-audio-large")
+    assert result is sentinel
+    assert captured["model_path"] == "mlx-community/sam-audio-large"
+    assert captured["model_type"] == "sam_audio"
+
+
+def test_sts_load_model_dispatches_moshi_via_from_pretrained(monkeypatch):
+    import mlx_audio.sts.utils as sts_utils
+
+    sentinel = object()
+
+    class StubMoshiSTSModel:
+        @classmethod
+        def from_pretrained(
+            cls,
+            model_name_or_path,
+            quantized=None,
+            revision=None,
+            force_download=False,
+        ):
+            assert model_name_or_path == "kyutai/moshiko-mlx-q4"
+            assert quantized == 4
+            assert revision is None
+            assert force_download is False
+            return sentinel
+
+    stub_module = types.ModuleType("mlx_audio.sts.models.moshi")
+    stub_module.MoshiSTSModel = StubMoshiSTSModel
+
+    def raise_missing_config(model_path, **kwargs):
+        raise FileNotFoundError("config missing at repo root")
+
+    monkeypatch.setattr(sts_utils, "load_config", raise_missing_config)
+    monkeypatch.delitem(sys.modules, "mlx_audio.sts.models.moshi", raising=False)
+    monkeypatch.setitem(sys.modules, "mlx_audio.sts.models.moshi", stub_module)
+
+    result = sts_utils.load_model("kyutai/moshiko-mlx-q4")
+    assert result is sentinel
+
+
+def test_top_level_load_model_routes_sts_from_name_when_config_missing(monkeypatch):
+    import mlx_audio.utils as utils
+
+    sentinel = object()
+    empty_utils = types.SimpleNamespace(MODEL_REMAPPING={}, load_model=lambda _: None)
+    sts_utils = types.SimpleNamespace(
+        MODEL_REMAPPING={
+            "deepfilternet": "deepfilternet",
+            "moshiko": "moshi",
+            "mossformer2": "mossformer2_se",
+            "mossformer2_se": "mossformer2_se",
+            "sam_audio": "sam_audio",
+        },
+        load_model=lambda model_name: sentinel,
+        infer_model_type_from_config=lambda config: None,
+    )
+
+    def raise_missing_config(model_name):
+        raise FileNotFoundError("config missing at repo root")
+
+    monkeypatch.setattr(utils, "load_config", raise_missing_config)
+    monkeypatch.setattr(utils, "_get_tts_utils", lambda: empty_utils)
+    monkeypatch.setattr(utils, "_get_stt_utils", lambda: empty_utils)
+    monkeypatch.setattr(utils, "_get_sts_utils", lambda: sts_utils)
+    monkeypatch.setattr(utils, "_get_lid_utils", lambda: empty_utils)
+    monkeypatch.setattr(utils, "_get_vad_utils", lambda: empty_utils)
+
+    assert utils.load_model("mlx-community/DeepFilterNet-mlx") is sentinel
+    assert utils.load_model("kyutai/moshiko-mlx-q4") is sentinel
+    assert utils.load_model("starkdmi/MossFormer2_SE_48K_MLX") is sentinel
+
+
+def test_top_level_load_model_routes_sts_from_sts_config_heuristics(monkeypatch):
+    import mlx_audio.utils as utils
+
+    sentinel = object()
+    empty_utils = types.SimpleNamespace(MODEL_REMAPPING={}, load_model=lambda _: None)
+    sts_utils = types.SimpleNamespace(
+        MODEL_REMAPPING={"sam_audio": "sam_audio"},
+        load_model=lambda model_name: sentinel,
+        infer_model_type_from_config=lambda config: "sam_audio",
+    )
+
+    monkeypatch.setattr(
+        utils,
+        "load_config",
+        lambda model_name: {
+            "audio_codec": {},
+            "text_encoder": {},
+            "transformer": {},
+        },
+    )
+    monkeypatch.setattr(utils, "_get_tts_utils", lambda: empty_utils)
+    monkeypatch.setattr(utils, "_get_stt_utils", lambda: empty_utils)
+    monkeypatch.setattr(utils, "_get_sts_utils", lambda: sts_utils)
+    monkeypatch.setattr(utils, "_get_lid_utils", lambda: empty_utils)
+    monkeypatch.setattr(utils, "_get_vad_utils", lambda: empty_utils)
+
+    assert utils.load_model("local-sam-model") is sentinel
+
+
+def test_sts_load_model_rejects_unsupported_generic_model(monkeypatch):
+    import mlx_audio.sts.utils as sts_utils
+
+    monkeypatch.setattr(
+        sts_utils,
+        "load_config",
+        lambda model_path, **kwargs: {"model_type": "unsupported_sts_model"},
+    )
+
+    with pytest.raises(ValueError, match="generic STS loader yet"):
+        sts_utils.load_model("kyutai/moshiko-mlx-q4")

--- a/mlx_audio/utils.py
+++ b/mlx_audio/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for mlx_audio.
 
-This module provides a unified interface for loading TTS and STT models,
+This module provides a unified interface for loading TTS, STT, and STS models,
 with lazy imports to avoid loading unnecessary dependencies.
 """
 
@@ -10,6 +10,7 @@ import importlib
 import importlib.util
 import json
 import logging
+import re
 from pathlib import Path
 from typing import (
     List,
@@ -219,6 +220,8 @@ def apply_quantization(
     """
     quantization = config.get("quantization", None)
     if quantization is None:
+        quantization = config.get("quantization_config", None)
+    if quantization is None:
         return
     group_size = quantization.get("group_size", 64)
 
@@ -237,8 +240,8 @@ def apply_quantization(
             if not pred_result:
                 return False
         # Handle custom per layer quantizations
-        if p in config["quantization"]:
-            return config["quantization"][p]
+        if p in quantization:
+            return quantization[p]
         # Handle legacy models which may not have everything quantized
         return f"{p}.scales" in weights
 
@@ -322,7 +325,7 @@ def base_load_model(
     **kwargs,
 ) -> nn.Module:
     """
-    Base implementation for loading models (shared between TTS and STT).
+    Base implementation for loading models (shared between TTS, STT, and STS).
 
     Args:
         model_path: The path or HuggingFace repo to load the model from.
@@ -335,22 +338,24 @@ def base_load_model(
     Returns:
         nn.Module: The loaded and initialized model.
     """
-    model_name = None
-    model_type = None
+    model_name = kwargs.pop("model_name_parts", None)
+    model_type = kwargs.pop("model_type", None)
+    allow_patterns = kwargs.pop("allow_patterns", None)
 
     if isinstance(model_path, str):
-        model_name = model_path.lower().split("/")[-1].split("-")
+        if model_name is None:
+            model_name = get_model_name_parts(model_path)
         revision = kwargs.get("revision", None)
         force_download = kwargs.get("force_download", False)
         model_path = get_model_path(
-            model_path, revision=revision, force_download=force_download
+            model_path,
+            revision=revision,
+            force_download=force_download,
+            allow_patterns=allow_patterns,
         )
     elif isinstance(model_path, Path):
-        try:
-            index = model_path.parts.index("hub")
-            model_name = model_path.parts[index + 1].lower().split("--")[-1].split("-")
-        except ValueError:
-            model_name = model_path.name.lower().split("-")
+        if model_name is None:
+            model_name = get_model_name_parts(model_path)
     else:
         raise ValueError(f"Invalid model path type: {type(model_path)}")
 
@@ -358,7 +363,8 @@ def base_load_model(
     config["model_path"] = str(model_path)
 
     # Determine model_type from config or model_name
-    model_type = config.get("model_type", None)
+    if model_type is None:
+        model_type = config.get("model_type", None)
     if model_type is None:
         model_type = config.get("architecture", None)
     if model_type is None:
@@ -411,6 +417,7 @@ def base_load_model(
 # Lazy-loaded modules
 _stt_utils = None
 _tts_utils = None
+_sts_utils = None
 _vad_utils = None
 _lid_utils = None
 
@@ -433,6 +440,16 @@ def _get_tts_utils():
 
         _tts_utils = tts_utils
     return _tts_utils
+
+
+def _get_sts_utils():
+    """Lazy load STS utils."""
+    global _sts_utils
+    if _sts_utils is None:
+        from mlx_audio.sts import utils as sts_utils
+
+        _sts_utils = sts_utils
+    return _sts_utils
 
 
 def _get_vad_utils():
@@ -712,9 +729,10 @@ def is_valid_module_name(name: str) -> bool:
 
 
 def get_model_category(model_type: str, model_name: List[str]) -> Optional[str]:
-    """Determine whether a model belongs to the TTS, STT, LID, or VAD category."""
+    """Determine whether a model belongs to the TTS, STT, STS, LID, or VAD category."""
     stt_utils = _get_stt_utils()
     tts_utils = _get_tts_utils()
+    sts_utils = _get_sts_utils()
     vad_utils = _get_vad_utils()
     lid_utils = _get_lid_utils()
 
@@ -723,9 +741,23 @@ def get_model_category(model_type: str, model_name: List[str]) -> Optional[str]:
     categories = [
         ("tts", tts_utils.MODEL_REMAPPING),
         ("stt", stt_utils.MODEL_REMAPPING),
+        ("sts", sts_utils.MODEL_REMAPPING),
         ("lid", lid_utils.MODEL_REMAPPING),
         ("vad", vad_utils.MODEL_REMAPPING),
     ]
+
+    # If the repo name already includes an explicit category token like "lid",
+    # prefer that category as long as we can resolve any candidate hint there.
+    for category, remap in categories:
+        if category not in candidates:
+            continue
+        for hint in candidates:
+            arch = remap.get(hint, hint)
+            if not is_valid_module_name(arch):
+                continue
+            module_path = f"mlx_audio.{category}.models.{arch}"
+            if importlib.util.find_spec(module_path) is not None:
+                return category
 
     # First pass: check for explicit remapping matches (higher priority)
     for category, remap in categories:
@@ -749,20 +781,54 @@ def get_model_category(model_type: str, model_name: List[str]) -> Optional[str]:
     return None
 
 
-def get_model_name_parts(model_path: Union[str, Path]) -> str:
+def get_model_name_parts(model_path: Union[str, Path]) -> List[str]:
     model_name = None
     if isinstance(model_path, str):
-        model_name = model_path.lower().split("/")[-1].split("-")
+        model_name = model_path.lower().split("/")[-1]
     elif isinstance(model_path, Path):
-        index = model_path.parts.index("hub")
-        model_name = model_path.parts[index + 1].lower().split("--")[-1].split("-")
+        try:
+            index = model_path.parts.index("hub")
+            model_name = model_path.parts[index + 1].lower().split("--")[-1]
+        except ValueError:
+            model_name = model_path.name.lower()
     else:
         raise ValueError(f"Invalid model path type: {type(model_path)}")
-    return model_name
+
+    parts = []
+    seen = set()
+
+    dash_parts = [part for part in model_name.split("-") if part]
+
+    for part in dash_parts:
+        if not part or part in seen:
+            continue
+        parts.append(part)
+        seen.add(part)
+
+        if "_" in part:
+            for subpart in part.split("_"):
+                if subpart and subpart not in seen:
+                    parts.append(subpart)
+                    seen.add(subpart)
+
+        normalized = re.sub(r"[^a-z0-9]+", "", part)
+        if normalized and normalized not in seen:
+            parts.append(normalized)
+            seen.add(normalized)
+
+    for start in range(len(dash_parts)):
+        for end in range(start + 2, len(dash_parts) + 1):
+            segment = dash_parts[start:end]
+            for combined in ("_".join(segment), "".join(segment)):
+                if combined and combined not in seen:
+                    parts.append(combined)
+                    seen.add(combined)
+
+    return parts
 
 
 def load_model(model_name: str):
-    """Load a TTS, STT, LID, or VAD model based on its configuration and name.
+    """Load a TTS, STT, STS, LID, or VAD model based on its configuration and name.
 
     Args:
         model_name (str): Name or path of the model to load
@@ -773,26 +839,34 @@ def load_model(model_name: str):
     Raises:
         ValueError: If the model type cannot be determined or is not supported
     """
-    tts_utils = _get_tts_utils()
-    stt_utils = _get_stt_utils()
-    vad_utils = _get_vad_utils()
-    lid_utils = _get_lid_utils()
-
-    config = tts_utils.load_config(model_name)
     model_name_parts = get_model_name_parts(model_name)
+    load_error = None
+
+    try:
+        config = load_config(model_name)
+    except FileNotFoundError as exc:
+        config = {}
+        load_error = exc
 
     # Try to determine model type from config first, then from name
     model_type = config.get("model_type", None)
+    if model_type is None:
+        model_type = config.get("architecture", None)
+    if model_type is None:
+        model_type = _get_sts_utils().infer_model_type_from_config(config)
     model_category = get_model_category(model_type, model_name_parts)
 
     if not model_category:
+        if load_error is not None:
+            raise load_error
         raise ValueError(f"Could not determine model type for {model_name}")
 
     model_loaders = {
-        "tts": tts_utils.load_model,
-        "stt": stt_utils.load_model,
-        "lid": lid_utils.load_model,
-        "vad": vad_utils.load_model,
+        "tts": _get_tts_utils().load_model,
+        "stt": _get_stt_utils().load_model,
+        "sts": _get_sts_utils().load_model,
+        "lid": _get_lid_utils().load_model,
+        "vad": _get_vad_utils().load_model,
     }
 
     if model_category not in model_loaders:


### PR DESCRIPTION
This matches the STT / TTS `load_model` behavior for STS models. I tried to make this as minimal as possible but the STS models are a bit more esoteric so I had to tweak the top-level `utils.py` a bit to make this work.

I also lit up the LID tests in CI which looks like it was missed when that category was added.