### PR TITLE
Clean up bare scipy usage

### DIFF
--- a/mlx_audio/dsp.py
+++ b/mlx_audio/dsp.py
@@ -18,6 +18,7 @@ __all__ = [
     "ISTFTCache",
     "mel_filters",
     "integrated_loudness",
+    "lfilter",
     "normalize_loudness",
     "normalize_peak",
     # Kaldi-compatible features
@@ -154,9 +155,50 @@ def _biquad_coefficients(
     return np.array([b0, b1, b2]) / a0, np.array([a0, a1, a2]) / a0
 
 
-def _apply_lfilter(b: np.ndarray, a: np.ndarray, data: np.ndarray) -> np.ndarray:
-    from scipy.signal import lfilter
+def lfilter(b: np.ndarray, a: np.ndarray, data: np.ndarray) -> np.ndarray:
+    """Apply a 1-D causal linear filter.
 
+    This implements the standard direct-form II transposed recurrence for the
+    1-D DSP paths used in this package.
+    """
+    b = np.asarray(b, dtype=np.float64)
+    a = np.asarray(a, dtype=np.float64)
+    data = np.asarray(data)
+
+    if data.ndim != 1:
+        raise ValueError("dsp.lfilter only supports 1-D input")
+    if a.size == 0 or a[0] == 0:
+        raise ValueError("filter denominator must have a non-zero leading term")
+    if b.size == 0:
+        return np.zeros_like(data)
+
+    b = b / a[0]
+    a = a / a[0]
+
+    dtype = np.result_type(data.dtype, b.dtype, a.dtype)
+    x = data.astype(dtype, copy=False)
+    y = np.empty_like(x, dtype=dtype)
+
+    state_len = max(len(a), len(b)) - 1
+    if state_len == 0:
+        return b[0] * x
+
+    state = np.zeros(state_len, dtype=dtype)
+    for n, sample in enumerate(x):
+        output = b[0] * sample + state[0]
+        for i in range(1, state_len):
+            feedforward = b[i] * sample if i < len(b) else 0.0
+            feedback = a[i] * output if i < len(a) else 0.0
+            state[i - 1] = state[i] + feedforward - feedback
+        feedforward = b[state_len] * sample if state_len < len(b) else 0.0
+        feedback = a[state_len] * output if state_len < len(a) else 0.0
+        state[-1] = feedforward - feedback
+        y[n] = output
+
+    return y
+
+
+def _apply_lfilter(b: np.ndarray, a: np.ndarray, data: np.ndarray) -> np.ndarray:
     return lfilter(b, a, data)
 
 

--- a/mlx_audio/sts/models/lfm_audio/processor.py
+++ b/mlx_audio/sts/models/lfm_audio/processor.py
@@ -2,7 +2,6 @@
 # LFM2.5-Audio: Processor for audio and text
 
 import json
-import math
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
@@ -392,47 +391,13 @@ class LFM2AudioProcessor:
         orig_sr: int,
         target_sr: int,
     ) -> mx.array:
-        """Resample audio using scipy's high-quality polyphase resampling."""
+        """Resample audio with polyphase filtering."""
         if orig_sr == target_sr:
             return audio
 
-        import numpy as np
-        from scipy import signal
+        from mlx_audio.utils import resample_audio
 
-        # Convert to numpy for scipy processing
-        audio_np = np.array(audio)
-        orig_dtype = audio_np.dtype
-
-        # Calculate target length
-        if audio_np.ndim == 1:
-            orig_len = audio_np.shape[0]
-            new_len = int(orig_len * target_sr / orig_sr)
-            resampled_np = signal.resample_poly(
-                audio_np.astype(np.float64),
-                target_sr,
-                orig_sr,
-            ).astype(orig_dtype)
-        elif audio_np.ndim == 2:
-            # Shape: (channels, samples) or (batch, samples)
-            orig_len = audio_np.shape[-1]
-            new_len = int(orig_len * target_sr / orig_sr)
-            resampled_np = signal.resample_poly(
-                audio_np.astype(np.float64),
-                target_sr,
-                orig_sr,
-                axis=-1,
-            ).astype(orig_dtype)
-        else:  # 3D: (batch, channels, samples)
-            orig_len = audio_np.shape[-1]
-            new_len = int(orig_len * target_sr / orig_sr)
-            resampled_np = signal.resample_poly(
-                audio_np.astype(np.float64),
-                target_sr,
-                orig_sr,
-                axis=-1,
-            ).astype(orig_dtype)
-
-        return mx.array(resampled_np)
+        return resample_audio(audio, orig_sr, target_sr, axis=-1)
 
 
 @dataclass

--- a/mlx_audio/sts/models/sam_audio/processor.py
+++ b/mlx_audio/sts/models/sam_audio/processor.py
@@ -388,19 +388,6 @@ def save_audio(
     if audio.ndim > 1:
         audio = audio.squeeze()
 
-    try:
-        from mlx_audio.audio_io import write as audio_write
+    from mlx_audio.audio_io import write as audio_write
 
-        audio_write(path, audio, sample_rate)
-    except ImportError:
-        try:
-            from scipy.io import wavfile
-
-            # Normalize to int16 range
-            audio_int = (audio * 32767).astype(np.int16)
-            wavfile.write(path, sample_rate, audio_int)
-        except ImportError:
-            raise ImportError(
-                "Please install miniaudio or scipy for audio saving: "
-                "pip install miniaudio scipy"
-            )
+    audio_write(path, audio, sample_rate)

--- a/mlx_audio/stt/models/voxtral_realtime/voxtral_realtime.py
+++ b/mlx_audio/stt/models/voxtral_realtime/voxtral_realtime.py
@@ -81,15 +81,12 @@ class Model(nn.Module):
         """Load and resample audio from file path or array to 16kHz float32 numpy."""
         if isinstance(audio_input, (str, Path)):
             from mlx_audio.audio_io import read as audio_read
+            from mlx_audio.utils import resample_audio
 
             audio_np, sr = audio_read(str(audio_input), dtype="float32")
             audio_np = audio_np.flatten()
             if sr != SAMPLE_RATE:
-                # Resample to 16kHz
-                from scipy.signal import resample
-
-                n_samples = int(len(audio_np) * SAMPLE_RATE / sr)
-                audio_np = resample(audio_np, n_samples).astype(np.float32)
+                audio_np = resample_audio(audio_np, sr, SAMPLE_RATE)
             return audio_np
         if isinstance(audio_input, list):
             audio_input = audio_input[0]

--- a/mlx_audio/stt/utils.py
+++ b/mlx_audio/stt/utils.py
@@ -27,13 +27,9 @@ MODEL_REMAPPING = {
 
 
 def resample_audio(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
-    from scipy import signal
+    from mlx_audio.utils import resample_audio as _resample_audio
 
-    gcd = np.gcd(orig_sr, target_sr)
-    up = target_sr // gcd
-    down = orig_sr // gcd
-    resampled = signal.resample_poly(audio, up, down, padtype="edge")
-    return resampled
+    return _resample_audio(audio, orig_sr, target_sr, axis=0)
 
 
 def load_audio(

--- a/mlx_audio/tests/test_dsp.py
+++ b/mlx_audio/tests/test_dsp.py
@@ -59,6 +59,19 @@ def test_dsp_all_exports():
         assert hasattr(dsp, name), f"Missing export: {name}"
 
 
+def test_lfilter_fir_and_iir():
+    """Verify the local lfilter recurrence for FIR and IIR filters."""
+    from mlx_audio.dsp import lfilter
+
+    x = np.array([1.0, 2.0, 4.0], dtype=np.float32)
+    fir = lfilter([1.0, -0.5], [1.0], x)
+    np.testing.assert_allclose(fir, [1.0, 1.5, 3.0])
+
+    impulse = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    iir = lfilter([1.0], [1.0, -0.5], impulse)
+    np.testing.assert_allclose(iir, [1.0, 0.5, 0.25, 0.125])
+
+
 def test_utils_lazy_imports():
     """Verify utils.py uses lazy imports for TTS/STT/STS.
 

--- a/mlx_audio/tts/models/bark/bark.py
+++ b/mlx_audio/tts/models/bark/bark.py
@@ -12,7 +12,6 @@ import numpy as np
 import tqdm
 from mlx.utils import tree_map, tree_unflatten
 from mlx_lm.models.base import create_causal_mask
-from scipy.io.wavfile import write as write_wav
 from transformers import BertTokenizer
 
 from ..base import BaseModelArgs, GenerationResult

--- a/mlx_audio/tts/models/chatterbox/s3gen/hifigan.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/hifigan.py
@@ -7,7 +7,7 @@ import mlx.nn as nn
 
 def hann_window_periodic(size: int) -> mx.array:
     """
-    Create periodic Hann window (fftbins=True), matching scipy.signal.get_window('hann', size, fftbins=True).
+    Create periodic Hann window (fftbins=True).
 
     Uses size in denominator instead of size-1, which is the correct window for STFT.
     """

--- a/mlx_audio/tts/models/chatterbox/s3gen/s3gen.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/s3gen.py
@@ -1,11 +1,11 @@
 # Ported from https://github.com/resemble-ai/chatterbox
 
-import math
 from typing import Dict, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
-from scipy import signal
+
+from mlx_audio.utils import resample_audio
 
 from .decoder import ConditionalDecoder
 from .f0_predictor import ConvRNNF0Predictor
@@ -15,20 +15,6 @@ from .hifigan import HiFTGenerator
 from .mel import mel_spectrogram
 from .transformer.upsample_encoder import UpsampleConformerEncoder
 from .xvector import CAMPPlus
-
-
-def resample_audio(audio: mx.array, orig_sr: int, target_sr: int) -> mx.array:
-    """Resample audio using scipy (numpy required for scipy)."""
-    if orig_sr == target_sr:
-        return audio
-    import numpy as np
-
-    audio_np = np.array(audio)
-    gcd = math.gcd(orig_sr, target_sr)
-    up = target_sr // gcd
-    down = orig_sr // gcd
-    resampled = signal.resample_poly(audio_np, up, down, padtype="edge")
-    return mx.array(resampled.astype(np.float32))
 
 
 # Constants

--- a/mlx_audio/tts/models/chatterbox/s3gen/s3gen.py
+++ b/mlx_audio/tts/models/chatterbox/s3gen/s3gen.py
@@ -16,7 +16,6 @@ from .mel import mel_spectrogram
 from .transformer.upsample_encoder import UpsampleConformerEncoder
 from .xvector import CAMPPlus
 
-
 # Constants
 S3GEN_SR = 24000
 S3_SR = 16000

--- a/mlx_audio/tts/models/chatterbox/voice_encoder/voice_encoder.py
+++ b/mlx_audio/tts/models/chatterbox/voice_encoder/voice_encoder.py
@@ -4,6 +4,8 @@ from typing import Dict, List, Optional
 import mlx.core as mx
 import mlx.nn as nn
 
+from mlx_audio.utils import resample_audio
+
 from .config import VoiceEncConfig
 from .melspec import melspectrogram
 
@@ -398,23 +400,11 @@ class VoiceEncoder(nn.Module):
         Returns:
             Embeddings
         """
-        import scipy.signal
-
         # Resample if needed
         if sample_rate != self.hp.sample_rate:
-            import numpy as np
-
-            resampled_wavs = []
-            for wav in wavs:
-                # Convert to numpy for resampling
-                wav_np = np.array(wav)
-                # Calculate resampling ratio
-                gcd = math.gcd(sample_rate, self.hp.sample_rate)
-                up = self.hp.sample_rate // gcd
-                down = sample_rate // gcd
-                wav_resampled = scipy.signal.resample_poly(wav_np, up, down)
-                resampled_wavs.append(mx.array(wav_resampled))
-            wavs = resampled_wavs
+            wavs = [
+                resample_audio(wav, sample_rate, self.hp.sample_rate) for wav in wavs
+            ]
 
         # Trim silence if requested
         if trim_top_db is not None:

--- a/mlx_audio/tts/models/chatterbox_turbo/chatterbox_turbo.py
+++ b/mlx_audio/tts/models/chatterbox_turbo/chatterbox_turbo.py
@@ -427,7 +427,7 @@ class ChatterboxTurboTTS(nn.Module):
                 logger.info(f"Loading {len(s3gen_weights)} S3Gen weights")
                 # S3Gen has some parameters generated at init (not from weights):
                 # - encoder.embed.pos_enc.pe, encoder.up_embed.pos_enc.pe (positional encodings)
-                # - mel2wav.stft_window (STFT window from scipy)
+                # - mel2wav.stft_window (periodic Hann STFT window)
                 # - trim_fade (fade buffer)
                 init_generated_params = {
                     "encoder.embed.pos_enc.pe",

--- a/mlx_audio/tts/models/chatterbox_turbo/models/s3gen/hifigan.py
+++ b/mlx_audio/tts/models/chatterbox_turbo/models/s3gen/hifigan.py
@@ -5,7 +5,8 @@ from typing import Dict, List, Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
-from scipy.signal import get_window
+
+from mlx_audio.dsp import hanning
 
 
 def get_padding(kernel_size: int, dilation: int = 1) -> int:
@@ -438,8 +439,8 @@ class HiFTGenerator(nn.Module):
         )
 
         # STFT window
-        self.stft_window = mx.array(
-            get_window("hann", istft_params["n_fft"], fftbins=True).astype(np.float32)
+        self.stft_window = hanning(istft_params["n_fft"], periodic=True).astype(
+            mx.float32
         )
 
     def _upsample_f0(self, f0: mx.array) -> mx.array:

--- a/mlx_audio/tts/models/chatterbox_turbo/models/voice_encoder/melspec.py
+++ b/mlx_audio/tts/models/chatterbox_turbo/models/voice_encoder/melspec.py
@@ -4,8 +4,8 @@ from functools import lru_cache
 
 import mlx.core as mx
 import numpy as np
-from scipy import signal
 
+from mlx_audio.dsp import lfilter
 from mlx_audio.utils import mel_filters, stft
 
 from .config import VoiceEncConfig
@@ -29,7 +29,7 @@ def mel_basis(hp: VoiceEncConfig):
 
 def preemphasis(wav, hp: VoiceEncConfig):
     assert hp.preemphasis != 0
-    wav = signal.lfilter([1, -hp.preemphasis], [1], wav)
+    wav = lfilter([1, -hp.preemphasis], [1], wav)
     wav = np.clip(wav, -1, 1)
     return wav
 

--- a/mlx_audio/tts/models/higgs_audio/serve.py
+++ b/mlx_audio/tts/models/higgs_audio/serve.py
@@ -23,7 +23,6 @@ Usage:
 from __future__ import annotations
 
 import json
-import wave
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Optional, Tuple
@@ -47,26 +46,18 @@ class HiggsAudioGenerationResult:
 
 
 def _load_wav_as_24k_mono(path: str) -> np.ndarray:
-    """Minimal wav loader → float32 mono at 24 kHz. Pure-python fallback.
+    """Load audio as float32 mono at 24 kHz.
 
-    Higgs codec expects 24 kHz mono input. We resample via scipy if available
-    and fall back to a noisy message if the source isn't already 24 kHz.
+    Higgs codec expects 24 kHz mono input.
     """
-    with wave.open(path, "rb") as r:
-        sr = r.getframerate()
-        nchan = r.getnchannels()
-        raw = r.readframes(r.getnframes())
-    samples = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
-    if nchan == 2:
-        samples = samples.reshape(-1, 2).mean(axis=1)
+    from mlx_audio.audio_io import read as audio_read
+    from mlx_audio.utils import resample_audio
+
+    samples, sr = audio_read(path, dtype="float32")
+    if samples.ndim > 1:
+        samples = samples.mean(axis=1)
     if sr != 24000:
-        try:
-            from scipy.signal import resample_poly
-        except ImportError as e:
-            raise RuntimeError(
-                f"reference audio is {sr} Hz; install scipy to resample, or pre-convert to 24 kHz mono wav"
-            ) from e
-        samples = resample_poly(samples, up=24000, down=sr).astype(np.float32)
+        samples = resample_audio(samples, sr, 24000)
     return samples
 
 

--- a/mlx_audio/tts/models/outetts/dac_interface.py
+++ b/mlx_audio/tts/models/outetts/dac_interface.py
@@ -2,11 +2,11 @@ import math
 
 import mlx.core as mx
 import numpy as np
-import scipy.signal
 
 from mlx_audio.audio_io import read as audio_read
 from mlx_audio.codec import DAC
 from mlx_audio.dsp import integrated_loudness, normalize_loudness, normalize_peak
+from mlx_audio.utils import resample_audio
 
 
 def process_audio_array(
@@ -66,7 +66,7 @@ class DacInterface:
         if len(audio_np.shape) < 2:
             audio_np = audio_np.reshape(1, -1)
 
-        channels, length = audio_np.shape[-2:]
+        channels = audio_np.shape[-2]
 
         if target_channels == 1:
             if channels > 1:
@@ -78,13 +78,7 @@ class DacInterface:
                 audio_np = audio_np[..., :2, :]
 
         if sr != target_sr:
-            new_length = int(length * target_sr / sr)
-            resampled = np.zeros((target_channels, new_length))
-
-            for ch in range(target_channels):
-                resampled[ch] = scipy.signal.resample(audio_np[ch], new_length)
-
-            audio_np = resampled
+            audio_np = resample_audio(audio_np, sr, target_sr, axis=-1)
 
         return mx.array(audio_np)
 

--- a/mlx_audio/tts/models/sesame/sesame.py
+++ b/mlx_audio/tts/models/sesame/sesame.py
@@ -14,14 +14,13 @@ from mlx_lm.models.cache import make_prompt_cache
 from mlx_lm.models.llama import LlamaModel
 from mlx_lm.models.llama import ModelArgs as LlamaModelArgs
 from mlx_lm.sample_utils import make_sampler
-from scipy import signal
 from tokenizers.processors import TemplateProcessing
 from tqdm import tqdm
 from transformers import AutoTokenizer
 
 from mlx_audio.audio_io import read as audio_read
 from mlx_audio.codec.models.mimi import Mimi, MimiStreamingDecoder
-from mlx_audio.utils import load_audio
+from mlx_audio.utils import load_audio, resample_audio
 
 from ..base import GenerationResult
 from .attention import Attention
@@ -33,14 +32,6 @@ except ImportError:
 
 MIMI_REPO = "kyutai/moshiko-pytorch-bf16"
 TOKENIZER_REPO = "unsloth/Llama-3.2-1B"
-
-
-def resample_audio(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
-    gcd = np.gcd(orig_sr, target_sr)
-    up = target_sr // gcd
-    down = orig_sr // gcd
-    resampled = signal.resample_poly(audio, up, down, padtype="edge")
-    return resampled
 
 
 @dataclass

--- a/mlx_audio/tts/models/sesame/watermarking.py
+++ b/mlx_audio/tts/models/sesame/watermarking.py
@@ -3,9 +3,9 @@ import argparse
 import mlx.core as mx
 import numpy as np
 import silentcipher
-from scipy import signal
 
 from mlx_audio.audio_io import read as audio_read
+from mlx_audio.utils import resample_audio
 
 # This watermark key is public, it is not secure.
 # If using CSM 1B in another application, use a new private key and keep it secret.
@@ -24,14 +24,6 @@ def load_watermarker() -> silentcipher.server.Model:
         model_type="44.1k",
     )
     return model
-
-
-def resample_audio(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
-    gcd = np.gcd(orig_sr, target_sr)
-    up = target_sr // gcd
-    down = orig_sr // gcd
-    resampled = signal.resample_poly(audio, up, down, padtype="edge")
-    return resampled
 
 
 def watermark(

--- a/mlx_audio/vad/models/sortformer/sortformer.py
+++ b/mlx_audio/vad/models/sortformer/sortformer.py
@@ -2027,17 +2027,13 @@ class Model(nn.Module):
 
     @staticmethod
     def _resample(waveform: mx.array, orig_sr: int, target_sr: int) -> mx.array:
-        """Resample audio using scipy (no librosa dependency)."""
+        """Resample audio to ``target_sr``."""
         if orig_sr == target_sr:
             return waveform
-        import numpy as np
-        from scipy import signal as scipy_signal
 
-        gcd = math.gcd(orig_sr, target_sr)
-        resampled = scipy_signal.resample_poly(
-            np.array(waveform), target_sr // gcd, orig_sr // gcd
-        ).astype(np.float32)
-        return mx.array(resampled)
+        from mlx_audio.utils import resample_audio
+
+        return resample_audio(waveform, orig_sr, target_sr)
 
     @staticmethod
     def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:


### PR DESCRIPTION
The vast majority of scipy usage is for audio resampling. This change consolidates all the resampling calls to use our built-in utilities and otherwise avoids any bare scipy usage where possible, a net code reduction.