### PR TITLE
Qwen3-TTS: honor caller-provided max_tokens in instruct and ICL paths.

### DIFF
--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -2231,12 +2231,9 @@ class Model(nn.Module):
             )
         )
 
-        # Cap max_tokens based on target text length to prevent runaway generation
-        # when reference audio is long and EOS logit is suppressed by top-k.
-        # At 12.5 Hz codec rate, ~3-5 codec tokens per text token is typical speech.
-        # Factor of 6 gives ~50% margin for slow speech / pauses.
-        target_token_count = len(self.tokenizer.encode(text))
-        effective_max_tokens = min(max_tokens, max(75, target_token_count * 6))
+        # Honor the caller-provided max_tokens; matches the base generation path.
+        # A text-length-derived cap could clip slow or expressive utterances.
+        effective_max_tokens = max_tokens
 
         # Initialize cache
         cache = self.talker.make_cache()
@@ -2546,12 +2543,9 @@ class Model(nn.Module):
             )
         )
 
-        # Cap max_tokens based on target text length to prevent runaway generation
-        # when EOS logit doesn't become dominant (seen especially with 0.6B model).
-        # At 12.5 Hz codec rate, ~3-5 codec tokens per text token is typical speech.
-        # Factor of 6 gives ~50% margin for slow speech / pauses.
-        target_token_count = len(self.tokenizer.encode(text))
-        effective_max_tokens = min(max_tokens, max(75, target_token_count * 6))
+        # Honor the caller-provided max_tokens; matches the base generation path.
+        # A text-length-derived cap could clip slow or expressive utterances.
+        effective_max_tokens = max_tokens
 
         # Initialize cache
         cache = self.talker.make_cache()

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -2933,36 +2933,6 @@ class TestQwen3TTSGenerateICL(unittest.TestCase):
             # token_count should be <= 2
             self.assertLessEqual(results[0].token_count, 2)
 
-    def test_generate_icl_text_based_max_tokens_cap(self):
-        """Test that effective_max_tokens is capped based on text length."""
-        model = self._make_icl_model()
-        ref_audio = mx.random.normal((24000,))
-
-        # tokenizer.encode returns 10 tokens for the text
-        # target_token_count = 10
-        # effective_max_tokens = min(200, max(75, 10 * 6)) = min(200, 75) = 75
-        # Without the cap, it would generate up to 200 tokens
-
-        # Mock _sample_token to never return EOS (forces hitting the cap)
-        def non_eos_sample(*args, **kwargs):
-            return mx.array([[5]])  # Always non-EOS (eos=30)
-
-        with patch.object(model, "_sample_token", side_effect=non_eos_sample):
-            results = list(
-                model._generate_icl(
-                    text="Hi",
-                    ref_audio=ref_audio,
-                    ref_text="Ref",
-                    max_tokens=200,  # Higher than text-based cap
-                    repetition_penalty=1.5,
-                )
-            )
-
-        self.assertEqual(len(results), 1)
-        # With text-based cap: effective = min(200, max(75, 10*6)) = 75
-        # Token count should be exactly 75 (hit the cap, not 200)
-        self.assertEqual(results[0].token_count, 75)
-
     def test_generate_icl_repetition_penalty_applied(self):
         """Test that repetition penalty is applied during generation."""
         model = self._make_icl_model()

--- a/mlx_audio/tts/tests/test_qwen3_tts.py
+++ b/mlx_audio/tts/tests/test_qwen3_tts.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2025, Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 
 import unittest
+from types import SimpleNamespace
 
 import mlx.core as mx
 import numpy as np
 
-from mlx_audio.tts.models.qwen3_tts.qwen3_tts import mel_spectrogram
+from mlx_audio.tts.models.qwen3_tts.qwen3_tts import Model, mel_spectrogram
 from mlx_audio.tts.models.qwen3_tts.speaker_encoder import (
     TimeDelayNetBlock,
     reflect_pad_1d,
@@ -328,6 +329,117 @@ class TestMelSpectrogram(unittest.TestCase):
             err_msg="mel_spectrogram output std should be ~0.37 with correct params. "
             f"Got std={mel_np.std():.4f}.",
         )
