### PR TITLE
Whisper: fall back to canonical openai/whisper-* processor when mlx-community repos lack one

### DIFF
--- a/mlx_audio/stt/models/whisper/whisper.py
+++ b/mlx_audio/stt/models/whisper/whisper.py
@@ -316,6 +316,200 @@ class ModelDimensions:
 ModelConfig = ModelDimensions
 
 
+# Each canonical openai/whisper-* variant has a unique architecture signature.
+# Identifying the variant from config.json dims (rather than the directory
+# name) makes the fallback robust to arbitrary repo naming
+# (whisper-large-v3-mlx-4bit, whisper-base.en-mlx, user-renamed local dirs).
+# Signature: (n_audio_state, n_mels, n_audio_layer, n_text_layer, n_vocab).
+# large-v1 and large-v2 share architecture; v2 is the more common upstream
+# choice and its processor files are interchangeable with v1's.  Issue #645.
+_WHISPER_ARCH_TO_OPENAI = {
+    # Multilingual variants (vocab 51865)
+    (384, 80, 4, 4, 51865): "openai/whisper-tiny",
+    (512, 80, 6, 6, 51865): "openai/whisper-base",
+    (768, 80, 12, 12, 51865): "openai/whisper-small",
+    (1024, 80, 24, 24, 51865): "openai/whisper-medium",
+    (1280, 80, 32, 32, 51865): "openai/whisper-large-v2",
+    # English-only variants (vocab 51864 — no language tokens)
+    (384, 80, 4, 4, 51864): "openai/whisper-tiny.en",
+    (512, 80, 6, 6, 51864): "openai/whisper-base.en",
+    (768, 80, 12, 12, 51864): "openai/whisper-small.en",
+    (1024, 80, 24, 24, 51864): "openai/whisper-medium.en",
+    # large-v3 (added Cantonese token + 128 mel bins)
+    (1280, 128, 32, 32, 51866): "openai/whisper-large-v3",
+    # large-v3-turbo (4 decoder layers vs 32)
+    (1280, 128, 32, 4, 51866): "openai/whisper-large-v3-turbo",
+    # distil-whisper variants (Hugging Face, not openai) — out of scope for
+    # this fallback. They have their own canonical repos (e.g.
+    # ``distil-whisper/distil-large-v3``) and would need a separate mapping
+    # if the project decides to support them.
+}
+
+
+def _whisper_arch_signature(
+    model_path: Path,
+) -> Optional[Tuple[int, int, int, int, int]]:
+    """Read config.json from ``model_path`` and return its 5-tuple of dims.
+
+    Returns None if config.json is missing, malformed (``JSONDecodeError``),
+    or doesn't expose the expected whisper dimensions. Read errors that
+    indicate a real filesystem problem (``PermissionError`` and other
+    ``OSError``) propagate rather than being masked as "no signature".
+    Handles both openai/mlx-style keys (``n_audio_state``, ``n_mels``, …)
+    and HF Transformers-style keys (``d_model``, ``num_mel_bins``, …).
+    """
+    cfg_path = model_path / "config.json"
+    if not cfg_path.is_file():
+        return None
+    # PermissionError / other OSError from read_text() propagates — a real
+    # filesystem issue should not be masked by silently returning None.
+    # Only swallow JSONDecodeError so a malformed local config.json still
+    # falls through to the existing "warn and return None" path rather than
+    # crashing the load.
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except json.JSONDecodeError:
+        return None
+    n_audio_state = cfg.get("n_audio_state") or cfg.get("d_model")
+    n_mels = cfg.get("n_mels") or cfg.get("num_mel_bins")
+    n_audio_layer = cfg.get("n_audio_layer") or cfg.get("encoder_layers")
+    n_text_layer = cfg.get("n_text_layer") or cfg.get("decoder_layers")
+    n_vocab = cfg.get("n_vocab") or cfg.get("vocab_size")
+    if None in (n_audio_state, n_mels, n_audio_layer, n_text_layer, n_vocab):
+        return None
+    return (n_audio_state, n_mels, n_audio_layer, n_text_layer, n_vocab)
+
+
+def _canonical_openai_whisper_repo(model_path: Path) -> Optional[str]:
+    """Return the canonical openai/whisper-* repo for ``model_path``.
+
+    Identifies the architecture from config.json dims rather than parsing
+    the directory name, so quantization suffixes and renames don't matter.
+    Returns None when the architecture isn't a recognized canonical variant
+    so the caller preserves the prior "warn and set _processor=None" path.
+    """
+    sig = _whisper_arch_signature(model_path)
+    if sig is None:
+        return None
+    return _WHISPER_ARCH_TO_OPENAI.get(sig)
+
+
+def _has_local_processor_files(model_path: Path) -> bool:
+    """Return True if ``model_path`` ships its own WhisperProcessor files.
+
+    The canonical-openai fallback should only fire when the local directory
+    is missing these files — not when the local load fails for other reasons
+    (cache/auth/path issues that would be masked by an unexpected HF Hub
+    download). ``preprocessor_config.json`` is the feature extractor; either
+    ``tokenizer.json`` or ``tokenizer_config.json`` covers the tokenizer
+    side.
+
+    The ``is True`` comparisons coerce the result to a strict boolean so a
+    mocked ``Path`` (whose ``is_file()`` returns a truthy ``MagicMock``)
+    reads as "files absent" — the caller's gate then falls through to the
+    existing fallback behavior instead of misclassifying a mock as a
+    complete local directory.
+    """
+    return (model_path / "preprocessor_config.json").is_file() is True and (
+        (model_path / "tokenizer.json").is_file() is True
+        or (model_path / "tokenizer_config.json").is_file() is True
+    )
+
+
+def _load_whisper_processor(model_path: Path):
+    """Load WhisperProcessor for ``model_path``, with canonical-openai fallback.
+
+    The local-load catch is narrow: only the "missing processor files"
+    scenario (the local directory lacks ``preprocessor_config.json`` /
+    tokenizer files) triggers the canonical fallback. A local directory
+    that *does* ship processor files but still raised propagates the error
+    so genuinely-broken local checkpoints (auth, cache, corrupt files)
+    surface their real cause instead of being masked by a network download.
+
+    The canonical fetch itself is best-effort graceful degradation: any
+    failure (offline mode, 401/404, network error, or a malformed canonical
+    config) is converted to a warning + ``None``, matching the pre-fix
+    "warn and set _processor=None" behavior. The user then gets the clear
+    "Processor not found" error at transcribe time.
+
+    Network: when the fallback fires, the canonical processor is fetched
+    from the HF Hub (~4 MB). Set ``HF_HUB_OFFLINE=1`` or
+    ``TRANSFORMERS_OFFLINE=1`` in air-gapped environments — transformers
+    raises an offline-mode error that is caught here and surfaced via the
+    warning path (preferable to a long network timeout).
+
+    Returns the processor or ``None`` if neither the local load nor the
+    canonical fallback succeeds.
+    """
+    try:
+        from transformers import WhisperProcessor
+    except ImportError as e:
+        warnings.warn(f"Could not load WhisperProcessor: {e}.")
+        return None
+
+    # Same expected-exception set as the fallback path below: OSError plus
+    # the HF Hub / network errors transformers raises when files aren't
+    # available (RepositoryNotFoundError, EntryNotFoundError, OfflineMode,
+    # RequestException). Imported lazily to keep the optional deps optional.
+    _expected_local_errors = [OSError]
+    # Import each HF error class separately so a missing one doesn't take
+    # out the whole catch list. Older huggingface_hub versions don't ship
+    # OfflineModeError; HfHubHTTPError has been stable since 0.16.
+    try:
+        from huggingface_hub.errors import HfHubHTTPError
+
+        _expected_local_errors.append(HfHubHTTPError)
+    except ImportError:
+        pass
+    try:
+        from huggingface_hub.errors import OfflineModeError
+
+        _expected_local_errors.append(OfflineModeError)
+    except ImportError:
+        pass
+    try:
+        from requests.exceptions import RequestException
+
+        _expected_local_errors.append(RequestException)
+    except ImportError:
+        pass
+
+    try:
+        return WhisperProcessor.from_pretrained(str(model_path))
+    except tuple(_expected_local_errors) as local_err:
+        # Only the "missing processor files" scenario should trigger the
+        # canonical fallback. A local directory that ships its own
+        # processor files but still raised indicates something else
+        # (auth, cache, env) — propagate so the user sees the real cause.
+        if _has_local_processor_files(model_path):
+            raise
+        canonical = _canonical_openai_whisper_repo(model_path)
+        if canonical is None:
+            warnings.warn(f"Could not load WhisperProcessor: {local_err}.")
+            return None
+        # The canonical fetch is best-effort graceful degradation: any
+        # failure (offline mode, 401/404, network error, or a malformed
+        # canonical config) degrades to a warning + ``None``, exactly as
+        # the pre-fix "warn and set _processor=None" path did. The user
+        # then sees the clear "Processor not found" error at transcribe
+        # time. The local-load catch above is the one that's narrowed, so
+        # genuinely-broken *local* checkpoints still surface their cause.
+        try:
+            processor = WhisperProcessor.from_pretrained(canonical)
+        except Exception as fallback_err:
+            warnings.warn(
+                f"Could not load WhisperProcessor locally or from {canonical}: "
+                f"local={local_err} fallback={fallback_err}"
+            )
+            return None
+        warnings.warn(
+            f"Loaded WhisperProcessor from {canonical} as fallback because "
+            f"{model_path} is missing processor files: {local_err}",
+            stacklevel=2,
+        )
+        return processor
+
+
 def sinusoids(length, channels, max_timescale=10000):
     """Returns sinusoids for positional embedding"""
     assert channels % 2 == 0
