### PR TITLE
fix voice pipeline thread safety issues

### DIFF
--- a/mlx_audio/sts/voice_pipeline.py
+++ b/mlx_audio/sts/voice_pipeline.py
@@ -97,8 +97,8 @@ class VoicePipeline:
         frame_size = int(self.input_sample_rate * (self.frame_duration_ms / 1000.0))
         logger.info(f"Loading speech-to-text model: {self.stt_model}")
         self.stt = load_stt(self.stt_model)
-        self.tts_loaded.wait()
-        self.llm_loaded.wait()
+        await self.tts_loaded.wait()
+        await self.llm_loaded.wait()
 
         stream = sd.InputStream(
             samplerate=self.input_sample_rate,

--- a/mlx_audio/sts/voice_pipeline.py
+++ b/mlx_audio/sts/voice_pipeline.py
@@ -9,7 +9,7 @@ import webrtcvad
 from mlx_lm.generate import generate as generate_text
 from mlx_lm.utils import load as load_llm
 
-from mlx_audio.stt.models.whisper import Model as Whisper
+from mlx_audio.stt import load as load_stt
 from mlx_audio.tts.audio_player import AudioPlayer
 from mlx_audio.tts.utils import load_model as load_tts
 
@@ -62,7 +62,7 @@ class VoicePipeline:
         self.tts = await asyncio.to_thread(lambda: load_tts(self.tts_model))
 
         logger.info(f"Loading speech-to-text model: {self.stt_model}")
-        self.stt = Whisper.from_pretrained(self.stt_model)
+        self.stt = load_stt(self.stt_model)
 
     async def start(self):
         self.loop = asyncio.get_running_loop()

--- a/mlx_audio/sts/voice_pipeline.py
+++ b/mlx_audio/sts/voice_pipeline.py
@@ -191,12 +191,6 @@ class VoicePipeline:
             self.transcription_queue.task_done()
 
     async def _generate_response(self, text):
-        def _get_llm_response(llm, tokenizer, messages, *, verbose=False):
-            prompt = tokenizer.apply_chat_template(
-                messages, tokenize=False, add_generation_prompt=True
-            )
-            return generate_text(llm, tokenizer, prompt, verbose=verbose).strip()
-
         try:
             logger.info("Generating response...")
 
@@ -207,9 +201,14 @@ class VoicePipeline:
                 },
                 {"role": "user", "content": text},
             ]
-            response_text = _get_llm_response(
-                self.llm, self.tokenizer, messages, verbose=False
+
+            prompt = self.tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
             )
+
+            response_text = generate_text(
+                self.llm, self.tokenizer, prompt, verbose=False
+            ).strip()
 
             logger.info(f"Generated response: {response_text}")
 