+
+
+class _FakeCodePredictor:
+    def __init__(self):
+        self.codec_embedding = []
+
+    def make_cache(self):
+        return []
+
+
+class _FakeTalker:
+    def __init__(self, hidden_size: int, vocab_size: int):
+        self.hidden_size = hidden_size
+        self.vocab_size = vocab_size
+        self.code_predictor = _FakeCodePredictor()
+
+    def make_cache(self):
+        return []
+
+    def get_input_embeddings(self):
+        return lambda token: mx.zeros((1, 1, self.hidden_size), dtype=mx.float32)
+
+    def __call__(self, input_embeds, cache=None):
+        logits = mx.zeros((1, 1, self.vocab_size), dtype=mx.float32)
+        hidden = mx.zeros((1, 1, self.hidden_size), dtype=mx.float32)
+        return logits, hidden
+
+
+class _FakeSpeechTokenizer:
+    def __init__(self):
+        self.decoder = SimpleNamespace(reset_streaming_state=lambda: None)
+
+    def decode(self, codes):
+        return mx.zeros((1, 16), dtype=mx.float32), mx.array([16], dtype=mx.int32)
+
+
+def _make_generation_test_model(text_token_count: int = 10):
+    hidden_size = 4
+    vocab_size = 1100
+
+    model = Model.__new__(Model)
+    model._sample_rate = 24000
+    model.config = SimpleNamespace(
+        talker_config=SimpleNamespace(
+            vocab_size=vocab_size,
+            codec_eos_token_id=vocab_size - 1,
+            num_code_groups=1,
+        )
+    )
+    model.talker = _FakeTalker(hidden_size=hidden_size, vocab_size=vocab_size)
+    model.speech_tokenizer = _FakeSpeechTokenizer()
+    model.tokenizer = SimpleNamespace(
+        encode=lambda text: list(range(text_token_count))
+    )
+    model._prepare_generation_inputs = lambda **kwargs: (
+        mx.zeros((1, 1, hidden_size), dtype=mx.float32),
+        mx.zeros((1, 1, hidden_size), dtype=mx.float32),
+        mx.zeros((1, 1, hidden_size), dtype=mx.float32),
+    )
+    model._prepare_icl_generation_inputs = lambda **kwargs: (
+        mx.zeros((1, 1, hidden_size), dtype=mx.float32),
+        mx.zeros((1, 1, hidden_size), dtype=mx.float32),
+        mx.zeros((1, 1, hidden_size), dtype=mx.float32),
+        mx.zeros((1, 1, 1), dtype=mx.int32),
+    )
+    model._sample_token = lambda *args, **kwargs: mx.array([[1]], dtype=mx.int32)
+    return model
+
+
+class TestQwen3TTSMaxTokens(unittest.TestCase):
+    def test_generate_with_instruct_honors_explicit_max_tokens(self):
+        model = _make_generation_test_model(text_token_count=10)
+
+        results = list(
+            Model._generate_with_instruct(
+                model,
+                text="slow emotional speech",
+                speaker="vivian",
+                language="English",
+                instruct="Speak in a sad, low, subdued, and slow tone.",
+                temperature=0.9,
+                max_tokens=120,
+                top_k=50,
+                top_p=1.0,
+                repetition_penalty=1.05,
+                verbose=False,
+            )
+        )
+
+        self.assertEqual(results[-1].token_count, 120)
+
+    def test_generate_icl_honors_explicit_max_tokens(self):
+        model = _make_generation_test_model(text_token_count=10)
+
+        results = list(
+            Model._generate_icl(
+                model,
+                text="slow cloned speech",
+                ref_audio=mx.zeros((24000,), dtype=mx.float32),
+                ref_text="This is the reference transcript.",
+                language="English",
+                temperature=0.9,
+                max_tokens=120,
+                top_k=50,
+                top_p=1.0,
+                repetition_penalty=1.5,
+                verbose=False,
+            )
+        )
+
+        self.assertEqual(results[-1].token_count, 120)
 
 
 if __name__ == "__main__":

