### PR TITLE
fix: prevent AudioPlayer hang when short text falls below min_buffer_seconds threshold

### DIFF
--- a/mlx_audio/tts/audio_player.py
+++ b/mlx_audio/tts/audio_player.py
@@ -112,6 +112,14 @@ class AudioPlayer:
             self.start_stream()
 
     def wait_for_drain(self):
+        # If the stream never started (e.g. short text whose total audio fell
+        # below the min_buffer_seconds threshold), force-start it now so the
+        # buffered audio is played instead of hanging forever.
+        if not self.playing:
+            if self.buffered_samples() > 0:
+                self.start_stream()
+            else:
+                return
         return self.drain_event.wait()
 
     def stop(self):


### PR DESCRIPTION
## Problem

When generating audio for short text (e.g. `"Hello!"`), the program hangs indefinitely if `--stream` (or `--play`) is used.

**Root cause:**

`AudioPlayer.queue_audio()` only starts the stream once `buffered_samples() >= needed`, where:

```python
needed = int(self.arrival_rate * self.min_buffer_seconds)  # e.g. 24000 * 1.5 = 36000
```

For short text, the total audio produced (e.g. ~0.3–0.8 s ≈ 7,200–19,200 samples at 24 kHz) never reaches this threshold, so `start_stream()` is never called.

Then in `generate.py`:

```python
if play:
    player.wait_for_drain()   # blocks forever ← hang here
    player.stop()
```

`wait_for_drain()` calls `self.drain_event.wait()`. The `drain_event` is only set inside the stream callback (when the buffer runs dry) or in `flush()`. Since the stream never started, neither code path is reached, and the program hangs forever.

## Fix

In `wait_for_drain()`, check whether the stream has started before waiting:
- If not playing but there is buffered audio → force-start the stream, then wait for drain.
- If not playing and the buffer is empty → return immediately (nothing to play).

## Test

```bash
python -m mlx_audio.tts.generate \
  --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit \
  --text "Hello!" \
  --voice Chelsie \
  --stream
# Previously hung; now completes and plays audio correctly.
```