### PR TITLE
Fix mx.random.seed() no-op in Fish and Whisper samplers

### DIFF
--- a/mlx_audio/stt/models/whisper/decoding.py
+++ b/mlx_audio/stt/models/whisper/decoding.py
@@ -2,6 +2,7 @@
 
 import zlib
 from dataclasses import dataclass, field, replace
+from functools import partial
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import mlx.core as mx
@@ -293,7 +294,7 @@ class TokenDecoder:
         raise NotImplementedError
 
 
-@mx.compile
+@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def categorical(logits, temp):
     return mx.random.categorical(logits / temp)
 

--- a/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
+++ b/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import time
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Optional, Union
 
@@ -357,7 +358,7 @@ class DualARTransformer(nn.Module):
         return self.fast_output(x[:, -1])
 
 
-@mx.compile
+@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def _sample_logits(
     logits: mx.array, temperature: float, top_p: float, top_k: int
 ) -> mx.array:


### PR DESCRIPTION
## Bug

Bare `@mx.compile` captures `mx.random.state` at compile time and reuses it, so `mx.random.seed()` is a silent no-op for any wrapped function that calls `mx.random.*`. Two such functions in this repo:

- [`fish_speech.py:360`](https://github.com/Blaizzy/mlx-audio/blob/main/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py#L360) — `_sample_logits` (uses `mx.random.uniform`)
- [`whisper/decoding.py:296`](https://github.com/Blaizzy/mlx-audio/blob/main/mlx_audio/stt/models/whisper/decoding.py#L296) — `categorical` (uses `mx.random.categorical`)

## Fix

Re-decorate both with the state-threaded form, which this repo already uses correctly in moshi:

```python
@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
```

References:
- Same-repo precedent: [`moshi/utils/sampling.py:10`](https://github.com/Blaizzy/mlx-audio/blob/main/mlx_audio/sts/models/moshi/utils/sampling.py#L10) applies this pattern to `min_p_sampling` (and three sibling samplers).
- MLX docs: `mx.compile`'s [`inputs` / `outputs` parameters](https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.compile.html) — "These inputs will be captured during the function compilation" / "These outputs will be captured and updated in a compiled function."

## Reproduce

Against `main`, in a venv with `mlx-audio` installed:

```python
import mlx.core as mx
import mlx_audio.tts.models.fish_qwen3_omni.fish_speech as fish_mod
import mlx_audio.stt.models.whisper.decoding as whisper_mod

mx.random.seed(0)
logits = mx.random.normal(shape=(1, 1000)); mx.eval(logits)

for seed in (42, 7, 999):
    mx.random.seed(seed)
    print(seed, fish_mod._sample_logits(logits, 0.8, 0.8, 30).item(),
                whisper_mod.categorical(logits, 0.8).item())
```

On `main`:
```
42 647 791
7 647 791
999 647 791
```
Same token / same index across three seeds → `mx.random.seed()` is being ignored. After this PR, all three rows differ.

## Diff

```diff
--- a/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
+++ b/mlx_audio/tts/models/fish_qwen3_omni/fish_speech.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import time
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Optional, Union

@@ -357,7 +358,7 @@
         return self.fast_output(x[:, -1])


-@mx.compile
+@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def _sample_logits(
     logits: mx.array, temperature: float, top_p: float, top_k: int
 ) -> mx.array:
```

```diff
--- a/mlx_audio/stt/models/whisper/decoding.py
+++ b/mlx_audio/stt/models/whisper/decoding.py
@@ -2,6 +2,7 @@

 import zlib
 from dataclasses import dataclass, field, replace
+from functools import partial
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union

@@ -293,7 +294,7 @@ class TokenDecoder:
         raise NotImplementedError


-@mx.compile
+@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
 def categorical(logits, temp):
     return mx.random.categorical(logits / temp)
```

## Prior context

The Fish half was identified in #571 and proposed (bundled with four unrelated sampling changes) in #572. This PR is the random-state component only, descoped to be evaluated on its own. The Whisper half is the same pattern in a separate file.

---

*Authored with assistance from [Claude Code](https://claude.com/claude-code).*
