### PR TITLE
ci: path-filtered tests via dynamic matrix (skip 5/6 legs when one domain changes)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,84 @@ on:
       - main
 
 jobs:
-  # Style checks run once
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      shared: ${{ steps.compute.outputs.shared }}
+      domains: ${{ steps.compute.outputs.domains }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - id: filter
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            shared:
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'MANIFEST.in'
+              - 'pytest.ini'
+              - '.pre-commit-config.yaml'
+              - '.github/workflows/tests.yml'
+              - 'mlx_audio/utils.py'
+              - 'mlx_audio/dsp.py'
+              - 'mlx_audio/audio_io.py'
+              - 'mlx_audio/__init__.py'
+              - 'mlx_audio/tests/**'
+            stt:
+              - 'mlx_audio/stt/**'
+            tts:
+              - 'mlx_audio/tts/**'
+            sts:
+              - 'mlx_audio/sts/**'
+            codec:
+              - 'mlx_audio/codec/**'
+            vad:
+              - 'mlx_audio/vad/**'
+            lid:
+              - 'mlx_audio/lid/**'
+
+      - id: compute
+        env:
+          SHARED: ${{ steps.filter.outputs.shared_any_changed }}
+          STT: ${{ steps.filter.outputs.stt_any_changed }}
+          TTS: ${{ steps.filter.outputs.tts_any_changed }}
+          STS: ${{ steps.filter.outputs.sts_any_changed }}
+          CODEC: ${{ steps.filter.outputs.codec_any_changed }}
+          VAD: ${{ steps.filter.outputs.vad_any_changed }}
+          LID: ${{ steps.filter.outputs.lid_any_changed }}
+        run: |
+          set -e
+          if [ "$SHARED" = "true" ]; then
+            domains='["stt","tts","sts","codec","vad","lid"]'
+          else
+            domains='[]'
+            for d in stt tts sts codec vad lid; do
+              case "$d" in
+                stt)   val="$STT"   ;;
+                tts)   val="$TTS"   ;;
+                sts)   val="$STS"   ;;
+                codec) val="$CODEC" ;;
+                vad)   val="$VAD"   ;;
+                lid)   val="$LID"   ;;
+              esac
+              if [ "$val" = "true" ]; then
+                domains=$(echo "$domains" | jq -c ". + [\"$d\"]")
+              fi
+            done
+          fi
+          echo "shared=${SHARED:-false}" >> "$GITHUB_OUTPUT"
+          echo "domains=$domains" >> "$GITHUB_OUTPUT"
+          echo "Computed shared=${SHARED:-false} domains=$domains"
+
   style:
     runs-on: macos-14
+    needs: changes
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -27,10 +102,10 @@ jobs:
             exit 1
           fi
 
-  # Core tests (DSP, utils)
   core:
     runs-on: macos-14
-    needs: style
+    needs: [changes, style]
+    if: needs.changes.outputs.shared == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -48,12 +123,10 @@ jobs:
       - name: Run core tests
         run: pytest -s mlx_audio/tests/
 
-  # Modular installation tests - validates issue #287
-  # Only verifies imports work with minimal deps installed.
-  # Full tests run separately with all deps (test files import models that need extra deps).
   modular:
     runs-on: macos-14
-    needs: style
+    needs: [changes, style]
+    if: needs.changes.outputs.shared == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -77,27 +150,14 @@ jobs:
       - name: Verify ${{ matrix.extra }} imports
         run: python -c "${{ matrix.verify }}; print('${{ matrix.extra }} imports OK')"
 
-  # Full test suites - need all deps
   tests:
     runs-on: macos-14
-    needs: style
+    needs: [changes, style]
+    if: needs.changes.outputs.domains != '[]'
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: TTS
-            path: mlx_audio/tts/tests
-          - name: STT
-            path: mlx_audio/stt/tests
-          - name: STS
-            path: mlx_audio/sts/tests
-          - name: LID
-            path: mlx_audio/lid/tests
-          - name: Codec
-            path: mlx_audio/codec/tests
-          - name: VAD
-            path: mlx_audio/vad/tests
-
+        domain: ${{ fromJSON(needs.changes.outputs.domains) }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -107,5 +167,5 @@ jobs:
       - name: Install all deps
         run: pip install -e ".[all,dev]"
 
-      - name: Run ${{ matrix.name }} tests
-        run: pytest -s ${{ matrix.path }}/
+      - name: Run ${{ matrix.domain }} tests
+        run: pytest -s mlx_audio/${{ matrix.domain }}/tests/


### PR DESCRIPTION
## What

Path-filtered CI for `Tests and Checks` workflow. A PR that touches only one model directory only runs that model's test leg, instead of the entire 6-leg matrix on macos-14.

## Why

Today every PR runs all of `tests (TTS|STT|STS|LID|Codec|VAD)` on macos-14 regardless of what changed. Most PRs change exactly one domain. The other 5 legs cost real macos-14 minutes (10× linux pricing) and clutter the UI.

## How

Single file change: `.github/workflows/tests.yml` (+85/−25). One signed commit.

1. New `changes` job (ubuntu, ~10s) uses `tj-actions/changed-files@v45` with inline `files_yaml` to bucket the diff into `shared` / `stt` / `tts` / `sts` / `codec` / `vad` / `lid`.
2. A 15-line shell+jq compute step turns those flags into a JSON list of active domains.
3. The existing `tests` job consumes that list as a dynamic matrix:

```yaml
tests:
  needs: [changes, style]
  if: needs.changes.outputs.domains != '[]'
  strategy:
    fail-fast: false
    matrix:
      domain: ${{ fromJSON(needs.changes.outputs.domains) }}
  steps:
    - uses: actions/checkout@v6
    - uses: actions/setup-python@v6
      with: { python-version: '3.10' }
    - run: pip install -e ".[all,dev]"
    - run: pytest -s mlx_audio/${{ matrix.domain }}/tests/
```

`shared` (workflow file, `pyproject.toml`, `mlx_audio/utils.py`, `mlx_audio/dsp.py`, `mlx_audio/audio_io.py`, `mlx_audio/tests/**`, etc.) expands `domains` to all six entries, so cross-cutting changes still run everything. `core` and `modular` remain gated on `shared` because they validate cross-package import contracts. `style` is unconditional.

## Verification

Live tested on the fork. Two runs side-by-side:

| Diff | `domains` output | Jobs spawned |
|---|---|---|
| `.github/workflows/tests.yml` only (in `shared`) | `["stt","tts","sts","codec","vad","lid"]` | 12 (full pipeline) |
| `mlx_audio/stt/models/cohere_asr/cohere_asr.py` only | `["stt"]` | **5** (changes/style/tests(stt) + core/modular skipped) |

Narrowing run: <https://github.com/beshkenadze/mlx-audio/actions/runs/25214732071>
Compute step printed `Computed shared=false domains=["stt"]`.

## What this does NOT do (out of scope)

- Per-model gating inside `test_models.py`. Touching one STT model still runs all STT tests; needs a class-name → model-name map. Easy follow-up if profiling shows it's worth it.
- Per-extra `modular` gating. `core` / `modular` only run on `shared` changes today; if you want them on per-domain changes too, just relax the `if:` conditions.

## Notes

- `tj-actions/changed-files@v45` is the maintained successor to `dorny/paths-filter` and supports the inline `files_yaml` form that keeps the bucket map next to the workflow.
- No new files. Nothing required outside of `tests.yml`.
- Commit signed (ED25519, beshkenadze@gmail.com).
