### PR TITLE
Fix slow and flaky tests

### DIFF
--- a/mlx_audio/sts/tests/test_deepfilternet.py
+++ b/mlx_audio/sts/tests/test_deepfilternet.py
@@ -1,5 +1,6 @@
 """Tests for DeepFilterNet STS model."""
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -131,6 +132,10 @@ class TestDeepFilterNetRuntimeHelpers(unittest.TestCase):
         self.assertIsInstance(y2, np.ndarray)
 
 
+@unittest.skipUnless(
+    os.environ.get("MLX_AUDIO_RUN_STS_INTEGRATION") == "1",
+    "Set MLX_AUDIO_RUN_STS_INTEGRATION=1 to run DeepFilterNet pretrained tests",
+)
 class TestDeepFilterNetIntegration(unittest.TestCase):
     """End-to-end integration tests with real model weights.
 

--- a/mlx_audio/sts/tests/test_sam_audio.py
+++ b/mlx_audio/sts/tests/test_sam_audio.py
@@ -6,6 +6,47 @@ from unittest.mock import patch
 import mlx.core as mx
 
 
+def _tiny_dacvae_config():
+    from mlx_audio.codec.models.dacvae import DACVAEConfig
+
+    return DACVAEConfig(
+        encoder_dim=8,
+        encoder_rates=[2, 2],
+        latent_dim=16,
+        decoder_dim=32,
+        decoder_rates=[2, 2],
+        n_codebooks=2,
+        codebook_size=16,
+        codebook_dim=8,
+    )
+
+
+def _tiny_sam_audio_config():
+    from mlx_audio.sts.models.sam_audio.config import (
+        SAMAudioConfig,
+        T5EncoderConfig,
+        TransformerConfig,
+    )
+
+    codebook_dim = 8
+    return SAMAudioConfig(
+        in_channels=6 * codebook_dim,
+        audio_codec=_tiny_dacvae_config(),
+        text_encoder=T5EncoderConfig(name="tiny-t5", dim=16, max_length=8),
+        transformer=TransformerConfig(
+            dim=32,
+            n_heads=4,
+            n_layers=1,
+            context_dim=32,
+            out_channels=2 * codebook_dim,
+            frequency_embedding_dim=16,
+            multiple_of=8,
+            max_positions=64,
+        ),
+        anchor_embedding_dim=8,
+    )
+
+
 class TestSAMAudioConfig(unittest.TestCase):
     """Tests for SAM-Audio configuration classes."""
 
@@ -103,11 +144,9 @@ class TestDACVAECodec(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         from mlx_audio.codec.models.dacvae import DACVAE
-        from mlx_audio.sts.models.sam_audio.config import DACVAEConfig
 
-        self.config = DACVAEConfig()
+        self.config = _tiny_dacvae_config()
         self.codec = DACVAE(self.config)
-        self.codec.hop_length = 192
 
     def test_codec_initialization(self):
         """Test DACVAE initialization."""
@@ -119,7 +158,7 @@ class TestDACVAECodec(unittest.TestCase):
 
     def test_codec_hop_length(self):
         """Test DACVAE hop_length property."""
-        expected_hop = 192
+        expected_hop = 4
         self.assertEqual(self.codec.hop_length, expected_hop)
 
     def test_codec_encode_shape(self):
@@ -191,10 +230,9 @@ class TestSAMAudioModel(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from mlx_audio.sts.models.sam_audio.config import SAMAudioConfig
         from mlx_audio.sts.models.sam_audio.model import SAMAudio
 
-        self.config = SAMAudioConfig()
+        self.config = _tiny_sam_audio_config()
         self.model = SAMAudio(self.config)
         self.model.eval()
 
@@ -246,7 +284,7 @@ class TestSAMAudioModel(unittest.TestCase):
         expected_frames = samples // self.model.audio_codec.hop_length
         self.assertEqual(features.shape[0], batch_size)
         self.assertEqual(features.shape[1], expected_frames)
-        self.assertEqual(features.shape[2], 256)  # 2 * 128
+        self.assertEqual(features.shape[2], 2 * self.config.audio_codec.codebook_dim)
 
 
 class TestSAMAudioProcessor(unittest.TestCase):
@@ -302,10 +340,9 @@ class TestODEStepFunctions(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        from mlx_audio.sts.models.sam_audio.config import SAMAudioConfig
         from mlx_audio.sts.models.sam_audio.model import SAMAudio
 
-        self.config = SAMAudioConfig()
+        self.config = _tiny_sam_audio_config()
         self.model = SAMAudio(self.config)
         self.model.eval()
 
@@ -313,11 +350,11 @@ class TestODEStepFunctions(unittest.TestCase):
         """Test Euler ODE step output shape."""
         batch_size = 1
         seq_len = 2
-        channels = 256
+        channels = 2 * self.config.audio_codec.codebook_dim
 
         noisy_audio = mx.zeros((batch_size, seq_len, channels))
         audio_features = mx.zeros((batch_size, seq_len, channels))
-        text_features = mx.zeros((batch_size, 5, 768))
+        text_features = mx.zeros((batch_size, 5, self.config.text_encoder.dim))
 
         result = self.model._ode_step_euler(
             t=0.0,
@@ -338,11 +375,11 @@ class TestODEStepFunctions(unittest.TestCase):
         """Test Midpoint ODE step output shape."""
         batch_size = 1
         seq_len = 2
-        channels = 256
+        channels = 2 * self.config.audio_codec.codebook_dim
 
         noisy_audio = mx.zeros((batch_size, seq_len, channels))
         audio_features = mx.zeros((batch_size, seq_len, channels))
-        text_features = mx.zeros((batch_size, 5, 768))
+        text_features = mx.zeros((batch_size, 5, self.config.text_encoder.dim))
 
         result = self.model._ode_step_midpoint(
             t=0.0,

--- a/mlx_audio/stt/tests/test_voxtral_realtime_streaming.py
+++ b/mlx_audio/stt/tests/test_voxtral_realtime_streaming.py
@@ -134,7 +134,9 @@ class TestStreamingMelParity(unittest.TestCase):
             (1600, 200),
             (24157, 1000),
         ]
-        tol = 1e-4
+        # Chunked streaming performs separate FFT/matmul batches, which can drift
+        # slightly from the full batch path across MLX backends.
+        tol = 3e-4
         for n_samples, chunk in cases:
             with self.subTest(n_samples=n_samples, chunk=chunk):
                 audio = _make_audio(n_samples)

--- a/mlx_audio/tts/tests/test_qwen3_tts.py
+++ b/mlx_audio/tts/tests/test_qwen3_tts.py
@@ -162,6 +162,9 @@ class TestMelSpectrogram(unittest.TestCase):
     if mel_scale, norm, or center/reflect padding is changed.
     """
 
