### PR TITLE
Improved dep handling for mlx-lm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ requires-python = ">=3.10"
 dependencies = [
     "huggingface_hub>=1.0",
     "miniaudio>=1.61",
-    "mlx-lm==0.31.1",
+    "mlx-lm>=0.31.1",
     "mlx>=0.31.1",
     "numpy>=1.26.4",
     "scipy>=1.10.0",
-    "sounddevice==0.5.3",
+    "sounddevice>=0.5.3",
     "tqdm>=4.67.1",
     "transformers>=5.5.0",
 ]


### PR DESCRIPTION
Don't hard-pin `mlx-lm` and `sounddevice` to specific versions, which introduces compatibility issues when upstream projects use minor version bumps, e.g. `mlx-vlm` allows `mlx-lm>=0.31.3`