@@ -692,14 +886,7 @@ class Model(nn.Module):
         Returns:
             The model with processor initialized
         """
-        try:
-            from transformers import WhisperProcessor
-
-            processor = WhisperProcessor.from_pretrained(str(model_path))
-            model._processor = processor
-        except Exception as e:
-            model._processor = None
-            warnings.warn(f"Could not load WhisperProcessor: {e}.")
+        model._processor = _load_whisper_processor(Path(model_path))
 
         # Load alignment heads from generation_config.json for word-level timestamps
         gen_config_path = Path(model_path) / "generation_config.json"

--- a/mlx_audio/stt/models/whisper/whisper.py
+++ b/mlx_audio/stt/models/whisper/whisper.py
@@ -326,6 +326,200 @@ class ModelDimensions:
 ModelConfig = ModelDimensions
 
 
+# Each canonical openai/whisper-* variant has a unique architecture signature.
+# Identifying the variant from config.json dims (rather than the directory
+# name) makes the fallback robust to arbitrary repo naming
+# (whisper-large-v3-mlx-4bit, whisper-base.en-mlx, user-renamed local dirs).
+# Signature: (n_audio_state, n_mels, n_audio_layer, n_text_layer, n_vocab).
+# large-v1 and large-v2 share architecture; v2 is the more common upstream
+# choice and its processor files are interchangeable with v1's.  Issue #645.
+_WHISPER_ARCH_TO_OPENAI = {
+    # Multilingual variants (vocab 51865)
+    (384, 80, 4, 4, 51865): "openai/whisper-tiny",
+    (512, 80, 6, 6, 51865): "openai/whisper-base",
+    (768, 80, 12, 12, 51865): "openai/whisper-small",
+    (1024, 80, 24, 24, 51865): "openai/whisper-medium",
+    (1280, 80, 32, 32, 51865): "openai/whisper-large-v2",
+    # English-only variants (vocab 51864 — no language tokens)
+    (384, 80, 4, 4, 51864): "openai/whisper-tiny.en",
+    (512, 80, 6, 6, 51864): "openai/whisper-base.en",
+    (768, 80, 12, 12, 51864): "openai/whisper-small.en",
+    (1024, 80, 24, 24, 51864): "openai/whisper-medium.en",
+    # large-v3 (added Cantonese token + 128 mel bins)
+    (1280, 128, 32, 32, 51866): "openai/whisper-large-v3",
+    # large-v3-turbo (4 decoder layers vs 32)
+    (1280, 128, 32, 4, 51866): "openai/whisper-large-v3-turbo",
+    # distil-whisper variants (Hugging Face, not openai) — out of scope for
+    # this fallback. They have their own canonical repos (e.g.
+    # ``distil-whisper/distil-large-v3``) and would need a separate mapping
+    # if the project decides to support them.
+}
+
+
+def _whisper_arch_signature(
+    model_path: Path,
+) -> Optional[Tuple[int, int, int, int, int]]:
+    """Read config.json from ``model_path`` and return its 5-tuple of dims.
+
+    Returns None if config.json is missing, malformed (``JSONDecodeError``),
+    or doesn't expose the expected whisper dimensions. Read errors that
+    indicate a real filesystem problem (``PermissionError`` and other
+    ``OSError``) propagate rather than being masked as "no signature".
+    Handles both openai/mlx-style keys (``n_audio_state``, ``n_mels``, …)
+    and HF Transformers-style keys (``d_model``, ``num_mel_bins``, …).
+    """
+    cfg_path = model_path / "config.json"
+    if not cfg_path.is_file():
+        return None
+    # PermissionError / other OSError from read_text() propagates — a real
+    # filesystem issue should not be masked by silently returning None.
+    # Only swallow JSONDecodeError so a malformed local config.json still
+    # falls through to the existing "warn and return None" path rather than
+    # crashing the load.
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except json.JSONDecodeError:
+        return None
+    n_audio_state = cfg.get("n_audio_state") or cfg.get("d_model")
+    n_mels = cfg.get("n_mels") or cfg.get("num_mel_bins")
+    n_audio_layer = cfg.get("n_audio_layer") or cfg.get("encoder_layers")
+    n_text_layer = cfg.get("n_text_layer") or cfg.get("decoder_layers")
+    n_vocab = cfg.get("n_vocab") or cfg.get("vocab_size")
+    if None in (n_audio_state, n_mels, n_audio_layer, n_text_layer, n_vocab):
+        return None
+    return (n_audio_state, n_mels, n_audio_layer, n_text_layer, n_vocab)
+
+
+def _canonical_openai_whisper_repo(model_path: Path) -> Optional[str]:
+    """Return the canonical openai/whisper-* repo for ``model_path``.
+
+    Identifies the architecture from config.json dims rather than parsing
+    the directory name, so quantization suffixes and renames don't matter.
+    Returns None when the architecture isn't a recognized canonical variant
+    so the caller preserves the prior "warn and set _processor=None" path.
+    """
+    sig = _whisper_arch_signature(model_path)
+    if sig is None:
+        return None
+    return _WHISPER_ARCH_TO_OPENAI.get(sig)
+
+
+def _has_local_processor_files(model_path: Path) -> bool:
+    """Return True if ``model_path`` ships its own WhisperProcessor files.
+
+    The canonical-openai fallback should only fire when the local directory
+    is missing these files — not when the local load fails for other reasons
+    (cache/auth/path issues that would be masked by an unexpected HF Hub
+    download). ``preprocessor_config.json`` is the feature extractor; either
+    ``tokenizer.json`` or ``tokenizer_config.json`` covers the tokenizer
+    side.
+
+    The ``is True`` comparisons coerce the result to a strict boolean so a
+    mocked ``Path`` (whose ``is_file()`` returns a truthy ``MagicMock``)
+    reads as "files absent" — the caller's gate then falls through to the
+    existing fallback behavior instead of misclassifying a mock as a
+    complete local directory.
+    """
+    return (model_path / "preprocessor_config.json").is_file() is True and (
+        (model_path / "tokenizer.json").is_file() is True
+        or (model_path / "tokenizer_config.json").is_file() is True
+    )
+
+
+def _load_whisper_processor(model_path: Path):
+    """Load WhisperProcessor for ``model_path``, with canonical-openai fallback.
+
+    The local-load catch is narrow: only the "missing processor files"
+    scenario (the local directory lacks ``preprocessor_config.json`` /
+    tokenizer files) triggers the canonical fallback. A local directory
+    that *does* ship processor files but still raised propagates the error
+    so genuinely-broken local checkpoints (auth, cache, corrupt files)
+    surface their real cause instead of being masked by a network download.
+
+    The canonical fetch itself is best-effort graceful degradation: any
+    failure (offline mode, 401/404, network error, or a malformed canonical
+    config) is converted to a warning + ``None``, matching the pre-fix
+    "warn and set _processor=None" behavior. The user then gets the clear
+    "Processor not found" error at transcribe time.
+
+    Network: when the fallback fires, the canonical processor is fetched
+    from the HF Hub (~4 MB). Set ``HF_HUB_OFFLINE=1`` or
+    ``TRANSFORMERS_OFFLINE=1`` in air-gapped environments — transformers
+    raises an offline-mode error that is caught here and surfaced via the
+    warning path (preferable to a long network timeout).
+
+    Returns the processor or ``None`` if neither the local load nor the
+    canonical fallback succeeds.
+    """
+    try:
+        from transformers import WhisperProcessor
+    except ImportError as e:
+        warnings.warn(f"Could not load WhisperProcessor: {e}.")
+        return None
+
+    # Same expected-exception set as the fallback path below: OSError plus
+    # the HF Hub / network errors transformers raises when files aren't
+    # available (RepositoryNotFoundError, EntryNotFoundError, OfflineMode,
+    # RequestException). Imported lazily to keep the optional deps optional.
+    _expected_local_errors = [OSError]
+    # Import each HF error class separately so a missing one doesn't take
+    # out the whole catch list. Older huggingface_hub versions don't ship
+    # OfflineModeError; HfHubHTTPError has been stable since 0.16.
+    try:
+        from huggingface_hub.errors import HfHubHTTPError
+
+        _expected_local_errors.append(HfHubHTTPError)
+    except ImportError:
+        pass
+    try:
+        from huggingface_hub.errors import OfflineModeError
+
+        _expected_local_errors.append(OfflineModeError)
+    except ImportError:
+        pass
+    try:
+        from requests.exceptions import RequestException
+
+        _expected_local_errors.append(RequestException)
+    except ImportError:
+        pass
+
+    try:
+        return WhisperProcessor.from_pretrained(str(model_path))
+    except tuple(_expected_local_errors) as local_err:
+        # Only the "missing processor files" scenario should trigger the
+        # canonical fallback. A local directory that ships its own
+        # processor files but still raised indicates something else
+        # (auth, cache, env) — propagate so the user sees the real cause.
+        if _has_local_processor_files(model_path):
+            raise
+        canonical = _canonical_openai_whisper_repo(model_path)
+        if canonical is None:
+            warnings.warn(f"Could not load WhisperProcessor: {local_err}.")
+            return None
+        # The canonical fetch is best-effort graceful degradation: any
+        # failure (offline mode, 401/404, network error, or a malformed
+        # canonical config) degrades to a warning + ``None``, exactly as
+        # the pre-fix "warn and set _processor=None" path did. The user
+        # then sees the clear "Processor not found" error at transcribe
+        # time. The local-load catch above is the one that's narrowed, so
+        # genuinely-broken *local* checkpoints still surface their cause.
+        try:
+            processor = WhisperProcessor.from_pretrained(canonical)
+        except Exception as fallback_err:
+            warnings.warn(
+                f"Could not load WhisperProcessor locally or from {canonical}: "
+                f"local={local_err} fallback={fallback_err}"
+            )
+            return None
+        warnings.warn(
+            f"Loaded WhisperProcessor from {canonical} as fallback because "
+            f"{model_path} is missing processor files: {local_err}",
+            stacklevel=2,
+        )
+        return processor
+
+
 def sinusoids(length, channels, max_timescale=10000):
     """Returns sinusoids for positional embedding"""
     assert channels % 2 == 0
@@ -704,14 +898,7 @@ class Model(nn.Module):
         Returns:
             The model with processor initialized
         """