--- a/mlx_audio/tts/tests/test_qwen3_tts.py
+++ b/mlx_audio/tts/tests/test_qwen3_tts.py
@@ -380,9 +380,7 @@ def _make_generation_test_model(text_token_count: int = 10):
     )
     model.talker = _FakeTalker(hidden_size=hidden_size, vocab_size=vocab_size)
     model.speech_tokenizer = _FakeSpeechTokenizer()
-    model.tokenizer = SimpleNamespace(
-        encode=lambda text: list(range(text_token_count))
-    )
+    model.tokenizer = SimpleNamespace(encode=lambda text: list(range(text_token_count)))
     model._prepare_generation_inputs = lambda **kwargs: (
         mx.zeros((1, 1, hidden_size), dtype=mx.float32),
         mx.zeros((1, 1, hidden_size), dtype=mx.float32),


### PR DESCRIPTION
Two of three Qwen3-TTS generation paths silently shrank the caller-provided `max_tokens` to `min(max_tokens, max(75, len(encode(text)) * 6))`, clipping slow or expressive speech mid-utterance even when the caller passed an ample budget. This restores `_generate_with_instruct` and `_generate_icl` to honor `max_tokens` directly, matching the base streaming path (`qwen3_tts.py:1047`) and `batch_generate` (`qwen3_tts.py:1416`), which never applied the cap.

**Behavior change**

Before, slow or expressive utterances were silently truncated because the implicit floor of 75 codec tokens (~6 s at 12.5 Hz) won for any short prompt regardless of the caller's budget:

```python
target_token_count = len(self.tokenizer.encode(text))
effective_max_tokens = min(max_tokens, max(75, target_token_count * 6))
```

After, the caller's `max_tokens` governs the loop directly, matching the base path:

```python
# Honor the caller-provided max_tokens; matches the base generation path.
# A text-length-derived cap could clip slow or expressive utterances.
effective_max_tokens = max_tokens
```

**#411 regression check**

The cap was introduced in #444 as defense-in-depth alongside fixes for #411 (four 0.6B-CustomVoice voices producing ~96 s of silence). Re-running the #411 reproducer against the patched source on `mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-bf16` with `text="Hello world"` and default `max_tokens=4096`:

| voice    | duration |    rms |  samples | gen_s | verdict |
| -------- | -------: | -----: | -------: | ----: | ------- |
| serena   |   1.36 s | 0.0555 |  32 640  |  0.42 | OK      |
| dylan    |   1.68 s | 0.0467 |  40 320  |  0.39 | OK      |
| ryan     |   2.64 s | 0.0815 |  63 360  |  0.59 | OK      |
| uncle_fu |   1.60 s | 0.0524 |  38 400  |  0.37 | OK      |
| ono_anna |   3.28 s | 0.0394 |  78 720  |  0.73 | OK      |

EOS fires naturally; nothing approaches `max_tokens=4096`. The primary fixes from #444 (mel-padding alignment, embedding slicing, sampler refactor) hold on their own — the cap was redundant defense-in-depth. Default `max_tokens=4096` is unchanged, so the worst-case ceiling matches what the base path and `batch_generate` already had (~60–70 s of GPU time on Apple Silicon).

**Tests**

`TestQwen3TTSMaxTokens` in `test_qwen3_tts.py` covers both paths with stubbed talker / speech-tokenizer; the tests fail on `main` (cap clamps `120 → 75` for short text) and pass after the fix. Also removes `test_generate_icl_text_based_max_tokens_cap` from `test_models.py`, which asserted the cap behavior being removed.

Refs #411, #444