### PR TITLE
docs: add Svara TTS (multilingual Indic) entry

### DIFF
--- a/docs/models/tts/index.md
+++ b/docs/models/tts/index.md
@@ -10,6 +10,7 @@ MLX-Audio supports a wide range of TTS models optimized for Apple Silicon. Each 
 | [**Qwen3-TTS**](qwen3-tts.md) | 0.6B / 1.7B | ZH, EN, JA, KO, + more | Yes | Yes | Voice cloning, emotion control, voice design, batch generation |
 | [**OmniVoice**](omnivoice.md) | 0.6B backbone + HiggsAudio tokenizer | 646+ languages | Yes | -- | Zero-shot multilingual cloning, nonverbal tags, CMU + pinyin controls |
 | [**Voxtral TTS**](voxtral-tts.md) | 4B | EN, FR, ES, DE, IT, PT, NL, AR, HI | -- | Yes | 20 voice presets, 9 languages, chunked streaming output |
+| [**Svara TTS**](svara.md) | 3B | 19 Indian langs (HI, BN, TA, TE, KN, ML, MR, GU, PA, OR, AS, BH, MAG, MAI, HNE, BRX, DOI, NE, SA, EN-IN) | -- | Yes | Orpheus-family, SNAC 24 kHz, 38 voices, 4-bit/8-bit MLX quants |
 | [**CSM**](csm.md) | 1B | EN | Yes | Yes | Conversational speech, voice cloning, multi-turn context |
 | [**Dia**](dia.md) | 1.6B | EN | -- | -- | Dialogue with `[S1]`/`[S2]` speaker tags |
 | [**Chatterbox**](chatterbox.md) | -- | EN + 15 languages | Yes | -- | Expressive, emotion exaggeration control |

