### PR TITLE
Fix Voxtral STT crash on eos_token_ids initialization

### DIFF
--- a/mlx_audio/stt/models/voxtral/voxtral.py
+++ b/mlx_audio/stt/models/voxtral/voxtral.py
@@ -16,6 +16,39 @@ from mlx_audio.stt.utils import get_model_path
 from ..base import STTOutput
 from .config import AudioConfig, ModelConfig
 
+# Voxtral's three EOS-equivalent token ids. Used as the default when a
+# loaded tokenizer has no `eos_token_ids` populated.
+_VOXTRAL_EOS_TOKEN_IDS = [2, 4, 32000]
+
+
+def _ensure_eos_token_ids_list(tokenizer, default=_VOXTRAL_EOS_TOKEN_IDS):
+    """Set `tokenizer.eos_token_ids` as a list, surviving the base
+    class's attribute-access magic.
+
+    `transformers.PreTrainedTokenizerBase` overrides `__getattr__` to
+    collapse any missing `*_id` / `*_ids` attribute lookup to the
+    corresponding single-token id (`eos_token_id` etc.), and overrides
+    `__setattr__` to reject non-string values for those keys. Together
+    these make `tok.eos_token_ids = [2, 4, 32000]` either silently
+    return the wrong value on read-back, or raise on assignment.
+
+    Bypass both by writing through the instance `__dict__` directly:
+    `__getattr__` only fires when the attribute is absent from
+    `__dict__`, so a `__dict__` write shadows the descriptor cleanly
+    on subsequent reads. Per Python data model.
+
+    If the tokenizer already has a list/tuple/set value present in
+    `__dict__`, preserve it (coerced to list); otherwise install
+    `default`.
+    """
+    existing = tokenizer.__dict__.get("eos_token_ids")
+    if isinstance(existing, set):
+        existing = sorted(existing)
+    elif not isinstance(existing, (list, tuple)):
+        existing = default
+    tokenizer.__dict__["eos_token_ids"] = list(existing)
+    return tokenizer.__dict__["eos_token_ids"]
+
 
 class Attention(nn.Module):
     def __init__(
@@ -288,9 +321,7 @@ class Model(nn.Module):
 
         processor = AutoProcessor.from_pretrained(str(model_path))
         model._processor = processor
-        model._processor.tokenizer.eos_token_ids = getattr(
-            model._processor.tokenizer, "eos_token_ids", [2, 4, 32000]
-        )
+        _ensure_eos_token_ids_list(model._processor.tokenizer)
 
         # Store model_repo for transcription requests
         if not hasattr(model.config, "model_repo") or model.config.model_repo is None:

--- a/mlx_audio/stt/tests/test_voxtral_eos_token_ids.py
+++ b/mlx_audio/stt/tests/test_voxtral_eos_token_ids.py
@@ -1,0 +1,125 @@
+"""Unit tests for `_ensure_eos_token_ids_list` in
+`mlx_audio.stt.models.voxtral.voxtral`.
+
+`transformers.PreTrainedTokenizerBase` defines `__getattr__` and
+`__setattr__` overrides that special-case attribute names ending in
+`_id` / `_ids`:
+
+  * `__getattr__` collapses any missing `*_id` / `*_ids` lookup to
+    the corresponding single-token id, so `getattr(tok,
+    "eos_token_ids", default)` returns the int `eos_token_id`
+    instead of falling back to `default`.
+  * `__setattr__` rejects non-string values for any attribute name
+    ending in `_id` / `_ids`, raising
+    `ValueError("Cannot set a non-string value as the eos_token")`.
+
+`_ensure_eos_token_ids_list` bypasses both by writing through
+`tokenizer.__dict__`. These tests exercise the production helper
+against a real `PreTrainedTokenizerFast` instance (no model
+download).
+"""
+
+import unittest
+
+from mlx_audio.stt.models.voxtral.voxtral import (
+    _VOXTRAL_EOS_TOKEN_IDS,
+    _ensure_eos_token_ids_list,
+)
+
+
+def _make_tokenizer():
+    """Build a minimal real `PreTrainedTokenizerFast` that exhibits
+    `PreTrainedTokenizerBase`'s `__getattr__` / `__setattr__` magic.
+    """
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from transformers import PreTrainedTokenizerFast
+
+    inner = Tokenizer(
+        WordLevel(
+            vocab={"<unk>": 0, "<s>": 1, "</s>": 2},
+            unk_token="<unk>",
+        )
+    )
+    return PreTrainedTokenizerFast(
+        tokenizer_object=inner,
+        unk_token="<unk>",
+        bos_token="<s>",
+        eos_token="</s>",
+    )
+
+
+class TestBaselineMagic(unittest.TestCase):
+    """Demonstrates the underlying base-class behavior that
+    `_ensure_eos_token_ids_list` exists to bypass.
+    """
+
+    def test_getattr_collapses_eos_token_ids_to_int(self):
+        tok = _make_tokenizer()
+        # The default list is NEVER returned, regardless of magic on
+        # `_ids`-suffixed attribute access:
+        result = getattr(tok, "eos_token_ids", [2, 4, 32000])
+        self.assertIsInstance(result, int)
+        self.assertEqual(result, tok.eos_token_id)
+        self.assertNotEqual(result, [2, 4, 32000])
+
+    def test_setattr_rejects_non_string_eos_token_ids(self):
+        tok = _make_tokenizer()
+        with self.assertRaises(ValueError):
+            tok.eos_token_ids = [2, 4, 32000]
+
+
+class TestEnsureEosTokenIdsList(unittest.TestCase):
+    """Exercises the production helper directly."""
+
+    def test_initializes_to_default_when_absent(self):
+        tok = _make_tokenizer()
+        result = _ensure_eos_token_ids_list(tok)
+        self.assertEqual(result, _VOXTRAL_EOS_TOKEN_IDS)
+        self.assertEqual(tok.__dict__["eos_token_ids"], _VOXTRAL_EOS_TOKEN_IDS)
+
+    def test_readback_via_attribute_returns_list(self):
+        tok = _make_tokenizer()
+        _ensure_eos_token_ids_list(tok)
+        # __getattr__ no longer fires (attribute now in __dict__),
+        # so the read returns the list, not the int.
+        self.assertIsInstance(tok.eos_token_ids, list)
+        self.assertEqual(tok.eos_token_ids, _VOXTRAL_EOS_TOKEN_IDS)
+
+    def test_iteration_works_for_generation_loop(self):
+        # Downstream caller (`generate.py`) does
+        #   if token in eos_token_ids:
+        # which previously failed with TypeError: 'int' is not iterable.
+        tok = _make_tokenizer()
+        _ensure_eos_token_ids_list(tok)
+        self.assertIn(2, tok.eos_token_ids)
+        self.assertNotIn(99, tok.eos_token_ids)
+        self.assertEqual(list(tok.eos_token_ids), _VOXTRAL_EOS_TOKEN_IDS)
+
+    def test_preserves_existing_list(self):
+        tok = _make_tokenizer()
+        tok.__dict__["eos_token_ids"] = [10, 20]
+        _ensure_eos_token_ids_list(tok)
+        self.assertEqual(tok.eos_token_ids, [10, 20])
+
+    def test_preserves_existing_tuple_as_list(self):
+        tok = _make_tokenizer()
+        tok.__dict__["eos_token_ids"] = (10, 20)
+        _ensure_eos_token_ids_list(tok)
+        self.assertEqual(tok.__dict__["eos_token_ids"], [10, 20])
+        self.assertIsInstance(tok.__dict__["eos_token_ids"], list)
+
+    def test_preserves_existing_set_sorted_as_list(self):
+        tok = _make_tokenizer()
+        tok.__dict__["eos_token_ids"] = {30, 10, 20}
+        _ensure_eos_token_ids_list(tok)
+        self.assertEqual(tok.__dict__["eos_token_ids"], [10, 20, 30])
+
+    def test_custom_default_is_used(self):
+        tok = _make_tokenizer()
+        _ensure_eos_token_ids_list(tok, default=[5, 6, 7])
+        self.assertEqual(tok.__dict__["eos_token_ids"], [5, 6, 7])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`Voxtral.Model.post_load_hook` currently does:

```python
model._processor.tokenizer.eos_token_ids = getattr(
    model._processor.tokenizer, "eos_token_ids", [2, 4, 32000]
)
```

On modern transformers, this crashes Voxtral transcription with `TypeError: 'int' object is not iterable` at the first decode step.

> **Re #450:** that PR was closed during a discussion centered on `transformers==5.0.0rc3` and a perceived warning-only behavior. Rechecking with current transformers releases (5.5.x and later) reproduces a hard `TypeError` with no transcription output produced; details below. This PR addresses the same root cause at the load site rather than defensively in `generate.py` / `stream_generate.py`, and omits the `added_tokens_decoder` patch from #450.

## Reproducer

Fresh venv:

```bash
python3.12 -m venv /tmp/voxtral-repro
source /tmp/voxtral-repro/bin/activate
pip install -U \
  "transformers>=5.5,<5.7" \
  "mistral-common[audio]>=1.11.0" \
  "torch>=2.0.0" \
  "librosa>=0.10.0" \
  "git+https://github.com/Blaizzy/mlx-audio@main"
```

```python
from mlx_audio.stt import load_model
from mlx_audio.stt.generate import generate_transcription

model = load_model("mlx-community/Voxtral-Mini-3B-2507-bf16")
result = generate_transcription(model=model, audio="speech.wav")
```

Observed (current main):

```
Traceback (most recent call last):
  ...
  File ".../mlx_audio/stt/models/voxtral/voxtral.py", line ..., in generate
    + list(self._processor.tokenizer.eos_token_ids),
TypeError: 'int' object is not iterable
```

(`stream_generate` has the same crash via `if token in self._processor.tokenizer.eos_token_ids` — same root cause; whichever path the caller exercises first crashes before the consumer can iterate.)

Transcription does not complete; the crash fires at the first decode step, with no fallback path.

## Root cause

`transformers.PreTrainedTokenizerBase` defines two relevant descriptor-style overrides:

* **`__getattr__`** collapses any missing attribute lookup whose key ends in `_id` or `_ids` to the corresponding **single-token id** (`eos_token_id`, `bos_token_id`, etc.). So `getattr(tok, "eos_token_ids", default)` does not return the `default` list — it returns the int `eos_token_id`.
* **`__setattr__`** rejects non-string values for any key ending in `_id` / `_ids`, raising `ValueError("Cannot set a non-string value as the eos_token")`.

The original line therefore:

1. `getattr(tok, "eos_token_ids", [2, 4, 32000])` returns an `int`.
2. `tok.eos_token_ids = <int>` is assigned, but `__setattr__` for `_ids` keys writes to the special tokens map without populating `tok.__dict__["eos_token_ids"]`. The intended list is gone.
3. Later reads via `tok.eos_token_ids` re-trigger `__getattr__` and return the collapsed int.
4. Downstream Voxtral generation reads `self._processor.tokenizer.eos_token_ids` in `stream_generate` and passes `list(self._processor.tokenizer.eos_token_ids)` to `make_sampler`; both require an iterable and fail when the tokenizer returns the collapsed int.

## Fix

Bypass both descriptor overrides by writing through `tokenizer.__dict__` directly. Per the Python data model, `__getattr__` only fires when the attribute is **absent** from the instance dict, so populating `__dict__["eos_token_ids"]` shadows the descriptor on subsequent reads.

The bypass is extracted into a module-level helper `_ensure_eos_token_ids_list(tokenizer, default=_VOXTRAL_EOS_TOKEN_IDS)` so the unit tests exercise the actual production code:

```python
_VOXTRAL_EOS_TOKEN_IDS = [2, 4, 32000]


def _ensure_eos_token_ids_list(tokenizer, default=_VOXTRAL_EOS_TOKEN_IDS):
    existing = tokenizer.__dict__.get("eos_token_ids")
    if isinstance(existing, set):
        existing = sorted(existing)
    elif not isinstance(existing, (list, tuple)):
        existing = default
    tokenizer.__dict__["eos_token_ids"] = list(existing)
    return tokenizer.__dict__["eos_token_ids"]
```

`Voxtral.Model.post_load_hook` calls `_ensure_eos_token_ids_list(model._processor.tokenizer)` after `AutoProcessor.from_pretrained`.

## Why this differs from PR #450

| Concern                                          | PR #450                              | This PR                       |
| ------------------------------------------------ | ------------------------------------ | ----------------------------- |
| Number of edited files                           | 3                                    | 1                             |
| Number of edited callsites                       | 3                                    | 1                             |
| Bundled `added_tokens_decoder` monkey-patch      | yes                                  | no                            |
| Approach                                         | symptomatic (defensive at consumer)  | root cause (correct assign)   |
| Behavior on tokenizer with pre-existing list     | unchanged                            | preserved                     |

## Note on persistence

The `__dict__` write is per-load: it does not survive `tokenizer.save_pretrained()` (transformers' serialization reads from the special tokens map, which is not populated by the bypass). This is acceptable here because mlx-audio invokes `post_load_hook` on every load, so the helper is reapplied each time. There is no path in mlx-audio's STT loader that goes through `save_pretrained` then a fresh `from_pretrained` without `post_load_hook` re-running.

## Verification

In `mlx_audio/stt/tests/test_voxtral_eos_token_ids.py`:

* `TestBaselineMagic` — demonstrates the underlying base-class behavior on a real `PreTrainedTokenizerFast` (no model download).
* `TestEnsureEosTokenIdsList` — exercises the production `_ensure_eos_token_ids_list` helper end to end: default initialization, list/tuple/set preservation, post-write attribute readback, custom default. Imports the helper from production `voxtral.py`, so the test suite cannot collect on `main` (where the helper does not exist) — strict A/B against the unfixed source.

End-to-end smoke against `mlx-community/Voxtral-Mini-3B-2507-bf16`:

* Before: `TypeError: 'int' object is not iterable` at first decode.
* After: clean transcript output.

## Backward compatibility

* Tokenizers that already have `eos_token_ids` populated as a list/tuple/set keep their existing values (coerced to list).
* Tokenizers without it populated get the historical default `[2, 4, 32000]`.
* No public API change; the helper is private.
