### PR TITLE
fix(fish_qwen3_omni): pass `instruct` field through to system prompt

### DIFF
--- a/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
+++ b/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
@@ -434,8 +434,17 @@ class Model(nn.Module):
         return remapped
 
     def _build_conversation(
-        self, prompt_texts: list[str], prompt_tokens: list[mx.array]
+        self,
+        prompt_texts: list[str],
+        prompt_tokens: list[mx.array],
+        instruct: Optional[str] = None,
     ) -> Conversation:
+        # Append the optional `instruct` style hint (e.g. "low whisper",
+        # "professional broadcast tone") to the system prompt so it actually
+        # influences generation. This is the path the OpenAI-compatible
+        # SpeechRequest.instruct field flows through; previously it was
+        # silently dropped by `del kwargs` in `.generate()`.
+        suffix = f". style: {instruct}" if instruct and instruct.strip() else ""
         conversation = Conversation()
         if prompt_texts and prompt_tokens:
             tagged_prompt_texts = []
@@ -446,14 +455,16 @@ class Model(nn.Module):
                     tagged_prompt_texts.append(f"<|speaker:{idx}|>{text}")
             system_parts = [
                 TextPart(
-                    "convert the provided text to speech reference to the following:\n\nText:\n"
+                    "convert the provided text to speech reference to the following"
+                    + suffix
+                    + ":\n\nText:\n"
                 ),
                 TextPart("\n".join(tagged_prompt_texts)),
                 TextPart("\n\nSpeech:\n"),
                 VQPart(mx.concatenate(prompt_tokens, axis=1)),
             ]
         else:
-            system_parts = [TextPart("convert the provided text to speech")]
+            system_parts = [TextPart("convert the provided text to speech" + suffix)]
 
         conversation.append(
             Message(
@@ -612,6 +623,7 @@ class Model(nn.Module):
         voice: Optional[str] = None,
         ref_audio: Optional[mx.array] = None,
         ref_text: Optional[str] = None,
+        instruct: Optional[str] = None,
         max_tokens: int = 1024,
         temperature: float = 0.7,
         top_p: float = 0.7,
@@ -647,7 +659,7 @@ class Model(nn.Module):
             prompt_tokens.append(indices[0, :, :prompt_length])
             prompt_texts.append(ref_text or "")
 
-        base_conversation = self._build_conversation(prompt_texts, prompt_tokens)
+        base_conversation = self._build_conversation(prompt_texts, prompt_tokens, instruct=instruct)
         turns = split_text_by_speaker(text)
         batches = (
             group_turns_into_batches(turns, max_speakers=5, max_bytes=chunk_length)


### PR DESCRIPTION
## Summary

`SpeechRequest.instruct` (sent by the OpenAI-compatible server at `/v1/audio/speech`) was silently dropped before reaching the model. This PR wires it into the system prompt so it actually influences generation.

## Bug

The server passes `instruct` via `**kwargs` to `Model.generate()`:

https://github.com/Blaizzy/mlx-audio/blob/main/mlx_audio/server.py — `tts_speech` calls `model.generate(payload.input, voice=..., instruct=payload.instruct, ...)`.

But `fish_qwen3_omni/fish_speech.py:Model.generate()` immediately discards it:

```python
def generate(
    self,
    text: str,
    voice: Optional[str] = None,
    ...
    **kwargs,
):
    del voice, repetition_penalty, verbose, kwargs   # ← instruct lives in kwargs and is discarded here
```

Reproduction (before fix) — 9 different `instruct` values, identical output:

```bash
for inst in "moaning" "professional broadcast tone" "low whisper" "" "angry shouting" \
            "娇喘" "呻吟" "哭腔" "低声耳语"; do
  curl -s -X POST http://127.0.0.1:8082/v1/audio/speech \
    -H 'Content-Type: application/json' \
    -d "{\"model\":\"mlx-community/fish-audio-s2-pro-bf16\",\"input\":\"啊不要了，好深好烫，要坏掉了。\",\"instruct\":\"$inst\",\"lang_code\":\"zh\",\"response_format\":\"mp3\"}" \
    -o "out_$(echo $inst | tr ' ' _).mp3"
done
md5 out_*.mp3
# ALL 9 files identical: fc36ab0f77a5388bc8e1a9f266bcb49e (51871 bytes each)
```

## Fix

Add `instruct: Optional[str] = None` to `.generate()`, thread it into `_build_conversation()`, append it to the system prompt:

- Without instruct: `"convert the provided text to speech"`
- With instruct: `"convert the provided text to speech. style: <instruct>"`

This is the natural integration point — Fish Audio S2's training places style/emotion priors at the system-prompt level, and using a system-level hook is more robust than expecting users to weave `[tag]` tokens into their input (which appears to OOD on the Chinese inference path; see Notes below).

## Verification

After patch, same 9-call reproduction produces 9 distinct outputs:

```
post_en_baseline.mp3       98683B  37d24ebb...
post_en_moaning.mp3       160959B  6abaf739...
post_zh_jiaochuan.mp3      76531B  b878ae2c...   instruct="娇喘呻吟，气息不稳"
post_zh_angry.mp3          38497B  08d3d7bc...   instruct="angry, shouting"
post_zh_none.mp3           69008B  58dbb154...   no instruct
```

Different instruct values now yield different durations / byte sizes / waveforms, and listening confirms the requested style is audible (e.g. \"angry, shouting\" → louder, harsher delivery; \"低声耳语\" → softer, quieter).

## Compatibility

- Backwards-compatible: `instruct` defaults to `None`, omitting it preserves the original system prompt verbatim.
- No new dependencies.
- No public API breakage (existing callers that pass `instruct` via `**kwargs` continue to work because the parameter is now consumed by name; callers that don't pass it are unaffected).

## Notes (out-of-scope but worth flagging)

While verifying this fix I observed a separate generation issue on the Chinese inference path with **inline** `[xxx]` style tags embedded in the user text. Inputs like `她说：[moaning] 啊不要了` produce clean audio for the part before the tag (\"她说\") then degenerate into noise. The same `[moaning]` tag works correctly when used in English-only inputs and when used with `instruct=...` instead. This appears to be a model-side inference / token-mixing issue rather than a server- or wiring-level bug, so I'm not addressing it in this PR — but it's worth a separate investigation. (System-level `instruct` introduced by this PR is unaffected and works for both Chinese and English inputs.)