### PR TITLE
fix(granite-speech): transpose pointwise conv weights from PyTorch layout

### DIFF
--- a/mlx_audio/stt/models/granite_speech/granite_speech.py
+++ b/mlx_audio/stt/models/granite_speech/granite_speech.py
@@ -499,21 +499,10 @@ class Model(nn.Module):
                 # layout, while PyTorch uses (out_channels, in_channels, kernel_size).
                 # Models converted from PyTorch checkpoints need transposing; models
                 # already saved in MLX-native layout (e.g. bf16 safetensors) do not.
-                #
-                # depth_conv (kernel > 1):
-                #   PyTorch (out, 1, kernel) vs MLX (out, kernel, 1)
-                #   → transpose when shape[-1] > shape[-2]
-                #
-                # up_conv / down_conv (kernel == 1):
-                #   PyTorch (out, in, 1) vs MLX (out, 1, in)
-                #   → shape[-1]==1 with shape[-2]>1 is unambiguously PyTorch layout
-                #     (MLX native would have shape[-2]==1 instead)
-                #   The original condition (shape[-1] > shape[-2]) missed this case
-                #   because 1 > in_channels is always False.
-                if "depth_conv" in k:
-                    if v.shape[-1] > v.shape[-2]:
-                        v = v.transpose(0, 2, 1)
-                elif v.shape[-1] == 1 and v.shape[-2] > 1:  # up_conv / down_conv
+                # depth_conv (kernel > 1) needs the shape heuristic to distinguish
+                # PyTorch (out, 1, kernel) from MLX (out, kernel, 1). up_conv and
+                # down_conv always use kernel_size=1, so they are always transposed.
+                if "depth_conv" not in k or v.shape[-1] > v.shape[-2]:
                     v = v.transpose(0, 2, 1)
 
             sanitized[k] = v

--- a/mlx_audio/stt/models/granite_speech/granite_speech.py
+++ b/mlx_audio/stt/models/granite_speech/granite_speech.py
@@ -499,10 +499,21 @@ class Model(nn.Module):
                 # layout, while PyTorch uses (out_channels, in_channels, kernel_size).
                 # Models converted from PyTorch checkpoints need transposing; models
                 # already saved in MLX-native layout (e.g. bf16 safetensors) do not.
-                # Detect PyTorch layout by shape:
-                #   - depthwise (kernel > 1): PyTorch (out, 1, kernel) → shape[-1] > shape[-2]
-                #   - pointwise (kernel == 1): PyTorch (out, in, 1)   → shape[-2] > shape[-1]
-                if v.shape[-1] > v.shape[-2] or (v.shape[-1] == 1 and v.shape[-2] > 1):
+                #
+                # depth_conv (kernel > 1):
+                #   PyTorch (out, 1, kernel) vs MLX (out, kernel, 1)
+                #   → transpose when shape[-1] > shape[-2]
+                #
+                # up_conv / down_conv (kernel == 1):
+                #   PyTorch (out, in, 1) vs MLX (out, 1, in)
+                #   → shape[-1]==1 with shape[-2]>1 is unambiguously PyTorch layout
+                #     (MLX native would have shape[-2]==1 instead)
+                #   The original condition (shape[-1] > shape[-2]) missed this case
+                #   because 1 > in_channels is always False.
+                if "depth_conv" in k:
+                    if v.shape[-1] > v.shape[-2]:
+                        v = v.transpose(0, 2, 1)
+                elif v.shape[-1] == 1 and v.shape[-2] > 1:  # up_conv / down_conv
                     v = v.transpose(0, 2, 1)
 
             sanitized[k] = v

--- a/mlx_audio/stt/models/granite_speech/granite_speech.py
+++ b/mlx_audio/stt/models/granite_speech/granite_speech.py
@@ -499,10 +499,10 @@ class Model(nn.Module):
                 # layout, while PyTorch uses (out_channels, in_channels, kernel_size).
                 # Models converted from PyTorch checkpoints need transposing; models
                 # already saved in MLX-native layout (e.g. bf16 safetensors) do not.
-                # Detect PyTorch layout: shape[-1] > shape[-2] indicates
-                # (out, in, kernel) where kernel > in (true for depthwise convs).
-                # When kernel_size == 1 the shapes are symmetric and no-op either way.
-                if v.shape[-1] > v.shape[-2]:
+                # Detect PyTorch layout by shape:
+                #   - depthwise (kernel > 1): PyTorch (out, 1, kernel) → shape[-1] > shape[-2]
+                #   - pointwise (kernel == 1): PyTorch (out, in, 1)   → shape[-2] > shape[-1]
+                if v.shape[-1] > v.shape[-2] or (v.shape[-1] == 1 and v.shape[-2] > 1):
                     v = v.transpose(0, 2, 1)
 
             sanitized[k] = v


### PR DESCRIPTION
## Problem

Loading `ibm-granite/granite-4.0-1b-speech` (or `granite-speech-4.1-2b`) crashes with:

```
ValueError: [conv] Expect the input channels in the input and weight array to match
but got shapes - input: (1,1247,1024) and weight: (4096,1024,1)
```

## Root cause

`ConformerConvModule` has three conv layers. `sanitize` transposes weights from PyTorch layout `(out, in, kernel)` to MLX layout `(out, kernel, in)` using:

```python
if v.shape[-1] > v.shape[-2]:
    v = v.transpose(0, 2, 1)
```

This works for `depth_conv` (kernel > 1): PyTorch shape `(out, 1, kernel)` has `shape[-1] > shape[-2]`.

But `up_conv` and `down_conv` have `kernel_size=1`, so their PyTorch shape is `(out, in, 1)`. The condition evaluates as `1 > in_channels` = False — they are never transposed, leaving the weights in the wrong layout and causing the crash. The original comment _"When kernel_size == 1 the shapes are symmetric and no-op either way"_ is incorrect.

## Fix

Since `up_conv` and `down_conv` always have `kernel_size=1`, no shape heuristic is needed — they should always be transposed. Only `depth_conv` (kernel > 1) needs the shape check to distinguish PyTorch `(out, 1, kernel)` from MLX-native `(out, kernel, 1)`:

```python
if "depth_conv" not in k or v.shape[-1] > v.shape[-2]:
    v = v.transpose(0, 2, 1)
```

## Test

```python
from mlx_audio.stt import load
model = load("ibm-granite/granite-4.0-1b-speech")
result = model.generate("audio.wav")
print(result.text)
```

Previously crashed at the `up_conv` call; now transcribes correctly.