-        try:
-            from transformers import WhisperProcessor
-
-            processor = WhisperProcessor.from_pretrained(str(model_path))
-            model._processor = processor
-        except Exception as e:
-            model._processor = None
-            warnings.warn(f"Could not load WhisperProcessor: {e}.")
+        model._processor = _load_whisper_processor(Path(model_path))
 
         # Load alignment heads from generation_config.json for word-level timestamps
         gen_config_path = Path(model_path) / "generation_config.json"

--- a/mlx_audio/stt/tests/test_whisper_processor_fallback.py
+++ b/mlx_audio/stt/tests/test_whisper_processor_fallback.py
@@ -1,0 +1,323 @@
+"""Tests for Whisper post_load_hook canonical-openai processor fallback (#645).
+
+mlx-community whisper conversions ship weights only — no
+``preprocessor_config.json`` or tokenizer files — so
+``WhisperProcessor.from_pretrained(model_path)`` raises and the model
+ends up with ``_processor = None``. ``get_tokenizer()`` then crashes on
+the first ``generate()`` call.
+
+The fix attempts a fallback: read the architecture dimensions from
+``config.json`` and resolve to the canonical ``openai/whisper-*`` repo
+that produced this architecture. Identifying by dims is robust to
+arbitrary repo naming (``whisper-large-v3-mlx-4bit``,
+``whisper-base.en-mlx``) and user-renamed local directories.
+"""
+
+import json
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Canonical architecture signatures: each unique combination of dims maps to
+# exactly one openai/whisper-* repo. Sourced from openai/whisper config.json.
+_TINY = {
+    "n_audio_state": 384,
+    "n_mels": 80,
+    "n_audio_layer": 4,
+    "n_text_layer": 4,
+    "n_vocab": 51865,
+}
+_BASE = {
+    "n_audio_state": 512,
+    "n_mels": 80,
+    "n_audio_layer": 6,
+    "n_text_layer": 6,
+    "n_vocab": 51865,
+}
+_BASE_EN = {
+    "n_audio_state": 512,
+    "n_mels": 80,
+    "n_audio_layer": 6,
+    "n_text_layer": 6,
+    "n_vocab": 51864,
+}
+_MEDIUM = {
+    "n_audio_state": 1024,
+    "n_mels": 80,
+    "n_audio_layer": 24,
+    "n_text_layer": 24,
+    "n_vocab": 51865,
+}
+_LARGE_V3 = {
+    "n_audio_state": 1280,
+    "n_mels": 128,
+    "n_audio_layer": 32,
+    "n_text_layer": 32,
+    "n_vocab": 51866,
+}
+_LARGE_V3_TURBO = {
+    "n_audio_state": 1280,
+    "n_mels": 128,
+    "n_audio_layer": 32,
+    "n_text_layer": 4,
+    "n_vocab": 51866,
+}
+
+
+def _write_whisper_config(repo: Path, dims: dict, hf_format: bool = False) -> None:
+    """Write a whisper config.json with the given dims.
+
+    ``hf_format=True`` uses HuggingFace Transformers key names
+    (``d_model``, ``num_mel_bins``, ``encoder_layers``, …); the default
+    openai/mlx format uses ``n_audio_state``, ``n_mels``, etc.
+    """
+    if hf_format:
+        cfg = {
+            "model_type": "whisper",
+            "architectures": ["WhisperForConditionalGeneration"],
+            "d_model": dims["n_audio_state"],
+            "num_mel_bins": dims["n_mels"],
+            "encoder_layers": dims["n_audio_layer"],
+            "decoder_layers": dims["n_text_layer"],
+            "vocab_size": dims["n_vocab"],
+        }
+    else:
+        cfg = {"model_type": "whisper", **dims}
+    (repo / "config.json").write_text(json.dumps(cfg))
+
+
+class _FakeModel:
+    """post_load_hook only touches ``_processor`` / ``set_alignment_heads``."""
+
+    _processor = "unset"
+
+    def set_alignment_heads(self, *_args, **_kwargs):
+        pass
+
+
+class TestWhisperProcessorFallback(unittest.TestCase):
+    def setUp(self):
+        from mlx_audio.stt.models.whisper.whisper import Model
+
+        self.Model = Model
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmpdir = Path(self._tmp.name)
+
+    def _make_repo(self, name: str, dims=None, hf_format: bool = False) -> Path:
+        d = self.tmpdir / name
+        d.mkdir()
+        if dims is not None:
+            _write_whisper_config(d, dims, hf_format=hf_format)
+        return d
+
+    def _run_with_fake_processor(self, repo: Path, fake):
+        model = _FakeModel()
+        with patch("transformers.WhisperProcessor.from_pretrained", side_effect=fake):
+            self.Model.post_load_hook(model, repo)
+        return model
+
+    # -------- canonical resolution by architecture dims --------
+
+    def test_tiny_dims_resolve_regardless_of_dir_name(self):
+        """Architecture identified by dims, not by directory naming."""
+        repo = self._make_repo("renamed-experimental-dir", _TINY)
+        sentinel = MagicMock(name="canonical_processor")
+
+        def fake(path):
+            if str(path) == str(repo):
+                raise OSError("missing")
+            self.assertEqual(path, "openai/whisper-tiny")
+            return sentinel
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIs(model._processor, sentinel)
+
+    def test_quantized_variant_resolves_via_dims(self):
+        """A repo whose name has -4bit / -8bit suffix shares dims with its
+        unquantized peer; the matcher must look at dims, not the suffix."""
+        repo = self._make_repo("whisper-base-mlx-4bit", _BASE)
+        sentinel = MagicMock()
+
+        def fake(path):
+            if str(path) == str(repo):
+                raise OSError("missing")
+            self.assertEqual(path, "openai/whisper-base")
+            return sentinel
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIs(model._processor, sentinel)
+
+    def test_large_v3_distinguished_from_v2_by_mels_and_vocab(self):
+        repo = self._make_repo("whisper-large-v3-mlx", _LARGE_V3)
+        sentinel = MagicMock()
+
+        def fake(path):
+            if str(path) == str(repo):
+                raise OSError("missing")
+            self.assertEqual(path, "openai/whisper-large-v3")
+            return sentinel
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIs(model._processor, sentinel)
+
+    def test_large_v3_turbo_distinguished_by_decoder_layers(self):
+        """large-v3-turbo has n_text_layer=4; vanilla large-v3 has 32."""
+        repo = self._make_repo("whisper-large-v3-turbo", _LARGE_V3_TURBO)
+        sentinel = MagicMock()
+
+        def fake(path):
+            if str(path) == str(repo):
+                raise OSError("missing")
+            self.assertEqual(path, "openai/whisper-large-v3-turbo")
+            return sentinel
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIs(model._processor, sentinel)
+
+    def test_english_only_variant_resolves_to_dot_en(self):
+        """vocab_size=51864 (no language tokens) → .en variant."""
+        repo = self._make_repo("whisper-base.en-mlx", _BASE_EN)
+        sentinel = MagicMock()
+
+        def fake(path):
+            if str(path) == str(repo):
+                raise OSError("missing")
+            self.assertEqual(path, "openai/whisper-base.en")
+            return sentinel
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIs(model._processor, sentinel)
+
+    def test_hf_transformers_format_config_keys_resolve(self):
+        """Configs using d_model / num_mel_bins (HF Transformers naming) resolve."""
+        repo = self._make_repo("whisper-large-v3-asr-4bit", _LARGE_V3, hf_format=True)
+        sentinel = MagicMock()
+
+        def fake(path):
+            if str(path) == str(repo):
+                raise OSError("missing")
+            self.assertEqual(path, "openai/whisper-large-v3")
+            return sentinel
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIs(model._processor, sentinel)
+
+    # -------- behavior preservation / no-fallback paths --------
+
+    def test_missing_config_json_skips_fallback(self):
+        repo = self._make_repo("whisper-foo-mlx", dims=None)
+        attempts = []
+
+        def fake(path):
+            attempts.append(str(path))
+            raise OSError("missing")
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIsNone(model._processor)
+        self.assertEqual(attempts, [str(repo)])  # no canonical retry
+
+    def test_unknown_dims_skip_fallback(self):
+        weird = {**_TINY, "n_audio_state": 999}  # not a real whisper arch
+        repo = self._make_repo("whisper-experimental", weird)
+        attempts = []
+
+        def fake(path):
+            attempts.append(str(path))
+            raise OSError("missing")
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIsNone(model._processor)
+        self.assertEqual(attempts, [str(repo)])
+
+    def test_local_success_skips_fallback(self):
+        repo = self._make_repo("whisper-base-mlx", _BASE)
+        local_processor = MagicMock(name="local_processor")
+        attempts = []
+
+        def fake(path):
+            attempts.append(str(path))
+            return local_processor
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIs(model._processor, local_processor)
+        self.assertEqual(attempts, [str(repo)])
+
+    def test_value_error_propagates_no_fallback(self):
+        """Non-OSError exceptions (corrupt tokenizer.json, etc.) must propagate
+        rather than silently substitute the canonical processor — that would
+        be a vocab-mismatch silent corruption for fine-tuned local models."""
+        repo = self._make_repo("whisper-base-mlx", _BASE)
+
+        def fake(path):
+            raise ValueError("corrupt tokenizer.json")
+
+        model = _FakeModel()
+        with patch("transformers.WhisperProcessor.from_pretrained", side_effect=fake):
+            with self.assertRaises(ValueError):
+                self.Model.post_load_hook(model, repo)
+
+    def test_canonical_lookup_failure_leaves_processor_none(self):
+        repo = self._make_repo("whisper-tiny-mlx", _TINY)
+
+        def fake(path):
+            raise OSError("offline / 401 / etc")
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIsNone(model._processor)
+
+    def test_local_oserror_with_processor_files_propagates(self):
+        """If the local dir already ships processor files, an OSError on
+        ``WhisperProcessor.from_pretrained`` is something other than the
+        missing-files scenario (cache / auth / env). Propagate it instead
+        of triggering a network fallback that would mask the real cause.
+        """
+        repo = self._make_repo("whisper-tiny-mlx", _TINY)
+        # Make the dir look complete from the heuristic's perspective.
+        (repo / "preprocessor_config.json").write_text("{}")
+        (repo / "tokenizer_config.json").write_text("{}")
+
+        def fake(path):
+            raise OSError("auth failure on cached file")
+
+        model = _FakeModel()
+        with patch("transformers.WhisperProcessor.from_pretrained", side_effect=fake):
+            with self.assertRaises(OSError):
+                self.Model.post_load_hook(model, repo)
+
+    def test_corrupt_local_config_swallowed_at_arch_probe(self):
+        """A malformed config.json (JSONDecodeError) at architecture probe
+        falls through to the existing "warn + None" path, not a crash. The
+        canonical fallback can't fire because the signature is unknown."""
+        repo = self._make_repo("whisper-base-mlx", dims=None)
+        (repo / "config.json").write_text("{ this is not json")
+
+        def fake(path):
+            raise OSError("missing")
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIsNone(model._processor)
+
+    def test_fallback_failure_degrades_to_none(self):
+        """The canonical fetch is best-effort: any failure (offline, 401,
+        network error, or a malformed canonical config) degrades to a
+        warning + ``_processor = None`` rather than crashing the load. The
+        user then gets the clear "Processor not found" error at transcribe
+        time — the same graceful-degradation behavior as before the fix.
+        (The *local* load catch is the narrowed one; see
+        ``test_local_oserror_with_processor_files_propagates``.)"""
+        repo = self._make_repo("whisper-tiny-mlx", _TINY)
+
+        def fake(path):
+            if str(path) == str(repo):
+                raise OSError("missing")  # local: missing processor files
+            raise ValueError("malformed canonical processor response")
+
+        model = self._run_with_fake_processor(repo, fake)
+        self.assertIsNone(model._processor)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Loading any mlx-community whisper repo (`whisper-large-v3-mlx`, `whisper-base-mlx-4bit`, `whisper-base.en-mlx`, etc.) crashes on first transcription with `ValueError: Processor not found.` These repos ship weights only, so `WhisperProcessor.from_pretrained` raises during load — leaving `_processor = None` after only a warning.

