### PR TITLE
feat(stt): OpenAI-compatible response_format on /v1/audio/transcriptions

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -38,7 +38,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
 
 from mlx_audio.audio_io import read as audio_read
@@ -930,8 +930,25 @@ async def stt_transcriptions(
     context: Optional[str] = Form(None),
     prefill_step_size: int = Form(2048),
     text: Optional[str] = Form(None),
+    response_format: str = Form("ndjson"),
 ):
-    """Transcribe audio using an STT model in OpenAI format."""
+    """Transcribe audio using an STT model.
+
+    The default ``response_format`` (``ndjson``) preserves mlx-audio's native
+    ``application/x-ndjson`` streaming transport, where each line is a JSON
+    object emitted by the underlying STT model (text deltas while streaming,
+    or the full whisper segment payload for batch transcription).
+
+    For OpenAI Audio API compatibility, ``response_format`` also accepts:
+
+    * ``text`` -- ``text/plain`` body with the final transcript only.
+    * ``json`` -- ``application/json`` body shaped ``{"text": "..."}``.
+    * ``verbose_json`` -- ``application/json`` body with the full payload
+      from the underlying model (``text``, ``segments``, ``language``,
+      ...), passed through unchanged.
+
+    See https://platform.openai.com/docs/api-reference/audio/createTranscription
+    """
     payload = TranscriptionRequest(
         model=model,
         language=language,
@@ -961,6 +978,46 @@ async def stt_transcriptions(
         normalized_kwargs=payload.model_dump(exclude={"model"}, exclude_none=True),
         stream=payload.stream,
     )
+
+    if response_format in ("text", "json", "verbose_json"):
+        full: Optional[dict] = None
+        accumulated = ""
+        try:
+            while True:
+                chunk = await _next_inference_chunk(handle)
+                if chunk.kind == "done":
+                    break
+                if chunk.kind == "error":
+                    raise chunk.error
+                line = chunk.payload
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8", errors="replace")
+                for raw in str(line).splitlines():
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        obj = json.loads(raw)
+                    except Exception:
+                        continue
+                    if isinstance(obj, dict) and (
+                        "segments" in obj or "language" in obj
+                    ):
+                        full = obj
+                    elif isinstance(obj, dict) and "text" in obj:
+                        accumulated += obj.get("text") or ""
+        finally:
+            handle.cancel()
+
+        if full is None:
+            full = {"text": accumulated}
+
+        if response_format == "text":
+            return PlainTextResponse((full.get("text") or "").strip())
+        if response_format == "json":
+            return JSONResponse({"text": (full.get("text") or "").strip()})
+        # verbose_json: full payload (text, segments, language, ...) as-is
+        return JSONResponse(full)
 
     return StreamingResponse(
         _stream_inference_results(handle, request),

--- a/mlx_audio/tests/test_server.py
+++ b/mlx_audio/tests/test_server.py
@@ -171,6 +171,110 @@ def test_stt_transcriptions(client, mock_model_provider):
 
 
 # ---------------------------------------------------------------------------
+# OpenAI-compatible response_format tests for /v1/audio/transcriptions
+# ---------------------------------------------------------------------------
+
+
+def _make_transcription_audio_buffer():
+    """Build a tiny mp3 buffer suitable as the ``file`` upload field."""
+    sample_rate = 16000
+    duration = 1
+    frequency = 440
+    t = np.linspace(0, duration, int(sample_rate * duration), False)
+    audio_data = 0.5 * np.sin(2 * np.pi * frequency * t).astype(np.float32)
+    buffer = io.BytesIO()
+    audio_write(buffer, audio_data, sample_rate, format="mp3")
+    buffer.seek(0)
+    return buffer
+
+
+def _post_transcription(client, mock_model_provider, mock_return, *, response_format):
+    mock_stt_model = MagicMock()
+    mock_stt_model.generate = MagicMock(return_value=mock_return)
+    mock_model_provider.load_model = MagicMock(return_value=mock_stt_model)
+
+    return client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("test.mp3", _make_transcription_audio_buffer(), "audio/mp3")},
+        data={"model": "test_stt_model", "response_format": response_format},
+    )
+
+
+def test_stt_transcriptions_response_format_text(client, mock_model_provider):
+    """response_format=text returns plain text body with the transcript."""
+    response = _post_transcription(
+        client,
+        mock_model_provider,
+        {"text": "Hello world."},
+        response_format="text",
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert response.text == "Hello world."
+
+
+def test_stt_transcriptions_response_format_json(client, mock_model_provider):
+    """response_format=json returns the OpenAI minimal {"text": ...} shape."""
+    response = _post_transcription(
+        client,
+        mock_model_provider,
+        {"text": "Hello world."},
+        response_format="json",
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {"text": "Hello world."}
+
+
+def test_stt_transcriptions_response_format_verbose_json(client, mock_model_provider):
+    """response_format=verbose_json passes the full model payload through unchanged."""
+    full_payload = {
+        "text": "Hello world.",
+        "language": "en",
+        "segments": [
+            {"id": 0, "text": "Hello", "start": 0.0, "end": 0.5},
+            {"id": 1, "text": " world.", "start": 0.5, "end": 1.0},
+        ],
+    }
+    response = _post_transcription(
+        client,
+        mock_model_provider,
+        full_payload,
+        response_format="verbose_json",
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert body["text"] == "Hello world."
+    assert body["language"] == "en"
+    assert [s["text"] for s in body["segments"]] == ["Hello", " world."]
+
+
+def test_stt_transcriptions_default_format_preserves_ndjson(
+    client, mock_model_provider
+):
+    """Without response_format, the legacy application/x-ndjson stream is preserved."""
+    mock_stt_model = MagicMock()
+    mock_stt_model.generate = MagicMock(return_value={"text": "hi"})
+    mock_model_provider.load_model = MagicMock(return_value=mock_stt_model)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("test.mp3", _make_transcription_audio_buffer(), "audio/mp3")},
+        data={"model": "test_stt_model"},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/x-ndjson")
+    # Each line in the body should be a JSON object.
+    lines = [line for line in response.text.splitlines() if line.strip()]
+    assert lines, "expected at least one ndjson line"
+    import json as _json
+
+    for line in lines:
+        _json.loads(line)
+
+
+# ---------------------------------------------------------------------------
 # WebSocket realtime streaming tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a `response_format` form parameter to `POST /v1/audio/transcriptions` so the endpoint can be driven by OpenAI Audio API clients (openai-python, the openai-go SDK, whisper.cpp clients, langchain wrappers, etc.) without per-client adaptation. Backwards-compatible: the default value is `ndjson`, which preserves the existing `application/x-ndjson` streaming transport unchanged.

Supported values:

| `response_format` | Content-Type | Body |
|---|---|---|
| `ndjson` *(default)* | `application/x-ndjson` | Existing whisper-segment stream, unchanged |
| `text` | `text/plain` | Final transcript only |
| `json` | `application/json` | `{"text": "..."}` |
| `verbose_json` | `application/json` | Full payload (`text`, `segments`, `language`, ...) passed through unchanged |

OpenAI spec: https://platform.openai.com/docs/api-reference/audio/createTranscription

## Motivation

[voicemode](https://github.com/mbailey/voicemode) is a downstream user that exposes mlx-audio as a local STT backend for AI coding assistants via the Model Context Protocol. Today voicemode ships a local patch that's applied to `mlx_audio/server.py` after `uv tool install` to get this exact shape -- folding the change into mlx-audio itself lets us drop the patch and lets every other OpenAI-Audio-API client point at mlx-audio out of the box.

## Implementation notes

- Default value is `ndjson` (not `json`), so existing clients see no behaviour change. OpenAI's own default is `json`, but flipping the default here would silently break every current mlx-audio caller, so the OpenAI-default semantics are opt-in.
- For the JSON/text formats the handler drains the broker's result chunks, parses each ndjson line, separates *segment-style* records (with `segments`/`language` keys) from *delta-style* records (with just `text`), then assembles the OpenAI-shaped response. `handle.cancel()` runs in `finally` to avoid leaking inference work if the client disconnects mid-drain.
- `verbose_json` returns the underlying model's payload as-is. No segment filtering, no text rewriting -- callers that want whisper's empty trailing segments stripped can do it client-side.

## Tests

4 new tests in `mlx_audio/tests/test_server.py`, plus the pre-existing `test_stt_transcriptions` retained for default-path regression coverage. All 18 tests in `test_server.py` pass:

- `test_stt_transcriptions_response_format_text` -- plain text body + content-type
- `test_stt_transcriptions_response_format_json` -- `{"text": "..."}` body + content-type
- `test_stt_transcriptions_response_format_verbose_json` -- segments + language + text passed through unchanged
- `test_stt_transcriptions_default_format_preserves_ndjson` -- legacy `application/x-ndjson` body, each line parses as JSON

Run locally:

```
pytest mlx_audio/tests/test_server.py -v
```

## Open question for the maintainer

- Default value: leave at `ndjson` (preserves existing behaviour) or flip to `json` to match OpenAI semantics? Happy either way; ndjson-default felt safer.