+    SNAPSHOT_RTOL = 2e-3
+    SNAPSHOT_ATOL = 2e-3
+
     def _get_random_audio(self):
         """Get deterministic random audio (seed=42, 12000 samples)."""
         np.random.seed(42)
@@ -209,8 +212,8 @@ class TestMelSpectrogram(unittest.TestCase):
         np.testing.assert_allclose(
             actual_frame0,
             expected_frame0,
-            rtol=1e-4,
-            atol=1e-4,
+            rtol=self.SNAPSHOT_RTOL,
+            atol=self.SNAPSHOT_ATOL,
             err_msg="mel_spectrogram must use norm='slaney' in mel_filters(). "
             "These values are specific to slaney-normalized filterbank.",
         )
@@ -244,8 +247,8 @@ class TestMelSpectrogram(unittest.TestCase):
         np.testing.assert_allclose(
             actual_frame23,
             expected_frame23,
-            rtol=1e-4,
-            atol=1e-4,
+            rtol=self.SNAPSHOT_RTOL,
+            atol=self.SNAPSHOT_ATOL,
             err_msg="mel_spectrogram must use mel_scale='slaney' in mel_filters(). "
             "HTK scale distributes mel bins differently and produces wrong values.",
         )
@@ -268,8 +271,8 @@ class TestMelSpectrogram(unittest.TestCase):
         np.testing.assert_allclose(
             actual_last,
             expected_last,
-            rtol=1e-4,
-            atol=1e-4,
+            rtol=self.SNAPSHOT_RTOL,
+            atol=self.SNAPSHOT_ATOL,
             err_msg="mel_spectrogram must use reflect padding. "
             "Boundary frames are sensitive to the padding mode used before STFT.",
         )
@@ -302,8 +305,8 @@ class TestMelSpectrogram(unittest.TestCase):
         np.testing.assert_allclose(
             actual,
             expected,
-            rtol=1e-4,
-            atol=1e-4,
+            rtol=self.SNAPSHOT_RTOL,
+            atol=self.SNAPSHOT_ATOL,
             err_msg="mel_spectrogram must use mel_scale='slaney' and norm='slaney'. "
             "A 1kHz sine wave should produce these specific bin activations "
             "with slaney-scale mel filterbank.",
@@ -318,14 +321,16 @@ class TestMelSpectrogram(unittest.TestCase):
         np.testing.assert_allclose(
             mel_np.mean(),
             -0.37329558,
-            rtol=1e-3,
+            rtol=self.SNAPSHOT_RTOL,
+            atol=self.SNAPSHOT_ATOL,
             err_msg="mel_spectrogram output mean should be ~-0.37 with correct params. "
             f"Got mean={mel_np.mean():.4f}. A positive mean (~2.5) indicates norm=None.",
         )
         np.testing.assert_allclose(
             mel_np.std(),
             0.37445435,
-            rtol=1e-3,
+            rtol=self.SNAPSHOT_RTOL,
+            atol=self.SNAPSHOT_ATOL,
             err_msg="mel_spectrogram output std should be ~0.37 with correct params. "
             f"Got std={mel_np.std():.4f}.",
         )


### PR DESCRIPTION
One of the STS tests was taking several minutes to run because it was downloading model weights, so this should speed up running tests in CI. I also tweaked some tolerances for some aggressively-tuned tests that often fail for me locally.

Edit: the real culprit was the SAM model, which materializes a huge model that taxes the runner. I sized it down with a smaller config.