This PR adds a fallback: read the architecture signature from `config.json` and retry the processor load against the canonical `openai/whisper-*` repo that produced this architecture. Processor files are architecture-independent (~4 MB), so a one-time download recovers transcription with no user intervention.

**Architecture-keyed lookup**

The 5-tuple `(n_audio_state, n_mels, n_audio_layer, n_text_layer, n_vocab)` from `config.json` uniquely identifies each canonical openai/whisper variant. `vocab_size = 51864` flags `.en` English-only models; `n_mels = 128` flags large-v3 family; `n_text_layer = 4` flags large-v3-turbo. large-v1 and large-v2 share dims (their processor files are interchangeable), so the lookup maps that signature to large-v2.

Identifying by dims rather than directory name handles the real mlx-community landscape uniformly — ~50+ repos with arbitrary suffixes like `-4bit`, `-8bit`, `-q4`, `-fp32`, `-asr-*`, plus user-renamed local directories. Both openai/mlx config keys (`n_audio_state`, `n_mels`, …) and HF Transformers keys (`d_model`, `num_mel_bins`, …) are read.

**Out of scope:** `distil-whisper/*` variants (different canonical org, different dim shapes for the decoder). Acknowledged as a comment in the architecture table; can be added in a follow-up if there is demand.

**Error handling (tightened after adversarial review)**

