### PR TITLE
Fix regression in Fish S2 Pro

### DIFF
--- a/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
+++ b/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
@@ -739,6 +739,7 @@ class Model(nn.Module):
             )
             next_result = self.model(next_input[:, :, None], cache=cache)
             logits = next_result.logits[:, -1]
+            hidden_state = next_result.hidden_states[:, -1]
 
         if not generated_steps:
             raise RuntimeError(


### PR DESCRIPTION
This was my regression from https://github.com/Blaizzy/mlx-audio/pull/675 -- the batch path works but the cache fill was busted for single generations. Resolves https://github.com/Blaizzy/mlx-audio/issues/690