### PR TITLE
docs: add shields.io badges and table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,27 @@
 
 # MLX-Audio
 
+[![PyPI version](https://img.shields.io/pypi/v/mlx-audio.svg)](https://pypi.org/project/mlx-audio/)
+[![Python](https://img.shields.io/pypi/pyversions/mlx-audio.svg)](https://pypi.org/project/mlx-audio/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![GitHub stars](https://img.shields.io/github/stars/Blaizzy/mlx-audio.svg?style=social)](https://github.com/Blaizzy/mlx-audio)
+
 The best audio processing library built on Apple's MLX framework, providing fast and efficient text-to-speech (TTS), speech-to-text (STT), and speech-to-speech (STS) on Apple Silicon.
+
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Supported Models](#supported-models)
+- [Model Examples](#model-examples)
+- [Web Interface \& API Server](#web-interface--api-server)
+- [Quantization](#quantization)
+- [Swift](#swift)
+- [Requirements](#requirements)
+- [License](#license)
+- [Citation](#citation)
+- [Acknowledgements](#acknowledgements)
 
 ## Features
 


### PR DESCRIPTION
## What this PR does
Adds PyPI version, Python version, license, and GitHub stars badges along with a table of contents to the README.

## Why
The README is comprehensive but currently spans 600+ lines without navigational aids. A table of contents helps readers jump directly to the section they need (e.g., Supported Models, Quantization, API Server). The badges surface key project metadata (current PyPI version, supported Python versions, license) at a glance — useful for developers evaluating whether to adopt the library.

## Changes
- Added four shields.io badges below the project title: PyPI version, Python versions, MIT license, GitHub stars
- Added a Table of Contents section linking to all top-level headings

---
🤖 This PR was created with AI assistance and reviewed by a human.