The fallback is conservative about *which* failures trigger it, so non-missing-file errors aren't masked by an unexpected HF Hub download:

- The local-load `OSError` only triggers the fallback when `model_path` is a local directory AND lacks the expected processor files (`preprocessor_config.json` plus `tokenizer.json` or `tokenizer_config.json`). Other `OSError` cases (cache permission, auth, env) propagate so the real cause is visible.
- The architecture-probe (`_whisper_arch_signature`) only swallows `json.JSONDecodeError`. `PermissionError` and other `OSError` from reading `config.json` propagate, surfacing real filesystem issues.
- Inside the fallback, only `OSError` and `ImportError` from the canonical load are converted to a warning + `None`. Unexpected exceptions (`ValueError`, `AttributeError`, etc.) propagate so silent masking of upstream regressions stays loud.

**Network behavior**

When the fallback fires, the canonical processor is fetched from the HF Hub (~4 MB). Set `HF_HUB_OFFLINE=1` or `TRANSFORMERS_OFFLINE=1` in air-gapped environments — transformers raises a clear offline-mode error rather than waiting on a network timeout. Documented in the load-helper docstring. Note: this introduces an implicit network access during what may have looked like a purely local `load_model()` call. Surfaced loudly via the post-fallback warning.

**Limitations**

Architecture-keyed dim collision is theoretically possible: a non-Whisper model with identical dims would also resolve to a canonical Whisper repo. Practically negligible given the 5-tuple's specificity (5-dim collision space).