--- a/docs/models/tts/svara.md
+++ b/docs/models/tts/svara.md
@@ -1,0 +1,111 @@
+# Svara TTS
+
+Multilingual autoregressive text-to-speech for **19 Indian languages**, in the Orpheus / SNAC family. Based on [`kenpath/svara-tts-v1`](https://huggingface.co/kenpath/svara-tts-v1) — a Llama-3.2-3B fine-tune over Canopy Labs' [`canopylabs/3b-hi-ft-research_release`](https://huggingface.co/canopylabs/3b-hi-ft-research_release) Orpheus base, paired with the [SNAC 24 kHz](https://huggingface.co/hubertsiuzdak/snac_24khz) neural codec.
+
+## Model Variants
+
+| Model | Format | Size | HuggingFace |
+|-------|--------|------|-------------|
+| `mlx-community/svara-tts-v1-4bit` | MLX 4-bit | ~1.9 GB | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/svara-tts-v1-4bit) |
+| `mlx-community/svara-tts-v1-8bit` | MLX 8-bit | ~3.5 GB | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/svara-tts-v1-8bit) |
+
+## Usage
+
+=== "CLI"
+
+    ```bash
+    mlx_audio.tts.generate \
+        --model mlx-community/svara-tts-v1-4bit \
+        --text "नमस्ते, आप कैसे हैं?" \
+        --voice "Hindi (Female)" \
+        --temperature 0.75 \
+        --top_p 0.9
+    ```
+
+=== "Python"
+
+    ```python
+    import numpy as np
+    import soundfile as sf
+    import mlx.core as mx
+    from mlx_audio.tts.utils import load_model
+
+    model = load_model("mlx-community/svara-tts-v1-4bit")
+
+    chunks = []
+    for result in model.generate(
+        text="नमस्ते, आप कैसे हैं? मैं ठीक हूँ।",
+        voice="Hindi (Female)",
+        temperature=0.75,
+        top_p=0.9,
+        top_k=40,
+        repetition_penalty=1.1,
+        max_tokens=1200,
+    ):
+        chunks.append(result.audio)
+
+    audio = mx.concatenate(chunks, axis=0)
+    sf.write("hello_hi.wav", np.asarray(audio), model.sample_rate)
+    ```
+
+## Voices
+
+Voice names follow the form `"<Language Name> (<Gender>)"`:
+
+| Language | Voices |
+|----------|--------|
+| Hindi | `Hindi (Male)`, `Hindi (Female)` |
+| Bengali | `Bengali (Male)`, `Bengali (Female)` |
+| Marathi | `Marathi (Male)`, `Marathi (Female)` |
+| Telugu | `Telugu (Male)`, `Telugu (Female)` |
+| Kannada | `Kannada (Male)`, `Kannada (Female)` |
+| Tamil | `Tamil (Male)`, `Tamil (Female)` |
+| Malayalam | `Malayalam (Male)`, `Malayalam (Female)` |
+| Gujarati | `Gujarati (Male)`, `Gujarati (Female)` |
+| Punjabi | `Punjabi (Male)`, `Punjabi (Female)` |
+| Assamese | `Assamese (Male)`, `Assamese (Female)` |
+| Bhojpuri | `Bhojpuri (Male)`, `Bhojpuri (Female)` |
+| Magahi | `Magahi (Male)`, `Magahi (Female)` |
+| Maithili | `Maithili (Male)`, `Maithili (Female)` |
+| Chhattisgarhi | `Chhattisgarhi (Male)`, `Chhattisgarhi (Female)` |
+| Bodo | `Bodo (Male)`, `Bodo (Female)` |
+| Dogri | `Dogri (Male)`, `Dogri (Female)` |
+| Nepali | `Nepali (Male)`, `Nepali (Female)` |
+| Sanskrit | `Sanskrit (Male)`, `Sanskrit (Female)` |
+| English (Indian) | `English (Indian) (Male)`, `English (Indian) (Female)` |
+
+**38 voices across 19 languages.**
+
+## Sampling Recommendations
+
+The upstream `svara-tts-inference` repo uses these defaults; they're a good starting point:
+
+| Parameter | Value |
+|-----------|-------|
+| `temperature` | 0.75 |
+| `top_p` | 0.9 |
+| `top_k` | 40 |
+| `repetition_penalty` | 1.1 |
+| `max_tokens` | 1200–2048 |
+
+## Architecture
+
+- **Backbone:** Llama-3.2-3B fine-tuned from Canopy Labs' Orpheus Hindi base.
+- **Codec:** SNAC 24 kHz, 3-level hierarchical RVQ, 7 codes per ~10 ms frame.
+- **Output:** 24 kHz mono PCM.
+
+Internally, mlx-audio dispatches Svara to the generic [Llama TTS loader](https://github.com/Blaizzy/mlx-audio/tree/main/mlx_audio/tts/models/llama) (any model whose `config.json` declares `model_type: llama` and uses the SNAC token layout works out of the box). The SNAC codec is auto-loaded from [`mlx-community/snac_24khz`](https://huggingface.co/mlx-community/snac_24khz).
+
+!!! warning "Voice cloning"
+    The shared Orpheus Llama loader exposes a `ref_audio` / `ref_text` voice-cloning path. Per the in-repo warning, it is known to be unreliable on Orpheus-family fine-tunes (including Svara) and is best avoided until upstream addresses the issue.
+
+## License
+
+Apache 2.0 — see the [parent model card](https://huggingface.co/kenpath/svara-tts-v1) for full details, training data, and evaluation.
+
+## Links
+
+- [:octicons-link-external-16: Parent model](https://huggingface.co/kenpath/svara-tts-v1) (`kenpath/svara-tts-v1`)
+- [:octicons-link-external-16: Orpheus Hindi base](https://huggingface.co/canopylabs/3b-hi-ft-research_release) (`canopylabs/3b-hi-ft-research_release`)
+- [:octicons-link-external-16: Reference inference repo](https://github.com/Kenpath/svara-tts-inference) (`Kenpath/svara-tts-inference`)
+- [:octicons-mark-github-16: Llama TTS source code](https://github.com/Blaizzy/mlx-audio/tree/main/mlx_audio/tts/models/llama)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Kokoro: models/tts/kokoro.md
       - Qwen3-TTS: models/tts/qwen3-tts.md
       - Voxtral TTS: models/tts/voxtral-tts.md
+      - Svara TTS: models/tts/svara.md
       - KugelAudio: models/tts/kugelaudio.md
       - CSM: models/tts/csm.md
       - Dia: models/tts/dia.md


### PR DESCRIPTION
## Summary
- Adds a docs entry for [Svara TTS v1](https://huggingface.co/kenpath/svara-tts-v1), a multilingual Indic TTS in the Orpheus / SNAC family.
- Pre-converted MLX weights are now published at [`mlx-community/svara-tts-v1`](https://huggingface.co/mlx-community/svara-tts-v1) (bf16, ~6.6 GB), [`-4bit`](https://huggingface.co/mlx-community/svara-tts-v1-4bit) (~1.9 GB), and [`-8bit`](https://huggingface.co/mlx-community/svara-tts-v1-8bit) (~3.5 GB).
- **No new model code required** — Svara's `config.json` declares `model_type: "llama"` with the same special-token layout used by the existing `mlx_audio/tts/models/llama` Orpheus loader, so `mlx_audio.tts.load_model("mlx-community/svara-tts-v1-4bit")` works out of the box.

## What's in the PR
- `docs/models/tts/svara.md` — usage (Python + CLI), all 38 voices across 19 Indian languages, recommended sampling defaults, architecture notes.
- `docs/models/tts/index.md` — comparison-table row.
- `mkdocs.yml` — nav entry.

`uv run --extra docs mkdocs build --strict` builds clean.

## Languages / Voices
38 voices total: Hindi, Bengali, Marathi, Telugu, Kannada, Tamil, Malayalam, Gujarati, Punjabi, Assamese, Bhojpuri, Magahi, Maithili, Chhattisgarhi, Bodo, Dogri, Nepali, Sanskrit, English (Indian) — male + female each.

## Verified locally
Smoke-tested with the published 4-bit on Apple Silicon: ~60 tok/s, RTF 0.56–0.69 (faster than realtime), Hindi + Tamil samples generated successfully via `mlx_audio.tts.utils.load_model`.

## Test plan
- [x] `uv run --extra docs mkdocs build --strict` passes.
- [x] `uv run python -c "from mlx_audio.tts.utils import load_model; m = load_model('mlx-community/svara-tts-v1-4bit'); next(m.generate(text='नमस्ते', voice='Hindi (Female)', max_tokens=200))"` produces non-silent audio.

## License
Apache 2.0, same as upstream Svara and the Orpheus Hindi base ([`canopylabs/3b-hi-ft-research_release`](https://huggingface.co/canopylabs/3b-hi-ft-research_release)) it's fine-tuned from.