### PR TITLE
Pre-flight model load on streaming audio routes

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -39,6 +39,7 @@ from fastapi import (
 )
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+from huggingface_hub.errors import RepositoryNotFoundError
 from pydantic import BaseModel
 
 from mlx_audio.audio_io import read as audio_read
@@ -227,6 +228,31 @@ class SeparationTaskPayload:
 
 def _load_model_for_inference(model_name: str):
     return model_provider.load_model(model_name)
+
+
+async def _preflight_model_load(model_name: str) -> None:
+    """Load ``model_name`` synchronously and translate failures into HTTPException.
+
+    Routes that return a ``StreamingResponse`` commit the HTTP status + headers
+    before the body generator runs, so any failure inside the inference worker
+    surfaces as 200 OK with an empty body. Pre-flighting the load here lets the
+    framework's exception handlers turn the failure into a real HTTP error
+    response. Warm models are a no-op (``ModelProvider.load_model`` is cached).
+    """
+    try:
+        await asyncio.to_thread(_load_model_for_inference, model_name)
+    except HTTPException:
+        raise
+    except RepositoryNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model not found: {model_name!r} is not a known HuggingFace repo or local path",
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to load model {model_name!r}: {exc}",
+        ) from exc
 
 
 class STTExecutionAdapter(BaseModelExecutionAdapter):
@@ -900,6 +926,8 @@ async def tts_speech(payload: SpeechRequest, request: Request):
                 detail=f"Reference audio file not found: {payload.ref_audio}",
             )
 
+    await _preflight_model_load(payload.model)
+
     handle = get_inference_broker().submit(
         endpoint_kind="tts",
         model_name=payload.model,
@@ -965,6 +993,8 @@ async def stt_transcriptions(
     tmp = io.BytesIO(data)
     audio, sr = audio_read(tmp, always_2d=False)
     tmp.close()
+
+    await _preflight_model_load(payload.model)
 
     handle = get_inference_broker().submit(
         endpoint_kind="stt",

--- a/mlx_audio/tests/test_server.py
+++ b/mlx_audio/tests/test_server.py
@@ -2,9 +2,11 @@ import functools
 import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import mlx.core as mx
 import numpy as np
 import pytest
+from huggingface_hub.errors import RepositoryNotFoundError
 
 from mlx_audio.audio_io import read as audio_read
 from mlx_audio.audio_io import write as audio_write
@@ -121,7 +123,7 @@ def test_tts_speech(client, mock_model_provider):
         == "attachment; filename=speech.mp3"
     )
 
-    mock_model_provider.load_model.assert_called_once_with("test_tts_model")
+    mock_model_provider.load_model.assert_any_call("test_tts_model")
     mock_tts_model.generate.assert_called_once()
 
     args, kwargs = mock_tts_model.generate.call_args
@@ -134,6 +136,86 @@ def test_tts_speech(client, mock_model_provider):
         assert len(audio_data) > 0
     except Exception as e:
         pytest.fail(f"Failed to read or validate MP3 content: {e}")
+
+
+def _hf_repo_not_found(model_name: str) -> RepositoryNotFoundError:
+    """Construct a RepositoryNotFoundError shaped like the real HF client raises."""
+    request = httpx.Request("GET", f"https://huggingface.co/api/models/{model_name}")
+    response = httpx.Response(404, request=request)
+    return RepositoryNotFoundError(f"404 Client Error. Repository Not Found", response=response)
+
+
+def test_tts_speech_bad_model_returns_404_not_silent_200(client, mock_model_provider):
+    """Regression: bad model ids must surface as 4xx, not 200 OK with empty body.
+
+    Before the pre-flight fix, ``StreamingResponse`` committed the response
+    headers (200 OK) before the worker thread tried to load the model, so any
+    HuggingFace failure ended up as a clean zero-byte body. The fix loads the
+    model synchronously before returning the response.
+    """
+
+    def _raise(model_name):
+        raise _hf_repo_not_found(model_name)
+
+    mock_model_provider.load_model = MagicMock(side_effect=_raise)
+
+    payload = {
+        "model": "does-not-exist-on-hf",
+        "input": "hi",
+        "response_format": "wav",
+    }
+    response = client.post("/v1/audio/speech", json=payload)
+
+    assert response.status_code == 404, (
+        f"expected 404 for bad model, got {response.status_code} "
+        f"(body length={len(response.content)})"
+    )
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert "detail" in body
+    assert "does-not-exist-on-hf" in body["detail"]
+
+
+def test_tts_speech_load_failure_returns_500(client, mock_model_provider):
+    """Non-HF load failures should surface as 500 with a JSON detail body."""
+
+    def _raise(model_name):
+        raise RuntimeError("checkpoint is corrupted")
+
+    mock_model_provider.load_model = MagicMock(side_effect=_raise)
+
+    payload = {"model": "some-model", "input": "hi", "response_format": "wav"}
+    response = client.post("/v1/audio/speech", json=payload)
+
+    assert response.status_code == 500
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert "detail" in body
+    assert "some-model" in body["detail"]
+
+
+def test_stt_transcriptions_bad_model_returns_404(client, mock_model_provider):
+    """Same silent-200 hazard applies to the default ndjson streaming response."""
+
+    def _raise(model_name):
+        raise _hf_repo_not_found(model_name)
+
+    mock_model_provider.load_model = MagicMock(side_effect=_raise)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("test.mp3", _make_transcription_audio_buffer(), "audio/mp3")},
+        data={"model": "does-not-exist-on-hf"},
+    )
+
+    assert response.status_code == 404, (
+        f"expected 404 for bad model, got {response.status_code} "
+        f"(body length={len(response.content)})"
+    )
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert "detail" in body
+    assert "does-not-exist-on-hf" in body["detail"]
 
 
 def test_stt_transcriptions(client, mock_model_provider):
