### PR TITLE
Fix Fish Speech S2 Pro hidden_state update in single-sample generation

### DIFF
--- a/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
+++ b/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
@@ -739,6 +739,7 @@ class Model(nn.Module):
             )
             next_result = self.model(next_input[:, :, None], cache=cache)
             logits = next_result.logits[:, -1]
+            hidden_state = next_result.hidden_states[:, -1]
 
         if not generated_steps:
             raise RuntimeError(


### PR DESCRIPTION
## Summary

Restores the `hidden_state` update inside Fish Speech S2 Pro's single-sample autoregressive generation loop.

Current `main` updates `logits` after each slow-transformer step, but leaves `hidden_state` stale:

```python
next_result = self.model(next_input[:, :, None], cache=cache)
logits = next_result.logits[:, -1]
```

The next residual codebook step then uses that stale `hidden_state`:

```python
fast_prefill = self.model.fast_forward_cached(hidden_state, fast_cache)
```

The batched path already updates `hidden_state`, so this PR makes the single-sample path match it.

## Change

```python
hidden_state = next_result.hidden_states[:, -1]
```

## Why

Local A/B testing with Fish Speech S2 Pro showed that current upstream generated valid but degraded/glitchy audio and roughly doubled output duration for the same prompt.

Adding this line restored normal duration and audio quality in local testing.

## Validation

Tested locally on:

```text
macOS 26.4.1 arm64
Mac Studio M2 Ultra
Python 3.14.4
mlx-lm 0.31.1
numpy 2.4.3
transformers 4.57.6
model: mlx-community/fish-audio-s2-pro-bf16
```

Results:

```text
old patched e42e143:          11.291s, normal
upstream bb6533d:             22.855s, glitchy/degraded
bb6533d + this hidden fix:    11.199s, normal again
```

## Notes

The new batched generation path already updates `hidden_state` after `next_result`, so this appears to be an accidental omission in the single-sample path.
