### PR TITLE
`fix(voxtral_realtime): empty downsample_and_project uses decoder dim`

### DIFF
--- a/mlx_audio/stt/models/voxtral_realtime/encoder.py
+++ b/mlx_audio/stt/models/voxtral_realtime/encoder.py
@@ -231,7 +231,8 @@ class AudioEncoder(nn.Module):
         ds = self.config.downsample_factor
         ds_len = seq_len // ds
         if ds_len == 0:
-            return encoded[:0]  # empty
+            decoder_dim = self.audio_language_projection_2.weight.shape[0]
+            return mx.zeros((0, decoder_dim), dtype=encoded.dtype)
         x = encoded[: ds_len * ds].reshape(ds_len, self.config.dim * ds)
         x = nn.gelu(self.audio_language_projection_0(x))
         return self.audio_language_projection_2(x)

--- a/mlx_audio/stt/tests/test_voxtral_realtime_streaming.py
+++ b/mlx_audio/stt/tests/test_voxtral_realtime_streaming.py
@@ -6,6 +6,8 @@ Covers the pieces that do not require downloaded model weights:
   chunking regimes.
 - StreamingCausalConv1d: parity with CausalConv1d on a randomly
   initialized module (no quantized checkpoint needed).
+- AudioEncoder.downsample_and_project: short tail rows stack with
+  downsampled chunks (decoder-width empty slice for concat).
 
 The end-to-end (encoder + session) parity lives in a weight-gated
 test class that skips cleanly when the model checkpoint is absent.
@@ -23,7 +25,8 @@ from mlx_audio.stt.models.voxtral_realtime.audio import (
     compute_mel_filters,
     compute_mel_spectrogram,
 )
-from mlx_audio.stt.models.voxtral_realtime.encoder import CausalConv1d
+from mlx_audio.stt.models.voxtral_realtime.config import EncoderConfig
+from mlx_audio.stt.models.voxtral_realtime.encoder import AudioEncoder, CausalConv1d
 from mlx_audio.stt.models.voxtral_realtime.streaming import (
     StreamingAudioSource,
     StreamingCausalConv1d,
@@ -201,6 +204,24 @@ class TestStreamingCausalConv1dParity(unittest.TestCase):
         for chunk in (4, 8, 12):
             with self.subTest(chunk=chunk):
                 self._run_case(kernel_size=4, stride=4, n_in=40, chunk=chunk)
+
+
+class TestAudioEncoder(unittest.TestCase):
+    """Weight-free checks on Voxtral Realtime AudioEncoder."""
+
+    def test_downsample_and_project_short_tail_concatenates(self):
+        """seq_len < downsample_factor yields (0, decoder_dim), not encoder dim."""
+        cfg = EncoderConfig(n_layers=1)
+        ds = cfg.downsample_factor
+        enc = AudioEncoder(cfg)
+        a = enc.downsample_and_project(mx.zeros((2 * ds, cfg.dim), dtype=mx.float32))
+        b = enc.downsample_and_project(mx.zeros((ds - 2, cfg.dim), dtype=mx.float32))
+        decoder_dim = enc.audio_language_projection_2.weight.shape[0]
+        self.assertEqual(tuple(a.shape), (2, decoder_dim))
+        self.assertEqual(tuple(b.shape), (0, decoder_dim))
+        merged = mx.concatenate([a, b], axis=0)
+        mx.eval(merged)
+        self.assertEqual(tuple(merged.shape), (2, decoder_dim))
 
 
 def _voxtral_weights_path() -> str:


### PR DESCRIPTION
Closes #699

## Context

Voxtral Realtime’s chunked encoder can emit a **last chunk** shorter than `downsample_factor`, for example when `conv_out` length aligns to 4 but not to the sliding window.

`downsample_and_project` must always return adapter rows with **`decoder_dim`**, including the **zero-row** case, because `_encode_and_prefill` and the decode loop concatenate adapter chunks on the time axis with `mx.concatenate`.

Previously, returning `encoded[:0]` preserved the **encoder width** instead of the decoder width, causing `mx.concatenate` to fail when a final short tail chunk was appended to prior adapter chunks.

## Description

When `seq_len // downsample_factor == 0`, return `mx.zeros((0, decoder_dim), dtype=encoded.dtype)`, where `decoder_dim` is taken from `self.audio_language_projection_2.weight.shape[0]`, instead of returning `encoded[:0]`.

Non-empty paths are unchanged.

## Changes

- **`mlx_audio/stt/models/voxtral_realtime/encoder.py`**
  - Updates the empty early return in `AudioEncoder.downsample_and_project` to use decoder-sized zeros.

- **`mlx_audio/stt/tests/test_voxtral_realtime_streaming.py`**
  - Adds `TestAudioEncoder.test_downsample_and_project_short_tail_concatenates`.
  - Regression test verifies that a short-tail `(0, decoder_dim)` result can be concatenated with a normal downsampled adapter chunk via `mx.concatenate`.