@@ -164,7 +246,7 @@ def test_stt_transcriptions(client, mock_model_provider):
     assert response.status_code == 200
     assert response.json() == {"text": "This is a test transcription."}
 
-    mock_model_provider.load_model.assert_called_once_with("test_stt_model")
+    mock_model_provider.load_model.assert_any_call("test_stt_model")
     mock_stt_model.generate.assert_called_once()
 
     assert mock_stt_model.generate.call_args[0][0].startswith("/tmp/")

--- a/mlx_audio/tests/test_server.py
+++ b/mlx_audio/tests/test_server.py
@@ -142,7 +142,9 @@ def _hf_repo_not_found(model_name: str) -> RepositoryNotFoundError:
     """Construct a RepositoryNotFoundError shaped like the real HF client raises."""
     request = httpx.Request("GET", f"https://huggingface.co/api/models/{model_name}")
     response = httpx.Response(404, request=request)
-    return RepositoryNotFoundError(f"404 Client Error. Repository Not Found", response=response)
+    return RepositoryNotFoundError(
+        f"404 Client Error. Repository Not Found", response=response
+    )
 
 
 def test_tts_speech_bad_model_returns_404_not_silent_200(client, mock_model_provider):


### PR DESCRIPTION
Fixes #724.

## What

`POST /v1/audio/speech` and `POST /v1/audio/transcriptions` (default `ndjson`) build a `StreamingResponse` before the broker worker touches the model. FastAPI commits the response (200 OK + headers) the moment the response object returns, so a worker failure (typically `huggingface_hub.RepositoryNotFoundError` from a bad model id) lands as a clean zero-byte body. Clients see a successful empty download.

Fix loads the model synchronously before constructing the response. Warm models stay free since `ModelProvider.load_model` is already cached. Maps `RepositoryNotFoundError` to 404 and any other load failure to 500, both with a JSON detail naming the model.

## Repro before / after

```sh
curl -i -X POST http://127.0.0.1:1237/v1/audio/speech \
  -H 'Content-Type: application/json' \
  -d '{"model":"does-not-exist","input":"hi","response_format":"wav"}'
```

Before:
```
HTTP/1.1 200 OK
content-type: audio/wav
(zero-byte body)
```

After:
```
HTTP/1.1 404 Not Found
content-type: application/json
{"detail":"Model not found: 'does-not-exist' is not a known HuggingFace repo or local path"}
```

## Tests

- 3 new regression tests in `test_server.py` cover bad-model 404, generic load-failure 500, and the STT route.
- Existing `test_tts_speech` / `test_stt_transcriptions` updated from `assert_called_once_with` to `assert_any_call` since pre-flight + worker now both call `load_model` (cheap, since the second call hits the in-memory cache).
- Full `test_server.py` suite passes (21/21).