### PR TITLE
fix: quantize Chatterbox ve projection for 4-bit checkpoints

### DIFF
--- a/mlx_audio/tts/models/chatterbox/chatterbox.py
+++ b/mlx_audio/tts/models/chatterbox/chatterbox.py
@@ -418,7 +418,10 @@ class Model(nn.Module):
                     return False
                 # Check if we have quantized weights (scales) for this path
                 # Need to check in the appropriate weight dict based on prefix
-                if path.startswith("t3."):
+                if path.startswith("ve."):
+                    weight_path = path[3:]  # Remove "ve." prefix
+                    return f"{weight_path}.scales" in ve_weights
+                elif path.startswith("t3."):
                     weight_path = path[3:]  # Remove "t3." prefix
                     return f"{weight_path}.scales" in t3_weights
                 elif path.startswith("s3gen."):

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -1,5 +1,6 @@
 import importlib.resources
 import importlib.util
+import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -1468,6 +1469,61 @@ class TestChatterboxModel(unittest.TestCase):
         self.assertIn("ve.lstm.weight", result)
         self.assertIn("t3.tfmr.weight", result)
         self.assertIn("s3gen.flow.weight", result)
+
+
+class TestChatterboxFromPretrainedQuantization(unittest.TestCase):
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.nn.quantize")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.mx.load")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.T3")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.S3Token2Wav")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.VoiceEncoder")
+    @patch("mlx_audio.tts.models.chatterbox.chatterbox.S3TokenizerV2")
+    def test_from_pretrained_quantizes_ve_projection_when_quantized_weights_exist(
+        self,
+        mock_s3_tokenizer,
+        mock_ve_class,
+        mock_s3gen_class,
+        mock_t3_class,
+        mock_mx_load,
+        mock_quantize,
+    ):
+        """Regression test for chatterbox-4bit loader: ve.proj must be quantized when scales exist."""
+        from mlx_audio.tts.models.chatterbox.chatterbox import Model
+
+        class StopAfterQuantize(Exception):
+            pass
+
+        quantizable_module = type(
+            "QuantizableModule", (), {"to_quantized": lambda self: None}
+        )()
+        non_quantizable_module = object()
+
+        def fake_quantize(model, group_size, bits, class_predicate):
+            self.assertEqual(group_size, 64)
+            self.assertEqual(bits, 4)
+            self.assertTrue(class_predicate("ve.proj", quantizable_module))
+            self.assertFalse(class_predicate("ve.lstm.layers.0", quantizable_module))
+            self.assertFalse(class_predicate("ve.proj", non_quantizable_module))
+            self.assertFalse(class_predicate("t3.tfmr", quantizable_module))
+            raise StopAfterQuantize
+
+        mock_quantize.side_effect = fake_quantize
+        mock_mx_load.return_value = {
+            "ve.proj.weight": mx.zeros((256, 32), dtype=mx.uint32),
+            "ve.proj.scales": mx.zeros((256, 4)),
+            "ve.proj.biases": mx.zeros((256, 4)),
+            "ve.proj.bias": mx.zeros((256,)),
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            model_dir = Path(tmpdir)
+            (model_dir / "model.safetensors").write_bytes(b"stub")
+            (model_dir / "config.json").write_text(
+                json.dumps({"quantization": {"bits": 4, "group_size": 64}})
+            )
+
+            with self.assertRaises(StopAfterQuantize):
+                Model.from_pretrained(model_dir)
 
 
 class TestChatterboxTurboConfig(unittest.TestCase):


### PR DESCRIPTION
## Summary
- quantize `ve.*` modules when quantized Chatterbox voice-encoder weights are present
- add a regression test covering `mlx-community/chatterbox-4bit` loader behavior

## Root cause
`Model.from_pretrained()` quantized `t3.*` and `s3gen.*` modules based on the presence of `.scales` weights, but skipped `ve.*`. The `mlx-community/chatterbox-4bit` checkpoint includes quantized `ve.proj.*` weights, so loading failed with extra `proj.scales` / `proj.biases` keys.

## Testing
```bash
pytest -q mlx_audio/tts/tests/test_models.py -k 've_projection_when_quantized_weights_exist or TestChatterboxModel'
pytest -q mlx_audio/tts/tests/test_models.py -k 'Chatterbox and not Turbo'
```

Closes #706