@@ -230,27 +229,20 @@ class VoicePipeline:
         """
         loop = self.loop
 
-        def _tts_stream(tts, txt, rate, queue, cancel_ev: asyncio.Event):
-            # This runs in a worker thread, so we *must* poll a thread‑safe flag.
-            for chunk in tts.generate(
-                txt,
-                sample_rate=rate,
+        try:
+            for chunk in self.tts.generate(
+                text,
+                sample_rate=self.output_sample_rate,
                 stream=True,
                 streaming_interval=self.streaming_interval,
                 verbose=False,
             ):
-                if cancel_ev.is_set():  # <-- stop immediately
+                if cancel_event.is_set():  # <-- stop immediately
                     break
-                loop.call_soon_threadsafe(queue.put_nowait, chunk.audio)
+                loop.call_soon_threadsafe(
+                    self.output_audio_queue.put_nowait, chunk.audio
+                )
 
-        try:
-            _tts_stream(
-                self.tts,
-                text,
-                self.output_sample_rate,
-                self.output_audio_queue,
-                cancel_event,
-            )
         except asyncio.CancelledError:
             # The coroutine itself was cancelled from outside → just exit cleanly.
             pass

--- a/mlx_audio/sts/voice_pipeline.py
+++ b/mlx_audio/sts/voice_pipeline.py
@@ -28,7 +28,7 @@ class VoicePipeline:
         output_sample_rate=24_000,
         streaming_interval=3,
         frame_duration_ms=30,
-        vad_model=3,
+        vad_mode=3,
         stt_model="mlx-community/whisper-large-v3-turbo-asr-fp16",
         llm_model="Qwen/Qwen2.5-0.5B-Instruct-4bit",
         tts_model="mlx-community/csm-1b-fp16",
@@ -44,7 +44,7 @@ class VoicePipeline:
         self.llm_model = llm_model
         self.tts_model = tts_model
 
-        self.vad = webrtcvad.Vad(vad_model)
+        self.vad = webrtcvad.Vad(vad_mode)
 
         self.input_audio_queue = asyncio.Queue(maxsize=50)
         self.transcription_queue = asyncio.Queue()
@@ -280,7 +280,7 @@ async def main():
         default="mlx-community/Qwen2.5-0.5B-Instruct-4bit",
         help="LLM model",
     )
-    parser.add_argument("--vad_model", type=int, default=3, help="VAD mode")
+    parser.add_argument("--vad_mode", type=int, default=3, help="VAD mode")
     parser.add_argument(
         "--silence_duration", type=float, default=1.5, help="Silence duration"
     )
@@ -296,7 +296,7 @@ async def main():
         stt_model=args.stt_model,
         tts_model=args.tts_model,
         llm_model=args.llm_model,
-        vad_model=args.vad_model,
+        vad_mode=args.vad_mode,
         silence_duration=args.silence_duration,
         silence_threshold=args.silence_threshold,
         streaming_interval=args.streaming_interval,

--- a/mlx_audio/sts/voice_pipeline.py
+++ b/mlx_audio/sts/voice_pipeline.py
@@ -28,7 +28,7 @@ class VoicePipeline:
         output_sample_rate=24_000,
         streaming_interval=3,
         frame_duration_ms=30,
-        vad_mode=3,
+        vad_model=3,
         stt_model="mlx-community/whisper-large-v3-turbo-asr-fp16",
         llm_model="Qwen/Qwen2.5-0.5B-Instruct-4bit",
         tts_model="mlx-community/csm-1b-fp16",
@@ -44,7 +44,7 @@ class VoicePipeline:
         self.llm_model = llm_model
         self.tts_model = tts_model
 
-        self.vad = webrtcvad.Vad(vad_mode)
+        self.vad = webrtcvad.Vad(vad_model)
 
         self.input_audio_queue = asyncio.Queue(maxsize=50)
         self.transcription_queue = asyncio.Queue()
@@ -296,7 +296,7 @@ async def main():
         default="mlx-community/Qwen2.5-0.5B-Instruct-4bit",
         help="LLM model",
     )
-    parser.add_argument("--vad_mode", type=int, default=3, help="VAD mode")
+    parser.add_argument("--vad_model", type=int, default=3, help="VAD mode")
     parser.add_argument(
         "--silence_duration", type=float, default=1.5, help="Silence duration"
     )
@@ -312,7 +312,7 @@ async def main():
         stt_model=args.stt_model,
         tts_model=args.tts_model,
         llm_model=args.llm_model,
-        vad_mode=args.vad_mode,
+        vad_model=args.vad_model,
         silence_duration=args.silence_duration,
         silence_threshold=args.silence_threshold,
         streaming_interval=args.streaming_interval,

--- a/mlx_audio/sts/voice_pipeline.py
+++ b/mlx_audio/sts/voice_pipeline.py
@@ -50,24 +50,12 @@ class VoicePipeline:
         self.transcription_queue = asyncio.Queue()
         self.output_audio_queue = asyncio.Queue(maxsize=50)
 
-        self.mlx_lock = asyncio.Lock()
-
-    async def init_models(self):
-        logger.info(f"Loading text generation model: {self.llm_model}")
-        self.llm, self.tokenizer = await asyncio.to_thread(
-            lambda: load_llm(self.llm_model)
-        )
-
-        logger.info(f"Loading text-to-speech model: {self.tts_model}")
-        self.tts = await asyncio.to_thread(lambda: load_tts(self.tts_model))
-
-        logger.info(f"Loading speech-to-text model: {self.stt_model}")
-        self.stt = load_stt(self.stt_model)
+        self.llm_loaded = asyncio.Event()
+        self.tts_loaded = asyncio.Event()
 
     async def start(self):
+        self.player = AudioPlayer(sample_rate=self.output_sample_rate)
         self.loop = asyncio.get_running_loop()
-
-        await self.init_models()
 
         tasks = [
             asyncio.create_task(self._listener()),
@@ -107,6 +95,11 @@ class VoicePipeline:
 
     async def _listener(self):
         frame_size = int(self.input_sample_rate * (self.frame_duration_ms / 1000.0))
+        logger.info(f"Loading speech-to-text model: {self.stt_model}")
+        self.stt = load_stt(self.stt_model)
+        self.tts_loaded.wait()
+        self.llm_loaded.wait()
+
         stream = sd.InputStream(
             samplerate=self.input_sample_rate,
             blocksize=frame_size,
@@ -151,7 +144,10 @@ class VoicePipeline:
                         if frames:
 
                             logger.info("Processing voice input...")
-                            await self._process_audio(frames)
+                            text = self._process_audio(frames)
+                            if text:
+                                logger.info(f"Transcribed: {text}")
+                                await self.transcription_queue.put(text)
 
                         frames = []
                         speaking_detected = False
@@ -175,22 +171,20 @@ class VoicePipeline:
 
         self.loop.call_soon_threadsafe(_enqueue)
 
-    async def _process_audio(self, frames):
+    def _process_audio(self, frames):
         audio = (
             np.frombuffer(b"".join(frames), dtype=np.int16).astype(np.float32) / 32768.0
         )
 
-        async with self.mlx_lock:
-            result = await asyncio.to_thread(self.stt.generate, mx.array(audio))
-        text = result.text.strip()
-
-        if text:
-            logger.info(f"Transcribed: {text}")
-            await self.transcription_queue.put(text)
+        result = self.stt.generate(mx.array(audio))
+        return result.text.strip()
 
     # response generation
 
     async def _response_processor(self):
+        logger.info(f"Loading text generation model: {self.llm_model}")
+        self.llm, self.tokenizer = load_llm(self.llm_model)
+        self.llm_loaded.set()
         while True:
             text = await self.transcription_queue.get()
             await self._generate_response(text)
@@ -213,10 +207,9 @@ class VoicePipeline:
                 },
                 {"role": "user", "content": text},
             ]
-            async with self.mlx_lock:
-                response_text = await asyncio.to_thread(
-                    _get_llm_response, self.llm, self.tokenizer, messages, verbose=False
-                )
+            response_text = _get_llm_response(
+                self.llm, self.tokenizer, messages, verbose=False
+            )
 
             logger.info(f"Generated response: {response_text}")
 
@@ -251,15 +244,13 @@ class VoicePipeline:
                 loop.call_soon_threadsafe(queue.put_nowait, chunk.audio)
 
         try:
-            async with self.mlx_lock:
-                await asyncio.to_thread(
-                    _tts_stream,
-                    self.tts,
-                    text,
-                    self.output_sample_rate,
-                    self.output_audio_queue,
-                    cancel_event,
-                )
+            _tts_stream(
+                self.tts,
+                text,
+                self.output_sample_rate,
+                self.output_audio_queue,
+                cancel_event,
+            )
         except asyncio.CancelledError:
             # The coroutine itself was cancelled from outside → just exit cleanly.
             pass
@@ -267,8 +258,9 @@ class VoicePipeline:
             logger.error("Speech synthesis error: %s", exc)
 
     async def _audio_output_processor(self):
-        self.player = AudioPlayer(sample_rate=self.output_sample_rate)
-
+        logger.info(f"Loading text-to-speech model: {self.tts_model}")
+        self.tts = load_tts(self.tts_model)  # pyright: ignore[reportArgumentType]
+        self.tts_loaded.set()
         try:
             while True:
                 audio = await self.output_audio_queue.get()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ requires-python = ">=3.10"
 dependencies = [
     "huggingface_hub>=1.0",
     "miniaudio>=1.61",
-    "mlx-lm>=0.31.1",
-    "mlx>=0.31.1",
+    "mlx-lm>=0.31.2",
+    "mlx>=0.31.2",
     "numpy>=1.26.4",
     "scipy>=1.10.0",
     "sounddevice>=0.5.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1030,8 +1030,8 @@ requires-dist = [
     { name = "mistral-common", extras = ["audio"], marker = "extra == 'tts'" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.6" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.29" },
-    { name = "mlx", specifier = ">=0.31.1" },
-    { name = "mlx-lm", specifier = "==0.31.1" },
+    { name = "mlx", specifier = ">=0.31.2" },
+    { name = "mlx-lm", specifier = ">=0.31.2" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -1045,7 +1045,7 @@ requires-dist = [
     { name = "setuptools", marker = "extra == 'all'", specifier = "<81" },
     { name = "setuptools", marker = "extra == 'server'", specifier = "<81" },
     { name = "setuptools", marker = "extra == 'sts'", specifier = "<81" },
-    { name = "sounddevice", specifier = "==0.5.3" },
+    { name = "sounddevice", specifier = ">=0.5.3" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "transformers", specifier = ">=5.5.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'all'", specifier = ">=0.22.0" },
@@ -1058,7 +1058,7 @@ provides-extras = ["stt", "tts", "server", "sts", "all", "dev", "docs"]
 
 [[package]]
 name = "mlx-lm"
-version = "0.31.1"
+version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -1070,9 +1070,9 @@ dependencies = [
     { name = "sentencepiece" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/f9/3f5597c62bd5733ebb3c9f96c33f2065db16353d743b8548bb05a01b7dd3/mlx_lm-0.31.1.tar.gz", hash = "sha256:1b2362ea301427004e5dda43b9241d751d4cb80eba641f6b85b29fc493affac5", size = 285473, upload-time = "2026-03-11T02:02:57.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/8e/2e40713fc673d7268e32222752919075c0024b02635af56531d9ee8317b5/mlx_lm-0.31.1-py3-none-any.whl", hash = "sha256:bfc3e08e919b87bebb6fe2dbea980ece8ae8ee7132b31421aa0923c4286ecfa0", size = 393971, upload-time = "2026-03-11T02:02:54.973Z" },
+    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890, upload-time = "2026-04-22T07:37:25.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context
The original implementation throw runtime error due to mlx is not thread safe. Lucky [mlx v0.31.2](https://github.com/ml-explore/mlx/releases/tag/v0.31.2) provided the tool needed for easier fixes. Along with some minor stuffs(like typos) which I am a little bit too lazy to pick them apart.  

## Description & Changes in the codebase
1. fixed runtime error like ```ERROR - Generation error: There is no Stream(gpu, 0) in current thread.``` By putting both model loading and its usage on the same thread.
2. Typo fix: vad_mode -> vade_model
3.  Whisper seems to throw error at runtime for me for some reason(need further investigation!). So I replaced the hard-coded Whisper.fromPretrained to the general STT load function to allowing users to load other STT. But I didn't replace the whisper model as the default STT as I don't know which model should be the default.
4. Removed some unneeded wrapping functions as some ``asyncio.to_thread`` usage were removed.

<!-- Optional: Add a checklist for contributors -->
## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Issue referenced (e.g., "Closes #...")