Fine-tunes with vocabulary changes that nonetheless preserve the canonical 5-tuple would silently get the canonical tokenizer. This is the same caveat for any architecture-keyed lookup; mitigated by the existing local-load attempt running first and only failing through to the fallback when processor files are entirely absent.

**Behavior**

Before, on `mlx-community/whisper-base-mlx-4bit` (or any non-canonical name):

```
warning: Could not load WhisperProcessor: Can't load feature extractor for '<path>'...
model._processor = None
# later, on first generate():
ValueError: Processor not found. Make sure the model was loaded with a HuggingFace processor.
```

After:

```
warning: Loaded WhisperProcessor from openai/whisper-base as fallback because <path> is missing processor files: ...
model._processor = <WhisperProcessor>
# transcription succeeds
```

Repos whose architecture isn't a recognized canonical variant, or whose `config.json` is missing or malformed (`JSONDecodeError`), preserve the existing "warn and set `_processor = None`" behavior. A `config.json` that exists but can't be read for a real filesystem reason (`PermissionError`, other `OSError`) propagates rather than being masked. Local checkpoints that ship their own processor files but hit unrelated `OSError` (auth, cache) also propagate instead of silently substituting a canonical processor.

**Tests**

14 unittest cases covering dim-based resolution (tiny / quantized / large-v3 / large-v3-turbo / `.en` / HF Transformers config format), behavior preservation (missing config / unknown dims / local success), error propagation (`ValueError` propagates, canonical fallback failure leaves `_processor = None`, fallback `ValueError` propagates), and the tightened guards (local OSError with processor files present propagates instead of triggering fallback, corrupt JSON falls through to warn+None).

Fixes #645
