### PR TITLE
feat(vad): Add FSMN-VAD model support

### DIFF
--- a/mlx_audio/vad/models/fsmn/README.md
+++ b/mlx_audio/vad/models/fsmn/README.md
@@ -6,7 +6,7 @@ FSMN-VAD is a lightweight, low-latency VAD model based on Feedforward Sequential
 
 ## Supported Model
 
-['taylorsweeit/fsmn-vad-mlx'](https://huggingface.co/taylorsweeit/fsmn-vad-mlx)
+[mlx-community/fsmn-vad](https://huggingface.co/mlx-community/fsmn-vad)
 
 ## Usage
 
@@ -15,7 +15,7 @@ FSMN-VAD is a lightweight, low-latency VAD model based on Feedforward Sequential
 ```python
 from mlx_audio.vad import load
 
-model = load("taylorsweeit/fsmn-vad-mlx")
+model = load("mlx-community/fsmn-vad")
 ```
 
 ### Load from model class directly
@@ -24,7 +24,7 @@ model = load("taylorsweeit/fsmn-vad-mlx")
 from mlx_audio.vad.models.fsmn.model import Model
 
 # From HuggingFace
-model = Model.from_pretrained("taylorsweeit/fsmn-vad-mlx")
+model = Model.from_pretrained("mlx-community/fsmn-vad")
 
 # Or from a local directory
 model = Model.from_pretrained("/path/to/fsmn-vad-mlx")
@@ -42,20 +42,16 @@ print(segments)  # [[start_ms, end_ms], ...]
 From a numpy waveform:
 
 ```python
-import soundfile as sf
+from mlx_audio.audio_io import read
 
-waveform, sr = sf.read("audio.wav", dtype="float32")
+waveform, sr = read("audio.wav")
 segments = model.detect(waveform, sample_rate=sr)
 print(segments)  # [[270, 3790], [4460, 6900], ...]
 ```
 
 ## Requirements
 
-The FSMN-VAD frontend uses Kaldi-style fbank features via `torchaudio`:
-
-```bash
-pip install torch torchaudio soundfile
-```
+The FSMN-VAD frontend uses `mlx_audio.dsp.compute_fbank_kaldi`, `mlx_audio.audio_io.read`, and `mlx_audio.utils.resample_audio`, so no extra torch/torchaudio/soundfile dependencies are required.
 
 ## Architecture
 

--- a/mlx_audio/vad/models/fsmn/README.md
+++ b/mlx_audio/vad/models/fsmn/README.md
@@ -15,7 +15,7 @@ FSMN-VAD is a lightweight, low-latency VAD model based on Feedforward Sequential
 ```python
 from mlx_audio.vad import load
 
-model = load("mlx-community/fsmn-vad")
+model = load("taylorsweeit/fsmn-vad-mlx")
 ```
 
 ### Load from model class directly

--- a/mlx_audio/vad/models/fsmn/README.md
+++ b/mlx_audio/vad/models/fsmn/README.md
@@ -24,7 +24,7 @@ model = load("mlx-community/fsmn-vad")
 from mlx_audio.vad.models.fsmn.model import Model
 
 # From HuggingFace
-model = Model.from_pretrained("mlx-community/fsmn-vad")
+model = Model.from_pretrained("taylorsweeit/fsmn-vad-mlx")
 
 # Or from a local directory
 model = Model.from_pretrained("/path/to/fsmn-vad-mlx")

--- a/mlx_audio/vad/models/fsmn/README.md
+++ b/mlx_audio/vad/models/fsmn/README.md
@@ -6,7 +6,7 @@ FSMN-VAD is a lightweight, low-latency VAD model based on Feedforward Sequential
 
 ## Supported Model
 
-[`mlx-community/fsmn-vad`](https://huggingface.co/mlx-community/fsmn-vad)
+['taylorsweeit/fsmn-vad-mlx'](https://huggingface.co/taylorsweeit/fsmn-vad-mlx)
 
 ## Usage
 

--- a/mlx_audio/vad/models/fsmn/README.md
+++ b/mlx_audio/vad/models/fsmn/README.md
@@ -1,0 +1,80 @@
+# FSMN-VAD
+
+MLX port of the [FunASR FSMN-VAD](https://github.com/modelscope/FunASR) voice activity detector.
+
+FSMN-VAD is a lightweight, low-latency VAD model based on Feedforward Sequential Memory Networks (FSMN), widely used in Chinese speech processing pipelines.
+
+## Supported Model
+
+[`mlx-community/fsmn-vad`](https://huggingface.co/mlx-community/fsmn-vad)
+
+## Usage
+
+### Load via framework (recommended)
+
+```python
+from mlx_audio.vad import load
+
+model = load("mlx-community/fsmn-vad")
+```
+
+### Load from model class directly
+
+```python
+from mlx_audio.vad.models.fsmn.model import Model
+
+# From HuggingFace
+model = Model.from_pretrained("mlx-community/fsmn-vad")
+
+# Or from a local directory
+model = Model.from_pretrained("/path/to/fsmn-vad-mlx")
+```
+
+### Detect speech segments
+
+From a WAV file:
+
+```python
+segments = model.detect("audio.wav")
+print(segments)  # [[start_ms, end_ms], ...]
+```
+
+From a numpy waveform:
+
+```python
+import soundfile as sf
+
+waveform, sr = sf.read("audio.wav", dtype="float32")
+segments = model.detect(waveform, sample_rate=sr)
+print(segments)  # [[270, 3790], [4460, 6900], ...]
+```
+
+## Requirements
+
+The FSMN-VAD frontend uses Kaldi-style fbank features via `torchaudio`:
+
+```bash
+pip install torch torchaudio soundfile
+```
+
+## Architecture
+
+- **Frontend**: Kaldi fbank (80-dim) → LFR (5×1) → CMVN → 400-dim input
+- **Encoder**: 4-layer FSMN with causal depthwise convolution
+- **Output**: 248-class softmax (speech/silence/noise posteriors)
+- **Post-processing**: Configurable VAD state machine with silence/speech thresholds
+
+## Model Conversion
+
+To convert your own FSMN-VAD weights from FunASR (PyTorch) to MLX:
+
+```python
+from mlx_audio.vad.models.fsmn.convert import convert
+
+convert("path/to/funasr/fsmn-vad", output_dir="fsmn-vad-mlx")
+```
+
+## Reference
+
+- [FunASR](https://github.com/modelscope/FunASR) — Alibaba DAMO Academy
+- [FSMN paper](https://arxiv.org/abs/1803.05030) — Feedforward Sequential Memory Networks

--- a/mlx_audio/vad/models/fsmn/__init__.py
+++ b/mlx_audio/vad/models/fsmn/__init__.py
@@ -1,0 +1,19 @@
+from .config import FSMNEncoderConfig, ModelConfig
+from .encoder import FSMNBlock, FSMNEncoder, FSMNLayer
+from .model import Model
+
+DETECTION_HINTS = {
+    "architectures": ["fsmn_vad", "FsmnVAD", "FsmnVADStreaming"],
+    "config_keys": ["encoder", "fsmn_layers", "lorder"],
+    "path_patterns": ["fsmn", "fsmn-vad", "fsmn_vad"],
+}
+
+__all__ = [
+    "FSMNEncoderConfig",
+    "ModelConfig",
+    "Model",
+    "FSMNBlock",
+    "FSMNEncoder",
+    "FSMNLayer",
+    "DETECTION_HINTS",
+]

--- a/mlx_audio/vad/models/fsmn/config.py
+++ b/mlx_audio/vad/models/fsmn/config.py
@@ -1,0 +1,63 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import List
+
+from mlx_audio.base import BaseModelArgs
+
+
+@dataclass
+class FSMNEncoderConfig(BaseModelArgs):
+    """FSMN encoder configuration."""
+
+    input_dim: int = 400
+    input_affine_dim: int = 140
+    fsmn_layers: int = 4
+    linear_dim: int = 250
+    proj_dim: int = 128
+    lorder: int = 20
+    rorder: int = 0
+    lstride: int = 1
+    rstride: int = 0
+    output_affine_dim: int = 140
+    output_dim: int = 248
+
+
+@dataclass
+class ModelConfig(BaseModelArgs):
+    """FSMN-VAD model configuration."""
+
+    model_type: str = "fsmn"
+    architecture: str = "fsmn_vad"
+
+    # Encoder
+    encoder: FSMNEncoderConfig = None
+
+    # Frontend
+    sample_rate: int = 16000
+    n_mels: int = 80
+    frame_length: int = 25
+    frame_shift: int = 10
+    lfr_m: int = 5
+    lfr_n: int = 1
+
+    # VAD post-processing
+    max_end_silence_time: int = 800
+    max_start_silence_time: int = 3000
+    window_size_ms: int = 200
+    sil_to_speech_time_thres: int = 150
+    speech_to_sil_time_thres: int = 150
+    speech_noise_thres: float = 0.6
+    sil_pdf_ids: List[int] = field(default_factory=lambda: [0])
+    frame_in_ms: int = 10
+
+    def __post_init__(self):
+        if isinstance(self.encoder, dict):
+            self.encoder = FSMNEncoderConfig.from_dict(self.encoder)
+        if self.encoder is None:
+            self.encoder = FSMNEncoderConfig()
+
+    @classmethod
+    def from_dict(cls, params):
+        params = params.copy()
+        valid_keys = set(inspect.signature(cls).parameters.keys())
+        return cls(**{k: v for k, v in params.items() if k in valid_keys})

--- a/mlx_audio/vad/models/fsmn/convert.py
+++ b/mlx_audio/vad/models/fsmn/convert.py
@@ -4,6 +4,7 @@
 用法:
     python convert.py --pt-path /path/to/model.pt --output-dir /path/to/fsmn-vad-mlx
 """
+
 import argparse
 import json
 import os
@@ -35,7 +36,7 @@ def sanitize(pt_weights: dict) -> dict:
 
         # 1. 去掉 "encoder." 前缀
         if new_k.startswith("encoder."):
-            new_k = new_k[len("encoder."):]
+            new_k = new_k[len("encoder.") :]
 
         # 2. 去掉多余的 ".linear" (in_linear1.linear.weight → in_linear1.weight)
         #    但保留 fsmn.X.linear.weight (这是层内的 linear 投影)
@@ -56,7 +57,7 @@ def sanitize(pt_weights: dict) -> dict:
         new_k = new_k.replace(".affine.linear.", ".affine.")
 
         # 3. Conv2d 权重转换: [128, 1, 20, 1] → [128, 20, 1]
-        v_np = v.numpy() if hasattr(v, 'numpy') else v
+        v_np = v.numpy() if hasattr(v, "numpy") else v
         if "conv_left.weight" in new_k and len(v_np.shape) == 4:
             # PyTorch Conv2d depthwise: [out, in/groups, kH, kW] = [128, 1, 20, 1]
             # MLX Conv1d: [out, kernel_size, in/groups] = [128, 20, 1]
@@ -87,7 +88,7 @@ def convert(pt_path: str, output_dir: str):
     os.makedirs(output_dir, exist_ok=True)
 
     # 保存权重
-    
+
     mx.save_safetensors(os.path.join(output_dir, "model.safetensors"), mlx_weights)
 
     # 保存 config
@@ -122,7 +123,11 @@ def convert(pt_path: str, output_dir: str):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--pt-path", type=str, required=True, help="PyTorch model.pt 路径")
-    parser.add_argument("--output-dir", type=str, required=True, help="MLX 模型输出目录")
+    parser.add_argument(
+        "--pt-path", type=str, required=True, help="PyTorch model.pt 路径"
+    )
+    parser.add_argument(
+        "--output-dir", type=str, required=True, help="MLX 模型输出目录"
+    )
     args = parser.parse_args()
     convert(args.pt_path, args.output_dir)

--- a/mlx_audio/vad/models/fsmn/convert.py
+++ b/mlx_audio/vad/models/fsmn/convert.py
@@ -1,0 +1,128 @@
+"""
+一次性转换脚本: PyTorch fsmn-vad → MLX safetensors
+
+用法:
+    python convert.py --pt-path /path/to/model.pt --output-dir /path/to/fsmn-vad-mlx
+"""
+import argparse
+import json
+import os
+
+import mlx.core as mx
+import numpy as np
+
+
+def sanitize(pt_weights: dict) -> dict:
+    """
+    将 PyTorch fsmn-vad 权重映射到 MLX 命名和布局。
+
+    PyTorch key 格式:
+        encoder.in_linear1.linear.weight
+        encoder.fsmn.0.linear.linear.weight
+        encoder.fsmn.0.fsmn_block.conv_left.weight  [128, 1, 20, 1]
+        encoder.fsmn.0.affine.linear.weight
+
+    MLX key 格式:
+        in_linear1.weight
+        fsmn.0.linear.weight
+        fsmn.0.fsmn_block.conv_left.weight  [128, 20, 1]
+        fsmn.0.affine.weight
+    """
+    mlx_weights = {}
+
+    for k, v in pt_weights.items():
+        new_k = k
+
+        # 1. 去掉 "encoder." 前缀
+        if new_k.startswith("encoder."):
+            new_k = new_k[len("encoder."):]
+
+        # 2. 去掉多余的 ".linear" (in_linear1.linear.weight → in_linear1.weight)
+        #    但保留 fsmn.X.linear.weight (这是层内的 linear 投影)
+        #    规则: "xxx.linear.weight" 或 "xxx.linear.bias" 中 xxx 不以数字结尾时去掉
+        #    更简洁: 把 ".linear.linear." 替换为 ".linear."
+        #            把 "in_linear1.linear." 替换为 "in_linear1."
+        #            把 "in_linear2.linear." 替换为 "in_linear2."
+        #            把 "out_linear1.linear." 替换为 "out_linear1."
+        #            把 "out_linear2.linear." 替换为 "out_linear2."
+        #            把 ".affine.linear." 替换为 ".affine."
+        new_k = new_k.replace("in_linear1.linear.", "in_linear1.")
+        new_k = new_k.replace("in_linear2.linear.", "in_linear2.")
+        new_k = new_k.replace("out_linear1.linear.", "out_linear1.")
+        new_k = new_k.replace("out_linear2.linear.", "out_linear2.")
+        # fsmn.X.linear.linear.weight → fsmn.X.linear.weight
+        new_k = new_k.replace(".linear.linear.", ".linear.")
+        # fsmn.X.affine.linear.weight → fsmn.X.affine.weight
+        new_k = new_k.replace(".affine.linear.", ".affine.")
+
+        # 3. Conv2d 权重转换: [128, 1, 20, 1] → [128, 20, 1]
+        v_np = v.numpy() if hasattr(v, 'numpy') else v
+        if "conv_left.weight" in new_k and len(v_np.shape) == 4:
+            # PyTorch Conv2d depthwise: [out, in/groups, kH, kW] = [128, 1, 20, 1]
+            # MLX Conv1d: [out, kernel_size, in/groups] = [128, 20, 1]
+            v_np = v_np.squeeze(-1)  # [128, 1, 20]
+            v_np = v_np.transpose(0, 2, 1)  # [128, 20, 1]
+
+        mlx_weights[new_k] = mx.array(v_np)
+
+    return mlx_weights
+
+
+def convert(pt_path: str, output_dir: str):
+    """执行转换."""
+    import torch
+
+    print(f"[1] 加载 PyTorch 权重: {pt_path}")
+    pt_weights = torch.load(pt_path, map_location="cpu")
+    print(f"    共 {len(pt_weights)} 个参数")
+
+    print(f"[2] Sanitize 权重映射...")
+    mlx_weights = sanitize(pt_weights)
+
+    print("    映射结果:")
+    for k, v in mlx_weights.items():
+        print(f"      {k:45s} {list(v.shape)}")
+
+    print(f"\n[3] 保存到: {output_dir}")
+    os.makedirs(output_dir, exist_ok=True)
+
+    # 保存权重
+    
+    mx.save_safetensors(os.path.join(output_dir, "model.safetensors"), mlx_weights)
+
+    # 保存 config
+    config = {
+        "model_type": "fsmn",
+        "architecture": "fsmn_vad",
+        "encoder": {
+            "input_dim": 400,
+            "input_affine_dim": 140,
+            "fsmn_layers": 4,
+            "linear_dim": 250,
+            "proj_dim": 128,
+            "lorder": 20,
+            "rorder": 0,
+            "lstride": 1,
+            "rstride": 0,
+            "output_affine_dim": 140,
+            "output_dim": 248,
+        },
+        "sample_rate": 16000,
+        "n_mels": 80,
+        "frame_length": 25,
+        "frame_shift": 10,
+        "lfr_m": 5,
+        "lfr_n": 1,
+    }
+    with open(os.path.join(output_dir, "config.json"), "w") as f:
+        json.dump(config, f, indent=2)
+
+    print("    ✅ 转换完成!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pt-path", type=str, required=True, help="PyTorch model.pt 路径")
+    parser.add_argument("--output-dir", type=str, required=True, help="MLX 模型输出目录")
+    args = parser.parse_args()
+    convert(args.pt_path, args.output_dir)

--- a/mlx_audio/vad/models/fsmn/encoder.py
+++ b/mlx_audio/vad/models/fsmn/encoder.py
@@ -1,0 +1,125 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import FSMNEncoderConfig
+
+
+class FSMNBlock(nn.Module):
+    """
+    FSMN memory block: causal depthwise conv + residual (inside block).
+
+    FunASR logic: output = input + conv_left(padded_input)
+    """
+
+    def __init__(self, proj_dim: int, lorder: int, lstride: int = 1):
+        super().__init__()
+        self.proj_dim = proj_dim
+        self.lorder = lorder
+        self.lstride = lstride
+        self.pad_left = (lorder - 1) * lstride
+        self.conv_left = nn.Conv1d(
+            in_channels=proj_dim,
+            out_channels=proj_dim,
+            kernel_size=lorder,
+            stride=1,
+            groups=proj_dim,
+            bias=False,
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """
+        Args:
+            x: [batch, time, proj_dim]
+        Returns:
+            x + memory: [batch, time, proj_dim]
+        """
+        # [batch, time, proj_dim] → [batch, proj_dim, time] for padding
+        x_t = mx.transpose(x, axes=(0, 2, 1))
+        # Causal left padding
+        x_padded = mx.pad(x_t, pad_width=[(0, 0), (0, 0), (self.pad_left, 0)])
+        # [batch, proj_dim, time+pad] → [batch, time+pad, proj_dim] for Conv1d
+        x_padded = mx.transpose(x_padded, axes=(0, 2, 1))
+        # Depthwise conv: [batch, time, proj_dim]
+        y_left = self.conv_left(x_padded)
+        # Residual inside block: output = input + conv(input)
+        return x + y_left
+
+
+class FSMNLayer(nn.Module):
+    """
+    One FSMN BasicBlock (from FunASR):
+        x1 = linear(input)           # project down, no bias
+        x2 = fsmn_block(x1)          # x1 + conv(x1), residual inside
+        x3 = affine(x2)              # project up, with bias
+        x4 = relu(x3)
+        return x4                    # NO outer skip connection
+    """
+
+    def __init__(self, linear_dim: int, proj_dim: int, lorder: int, lstride: int = 1):
+        super().__init__()
+        self.linear = nn.Linear(linear_dim, proj_dim, bias=False)
+        self.fsmn_block = FSMNBlock(proj_dim, lorder, lstride)
+        self.affine = nn.Linear(proj_dim, linear_dim, bias=True)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """
+        Args:
+            x: [batch, time, linear_dim]
+        Returns:
+            [batch, time, linear_dim]
+        """
+        x1 = self.linear(x)
+        x2 = self.fsmn_block(x1)  # includes internal residual
+        x3 = self.affine(x2)
+        x4 = nn.relu(x3)
+        return x4
+
+
+class FSMNEncoder(nn.Module):
+    """
+    Full FSMN encoder (matches FunASR FSMN class):
+
+        x = in_linear1(input)         # AffineTransform, NO relu
+        x = in_linear2(x)             # AffineTransform, NO relu
+        x = relu(x)                   # single relu
+        x = fsmn_stack(x)             # 4x BasicBlock
+        x = out_linear1(x)            # AffineTransform, NO relu
+        x = out_linear2(x)            # AffineTransform, NO relu
+        x = softmax(x)
+    """
+
+    def __init__(self, config: FSMNEncoderConfig):
+        super().__init__()
+        self.config = config
+
+        self.in_linear1 = nn.Linear(config.input_dim, config.input_affine_dim, bias=True)
+        self.in_linear2 = nn.Linear(config.input_affine_dim, config.linear_dim, bias=True)
+
+        self.fsmn = [
+            FSMNLayer(config.linear_dim, config.proj_dim, config.lorder, config.lstride)
+            for _ in range(config.fsmn_layers)
+        ]
+
+        self.out_linear1 = nn.Linear(config.linear_dim, config.output_affine_dim, bias=True)
+        self.out_linear2 = nn.Linear(config.output_affine_dim, config.output_dim, bias=True)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """
+        Args:
+            x: [batch, time, input_dim] (400-dim)
+        Returns:
+            [batch, time, output_dim] (248-dim softmax)
+        """
+        x = self.in_linear1(x)      # no relu
+        x = self.in_linear2(x)      # no relu
+        x = nn.relu(x)              # single relu after in_linear2
+
+        for layer in self.fsmn:
+            x = layer(x)
+
+        x = self.out_linear1(x)     # no relu
+        x = self.out_linear2(x)     # no relu
+        x = mx.softmax(x, axis=-1)
+        return x

--- a/mlx_audio/vad/models/fsmn/encoder.py
+++ b/mlx_audio/vad/models/fsmn/encoder.py
@@ -94,16 +94,24 @@ class FSMNEncoder(nn.Module):
         super().__init__()
         self.config = config
 
-        self.in_linear1 = nn.Linear(config.input_dim, config.input_affine_dim, bias=True)
-        self.in_linear2 = nn.Linear(config.input_affine_dim, config.linear_dim, bias=True)
+        self.in_linear1 = nn.Linear(
+            config.input_dim, config.input_affine_dim, bias=True
+        )
+        self.in_linear2 = nn.Linear(
+            config.input_affine_dim, config.linear_dim, bias=True
+        )
 
         self.fsmn = [
             FSMNLayer(config.linear_dim, config.proj_dim, config.lorder, config.lstride)
             for _ in range(config.fsmn_layers)
         ]
 
-        self.out_linear1 = nn.Linear(config.linear_dim, config.output_affine_dim, bias=True)
-        self.out_linear2 = nn.Linear(config.output_affine_dim, config.output_dim, bias=True)
+        self.out_linear1 = nn.Linear(
+            config.linear_dim, config.output_affine_dim, bias=True
+        )
+        self.out_linear2 = nn.Linear(
+            config.output_affine_dim, config.output_dim, bias=True
+        )
 
     def __call__(self, x: mx.array) -> mx.array:
         """
@@ -112,14 +120,14 @@ class FSMNEncoder(nn.Module):
         Returns:
             [batch, time, output_dim] (248-dim softmax)
         """
-        x = self.in_linear1(x)      # no relu
-        x = self.in_linear2(x)      # no relu
-        x = nn.relu(x)              # single relu after in_linear2
+        x = self.in_linear1(x)  # no relu
+        x = self.in_linear2(x)  # no relu
+        x = nn.relu(x)  # single relu after in_linear2
 
         for layer in self.fsmn:
             x = layer(x)
 
-        x = self.out_linear1(x)     # no relu
-        x = self.out_linear2(x)     # no relu
+        x = self.out_linear1(x)  # no relu
+        x = self.out_linear2(x)  # no relu
         x = mx.softmax(x, axis=-1)
         return x

--- a/mlx_audio/vad/models/fsmn/frontend.py
+++ b/mlx_audio/vad/models/fsmn/frontend.py
@@ -1,0 +1,151 @@
+"""
+FSMN-VAD 前端特征提取: Kaldi-style Fbank + LFR + CMVN
+
+与 FunASR WavFrontendOnline 对齐:
+- Kaldi fbank (torchaudio.compliance.kaldi.fbank)
+- LFR: lfr_m=5, lfr_n=1
+- CMVN: Kaldi Nnet 格式 (AddShift + Rescale)
+"""
+import re
+import numpy as np
+from typing import Tuple, Optional
+
+
+def load_cmvn(cmvn_path: str) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    加载 Kaldi Nnet 格式的 CMVN 文件 (am.mvn).
+
+    格式:
+        <AddShift> D D
+        <LearnRateCoef> 0 [ shift_values ]
+        <Rescale> D D
+        <LearnRateCoef> 0 [ scale_values ]
+
+    CMVN 操作: output = (input + shift) * scale
+    """
+    with open(cmvn_path, "r") as f:
+        content = f.read()
+
+    # 提取 AddShift 后的数值
+    shift_match = re.search(r"<AddShift>.*?\[(.*?)\]", content, re.DOTALL)
+    scale_match = re.search(r"<Rescale>.*?\[(.*?)\]", content, re.DOTALL)
+
+    if not shift_match or not scale_match:
+        raise ValueError(f"Cannot parse CMVN file: {cmvn_path}")
+
+    shift = np.array([float(x) for x in shift_match.group(1).split()], dtype=np.float32)
+    scale = np.array([float(x) for x in scale_match.group(1).split()], dtype=np.float32)
+
+    return shift, scale
+
+
+def compute_fbank_kaldi(
+    waveform: np.ndarray,
+    sample_rate: int = 16000,
+    n_mels: int = 80,
+    frame_length_ms: int = 25,
+    frame_shift_ms: int = 10,
+    dither: float = 0.0,
+) -> np.ndarray:
+    """
+    Kaldi-style fbank 特征提取 (通过 torchaudio).
+
+    Returns:
+        fbank: [num_frames, n_mels] float32
+    """
+    import torch
+    import torchaudio
+
+    waveform_tensor = torch.from_numpy(waveform).unsqueeze(0).float() * (1 << 15)
+
+    fbank = torchaudio.compliance.kaldi.fbank(
+        waveform_tensor,
+        sample_frequency=sample_rate,
+        num_mel_bins=n_mels,
+        frame_length=frame_length_ms,
+        frame_shift=frame_shift_ms,
+        dither=dither,
+        window_type="hamming",
+    )
+
+    return fbank.numpy()  # [T, n_mels]
+
+
+def apply_lfr(
+    features: np.ndarray, lfr_m: int = 5, lfr_n: int = 1
+) -> np.ndarray:
+    """
+    Low Frame Rate: 每 lfr_n 帧取一帧, 每帧拼接 lfr_m 帧.
+
+    FunASR 的 LFR 对前几帧做左侧填充 (用第一帧重复).
+
+    Args:
+        features: [T, D]
+        lfr_m: 拼接帧数
+        lfr_n: 步长
+
+    Returns:
+        [T', D * lfr_m]
+    """
+    T, D = features.shape
+    # FunASR 左侧 padding: 重复第一帧 (lfr_m - 1) // 2 次
+    left_pad = (lfr_m - 1) // 2
+    if left_pad > 0:
+        pad_frames = np.tile(features[0:1], (left_pad, 1))
+        features = np.concatenate([pad_frames, features], axis=0)
+
+    T_padded = features.shape[0]
+    T_out = (T_padded + lfr_n - 1) // lfr_n
+    out = np.zeros((T_out, D * lfr_m), dtype=np.float32)
+
+    for i in range(T_out):
+        start = i * lfr_n
+        for j in range(lfr_m):
+            idx = start + j
+            if idx < T_padded:
+                out[i, j * D : (j + 1) * D] = features[idx]
+            else:
+                out[i, j * D : (j + 1) * D] = features[T_padded - 1]
+
+    return out
+
+
+def apply_cmvn(
+    features: np.ndarray, shift: np.ndarray, scale: np.ndarray
+) -> np.ndarray:
+    """
+    Kaldi CMVN: output = (input + shift) * scale
+    """
+    return (features + shift) * scale
+
+
+def extract_features(
+    waveform: np.ndarray,
+    sample_rate: int = 16000,
+    n_mels: int = 80,
+    frame_length_ms: int = 25,
+    frame_shift_ms: int = 10,
+    lfr_m: int = 5,
+    lfr_n: int = 1,
+    cmvn_path: Optional[str] = None,
+    cmvn_shift: Optional[np.ndarray] = None,
+    cmvn_scale: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """
+    Full frontend: waveform → Kaldi fbank → LFR → CMVN → [T', 400]
+
+    CMVN can be provided via file path (cmvn_path) or directly as
+    numpy arrays (cmvn_shift, cmvn_scale). Direct arrays take priority.
+    """
+    fbank = compute_fbank_kaldi(waveform, sample_rate, n_mels, frame_length_ms, frame_shift_ms)
+    features = apply_lfr(fbank, lfr_m, lfr_n)
+
+    if cmvn_shift is not None and cmvn_scale is not None:
+        if len(cmvn_shift) == features.shape[1]:
+            features = apply_cmvn(features, cmvn_shift, cmvn_scale)
+    elif cmvn_path is not None:
+        shift, scale = load_cmvn(cmvn_path)
+        if len(shift) == features.shape[1]:
+            features = apply_cmvn(features, shift, scale)
+
+    return features

--- a/mlx_audio/vad/models/fsmn/frontend.py
+++ b/mlx_audio/vad/models/fsmn/frontend.py
@@ -1,32 +1,35 @@
 """
-FSMN-VAD 前端特征提取: Kaldi-style Fbank + LFR + CMVN
+FSMN-VAD frontend: Kaldi-style Fbank + LFR + CMVN
 
-与 FunASR WavFrontendOnline 对齐:
-- Kaldi fbank (torchaudio.compliance.kaldi.fbank)
+Aligned with FunASR WavFrontendOnline:
+- Kaldi fbank via mlx_audio.dsp.compute_fbank_kaldi
 - LFR: lfr_m=5, lfr_n=1
-- CMVN: Kaldi Nnet 格式 (AddShift + Rescale)
+- CMVN: Kaldi Nnet format (AddShift + Rescale)
 """
+
 import re
+from typing import Optional, Tuple
+
+import mlx.core as mx
 import numpy as np
-from typing import Tuple, Optional
+from mlx_audio.dsp import compute_fbank_kaldi as _compute_fbank_kaldi
 
 
 def load_cmvn(cmvn_path: str) -> Tuple[np.ndarray, np.ndarray]:
     """
-    加载 Kaldi Nnet 格式的 CMVN 文件 (am.mvn).
+    Load Kaldi Nnet format CMVN file (am.mvn).
 
-    格式:
+    Format:
         <AddShift> D D
         <LearnRateCoef> 0 [ shift_values ]
         <Rescale> D D
         <LearnRateCoef> 0 [ scale_values ]
 
-    CMVN 操作: output = (input + shift) * scale
+    CMVN operation: output = (input + shift) * scale
     """
     with open(cmvn_path, "r") as f:
         content = f.read()
 
-    # 提取 AddShift 后的数值
     shift_match = re.search(r"<AddShift>.*?\[(.*?)\]", content, re.DOTALL)
     scale_match = re.search(r"<Rescale>.*?\[(.*?)\]", content, re.DOTALL)
 
@@ -39,7 +42,7 @@ def load_cmvn(cmvn_path: str) -> Tuple[np.ndarray, np.ndarray]:
     return shift, scale
 
 
-def compute_fbank_kaldi(
+def compute_fbank(
     waveform: np.ndarray,
     sample_rate: int = 16000,
     n_mels: int = 80,
@@ -48,47 +51,46 @@ def compute_fbank_kaldi(
     dither: float = 0.0,
 ) -> np.ndarray:
     """
-    Kaldi-style fbank 特征提取 (通过 torchaudio).
+    Kaldi-style fbank feature extraction via mlx_audio.dsp.
 
     Returns:
         fbank: [num_frames, n_mels] float32
     """
-    import torch
-    import torchaudio
+    win_len = int(sample_rate * frame_length_ms / 1000)
+    win_inc = int(sample_rate * frame_shift_ms / 1000)
 
-    waveform_tensor = torch.from_numpy(waveform).unsqueeze(0).float() * (1 << 15)
+    # Scale to Kaldi PCM convention (int16 range)
+    waveform_mx = mx.array(waveform * (1 << 15), dtype=mx.float32)
 
-    fbank = torchaudio.compliance.kaldi.fbank(
-        waveform_tensor,
-        sample_frequency=sample_rate,
-        num_mel_bins=n_mels,
-        frame_length=frame_length_ms,
-        frame_shift=frame_shift_ms,
+    fbank = _compute_fbank_kaldi(
+        waveform_mx,
+        sample_rate=sample_rate,
+        win_len=win_len,
+        win_inc=win_inc,
+        num_mels=n_mels,
+        win_type="hamming",
         dither=dither,
-        window_type="hamming",
     )
 
-    return fbank.numpy()  # [T, n_mels]
+    mx.eval(fbank)
+    return np.array(fbank)
 
 
-def apply_lfr(
-    features: np.ndarray, lfr_m: int = 5, lfr_n: int = 1
-) -> np.ndarray:
+def apply_lfr(features: np.ndarray, lfr_m: int = 5, lfr_n: int = 1) -> np.ndarray:
     """
-    Low Frame Rate: 每 lfr_n 帧取一帧, 每帧拼接 lfr_m 帧.
+    Low Frame Rate: stack lfr_m frames every lfr_n steps.
 
-    FunASR 的 LFR 对前几帧做左侧填充 (用第一帧重复).
+    FunASR pads the left side by repeating the first frame.
 
     Args:
         features: [T, D]
-        lfr_m: 拼接帧数
-        lfr_n: 步长
+        lfr_m: number of frames to stack
+        lfr_n: step size
 
     Returns:
         [T', D * lfr_m]
     """
     T, D = features.shape
-    # FunASR 左侧 padding: 重复第一帧 (lfr_m - 1) // 2 次
     left_pad = (lfr_m - 1) // 2
     if left_pad > 0:
         pad_frames = np.tile(features[0:1], (left_pad, 1))
@@ -132,12 +134,14 @@ def extract_features(
     cmvn_scale: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """
-    Full frontend: waveform → Kaldi fbank → LFR → CMVN → [T', 400]
+    Full frontend: waveform -> Kaldi fbank -> LFR -> CMVN -> [T', 400]
 
     CMVN can be provided via file path (cmvn_path) or directly as
     numpy arrays (cmvn_shift, cmvn_scale). Direct arrays take priority.
     """
-    fbank = compute_fbank_kaldi(waveform, sample_rate, n_mels, frame_length_ms, frame_shift_ms)
+    fbank = compute_fbank(
+        waveform, sample_rate, n_mels, frame_length_ms, frame_shift_ms
+    )
     features = apply_lfr(fbank, lfr_m, lfr_n)
 
     if cmvn_shift is not None and cmvn_scale is not None:

--- a/mlx_audio/vad/models/fsmn/frontend.py
+++ b/mlx_audio/vad/models/fsmn/frontend.py
@@ -12,6 +12,7 @@ from typing import Optional, Tuple
 
 import mlx.core as mx
 import numpy as np
+
 from mlx_audio.dsp import compute_fbank_kaldi as _compute_fbank_kaldi
 
 

--- a/mlx_audio/vad/models/fsmn/model.py
+++ b/mlx_audio/vad/models/fsmn/model.py
@@ -1,0 +1,156 @@
+"""
+FSMN-VAD: frontend + encoder + postprocess.
+
+Usage:
+    from mlx_audio.vad import load
+    model = load("mlx-community/fsmn-vad")
+    segments = model.detect("test.wav")
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .config import FSMNEncoderConfig, ModelConfig
+from .encoder import FSMNEncoder
+from .frontend import extract_features
+from .postprocess import VADPostProcess, VADXOptions
+
+
+class Model(nn.Module):
+    """FSMN-VAD: complete VAD pipeline."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.encoder = FSMNEncoder(config.encoder)
+
+        opts = VADXOptions(
+            sample_rate=config.sample_rate,
+            frame_in_ms=config.frame_in_ms,
+            frame_length_ms=config.frame_length,
+            window_size_ms=config.window_size_ms,
+            sil_to_speech_time_thres=config.sil_to_speech_time_thres,
+            speech_to_sil_time_thres=config.speech_to_sil_time_thres,
+            speech_noise_thres=config.speech_noise_thres,
+            max_end_silence_time=config.max_end_silence_time,
+            max_start_silence_time=config.max_start_silence_time,
+            sil_pdf_ids=config.sil_pdf_ids,
+        )
+        self.postprocess = VADPostProcess(opts)
+
+        self._cmvn_shift: Optional[np.ndarray] = None
+        self._cmvn_scale: Optional[np.ndarray] = None
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        sanitized = {}
+        for k, v in weights.items():
+            if not k.startswith("encoder."):
+                k = f"encoder.{k}"
+            sanitized[k] = v
+        return sanitized
+
+    @classmethod
+    def from_pretrained(cls, model_path: Union[str, Path], **kwargs) -> "Model":
+        """Load model from a local directory or HuggingFace repo.
+
+        Args:
+            model_path: local path or HuggingFace repo ID
+                (e.g. "mlx-community/fsmn-vad")
+        """
+        from mlx_audio.utils import get_model_path
+
+        model_path = get_model_path(str(model_path), **kwargs)
+
+        with open(model_path / "config.json") as f:
+            config_dict = json.load(f)
+        config = ModelConfig.from_dict(config_dict)
+
+        model = cls(config)
+
+        weights = mx.load(str(model_path / "model.safetensors"))
+        model.encoder.load_weights(list(weights.items()))
+
+        cmvn_json = model_path / "cmvn.json"
+        cmvn_mvn = model_path / "am.mvn"
+        if cmvn_json.exists():
+            with open(cmvn_json) as f:
+                cmvn = json.load(f)
+            model._cmvn_shift = np.array(cmvn["shift"], dtype=np.float32)
+            model._cmvn_scale = np.array(cmvn["scale"], dtype=np.float32)
+        elif cmvn_mvn.exists():
+            from .frontend import load_cmvn
+            shift, scale = load_cmvn(str(cmvn_mvn))
+            model._cmvn_shift = shift
+            model._cmvn_scale = scale
+
+        return model
+
+    @staticmethod
+    def post_load_hook(model: "Model", model_path: Path) -> "Model":
+        cmvn_path = Path(model_path) / "cmvn.json"
+        if cmvn_path.exists():
+            with open(cmvn_path) as f:
+                cmvn = json.load(f)
+            model._cmvn_shift = np.array(cmvn["shift"], dtype=np.float32)
+            model._cmvn_scale = np.array(cmvn["scale"], dtype=np.float32)
+        return model
+
+    def detect(
+        self,
+        audio: Union[str, np.ndarray],
+        sample_rate: int = 16000,
+    ) -> List[List[int]]:
+        """
+        Detect speech segments in audio.
+
+        Args:
+            audio: path to wav file or float32 numpy waveform
+            sample_rate: audio sample rate (used only when audio is numpy)
+
+        Returns:
+            [[start_ms, end_ms], ...] speech segment timestamps
+        """
+        if isinstance(audio, str):
+            import soundfile as sf
+
+            waveform, sr = sf.read(audio, dtype="float32")
+            if sr != self.config.sample_rate:
+                from scipy.signal import resample
+
+                waveform = resample(
+                    waveform, int(len(waveform) * self.config.sample_rate / sr)
+                ).astype(np.float32)
+        else:
+            waveform = audio.astype(np.float32)
+
+        features = extract_features(
+            waveform,
+            sample_rate=self.config.sample_rate,
+            n_mels=self.config.n_mels,
+            frame_length_ms=self.config.frame_length,
+            frame_shift_ms=self.config.frame_shift,
+            lfr_m=self.config.lfr_m,
+            lfr_n=self.config.lfr_n,
+            cmvn_shift=self._cmvn_shift,
+            cmvn_scale=self._cmvn_scale,
+        )
+
+        x = mx.array(features[np.newaxis, :, :])
+        scores = self.encoder(x)
+        mx.eval(scores)
+        scores_np = np.array(scores)
+
+        cache = self.postprocess.init_cache()
+        segments = self.postprocess.forward(
+            scores=scores_np,
+            waveform=waveform,
+            cache=cache,
+            is_final=True,
+        )
+
+        return segments

--- a/mlx_audio/vad/models/fsmn/model.py
+++ b/mlx_audio/vad/models/fsmn/model.py
@@ -84,6 +84,7 @@ class Model(nn.Module):
             model._cmvn_scale = np.array(cmvn["scale"], dtype=np.float32)
         elif cmvn_mvn.exists():
             from .frontend import load_cmvn
+
             shift, scale = load_cmvn(str(cmvn_mvn))
             model._cmvn_shift = shift
             model._cmvn_scale = scale
@@ -109,22 +110,23 @@ class Model(nn.Module):
         Detect speech segments in audio.
 
         Args:
-            audio: path to wav file or float32 numpy waveform
+            audio: path to audio file or float32 numpy waveform
             sample_rate: audio sample rate (used only when audio is numpy)
 
         Returns:
             [[start_ms, end_ms], ...] speech segment timestamps
         """
         if isinstance(audio, str):
-            import soundfile as sf
+            from mlx_audio.audio_io import read as audio_read
+            from mlx_audio.utils import resample_audio
 
-            waveform, sr = sf.read(audio, dtype="float32")
+            waveform, sr = audio_read(audio, dtype="float32")
+            if waveform.ndim > 1:
+                waveform = np.mean(waveform, axis=-1)
             if sr != self.config.sample_rate:
-                from scipy.signal import resample
-
-                waveform = resample(
-                    waveform, int(len(waveform) * self.config.sample_rate / sr)
-                ).astype(np.float32)
+                waveform = resample_audio(waveform, sr, self.config.sample_rate).astype(
+                    np.float32
+                )
         else:
             waveform = audio.astype(np.float32)
 

--- a/mlx_audio/vad/models/fsmn/postprocess.py
+++ b/mlx_audio/vad/models/fsmn/postprocess.py
@@ -1,0 +1,546 @@
+"""
+FSMN-VAD 后处理状态机
+
+从 FunASR fsmn_vad_streaming/model.py 移植，去掉 torch 依赖。
+所有 tensor 操作改为 numpy / 纯 Python。
+"""
+import math
+import numpy as np
+from enum import Enum
+from typing import List, Dict, Any, Optional
+
+
+class VadStateMachine(Enum):
+    kVadInStateStartPointNotDetected = 1
+    kVadInStateInSpeechSegment = 2
+    kVadInStateEndPointDetected = 3
+
+
+class FrameState(Enum):
+    kFrameStateInvalid = -1
+    kFrameStateSpeech = 1
+    kFrameStateSil = 0
+
+
+class AudioChangeState(Enum):
+    kChangeStateSpeech2Speech = 0
+    kChangeStateSpeech2Sil = 1
+    kChangeStateSil2Sil = 2
+    kChangeStateSil2Speech = 3
+    kChangeStateNoBegin = 4
+    kChangeStateInvalid = 5
+
+
+class VadDetectMode(Enum):
+    kVadSingleUtteranceDetectMode = 0
+    kVadMutipleUtteranceDetectMode = 1
+
+
+class VADXOptions:
+    def __init__(self, sample_rate=16000, detect_mode=1, snr_mode=0,
+                 max_end_silence_time=800, max_start_silence_time=3000,
+                 do_start_point_detection=True, do_end_point_detection=True,
+                 window_size_ms=200, sil_to_speech_time_thres=150,
+                 speech_to_sil_time_thres=150, speech_2_noise_ratio=1.0,
+                 do_extend=1, lookback_time_start_point=200,
+                 lookahead_time_end_point=100, max_single_segment_time=60000,
+                 nn_eval_block_size=8, dcd_block_size=4, snr_thres=-100.0,
+                 noise_frame_num_used_for_snr=100, decibel_thres=-100.0,
+                 speech_noise_thres=0.6, fe_prior_thres=1e-4,
+                 silence_pdf_num=1, sil_pdf_ids=None,
+                 speech_noise_thresh_low=-0.1, speech_noise_thresh_high=0.3,
+                 output_frame_probs=False, frame_in_ms=10, frame_length_ms=25,
+                 **kwargs):
+        self.sample_rate = sample_rate
+        self.detect_mode = detect_mode
+        self.snr_mode = snr_mode
+        self.max_end_silence_time = max_end_silence_time
+        self.max_start_silence_time = max_start_silence_time
+        self.do_start_point_detection = do_start_point_detection
+        self.do_end_point_detection = do_end_point_detection
+        self.window_size_ms = window_size_ms
+        self.sil_to_speech_time_thres = sil_to_speech_time_thres
+        self.speech_to_sil_time_thres = speech_to_sil_time_thres
+        self.speech_2_noise_ratio = speech_2_noise_ratio
+        self.do_extend = do_extend
+        self.lookback_time_start_point = lookback_time_start_point
+        self.lookahead_time_end_point = lookahead_time_end_point
+        self.max_single_segment_time = max_single_segment_time
+        self.nn_eval_block_size = nn_eval_block_size
+        self.dcd_block_size = dcd_block_size
+        self.snr_thres = snr_thres
+        self.noise_frame_num_used_for_snr = noise_frame_num_used_for_snr
+        self.decibel_thres = decibel_thres
+        self.speech_noise_thres = speech_noise_thres
+        self.fe_prior_thres = fe_prior_thres
+        self.silence_pdf_num = silence_pdf_num
+        self.sil_pdf_ids = sil_pdf_ids if sil_pdf_ids is not None else [0]
+        self.speech_noise_thresh_low = speech_noise_thresh_low
+        self.speech_noise_thresh_high = speech_noise_thresh_high
+        self.output_frame_probs = output_frame_probs
+        self.frame_in_ms = frame_in_ms
+        self.frame_length_ms = frame_length_ms
+
+
+class E2EVadSpeechBufWithDoa:
+    def __init__(self):
+        self.Reset()
+
+    def Reset(self):
+        self.start_ms = 0
+        self.end_ms = 0
+        self.buffer = []
+        self.contain_seg_start_point = False
+        self.contain_seg_end_point = False
+        self.doa = 0
+
+
+class E2EVadFrameProb:
+    def __init__(self):
+        self.noise_prob = 0.0
+        self.speech_prob = 0.0
+        self.score = 0.0
+        self.frame_id = 0
+        self.frm_state = 0
+
+
+class WindowDetector:
+    def __init__(self, window_size_ms, sil_to_speech_time, speech_to_sil_time, frame_size_ms):
+        self.window_size_ms = window_size_ms
+        self.frame_size_ms = frame_size_ms
+        self.win_size_frame = int(window_size_ms / frame_size_ms)
+        self.sil_to_speech_frmcnt_thres = int(sil_to_speech_time / frame_size_ms)
+        self.speech_to_sil_frmcnt_thres = int(speech_to_sil_time / frame_size_ms)
+        self.Reset()
+
+    def Reset(self):
+        self.cur_win_pos = 0
+        self.win_sum = 0
+        self.win_state = [0] * self.win_size_frame
+        self.pre_frame_state = FrameState.kFrameStateSil
+        self.cur_frame_state = FrameState.kFrameStateSil
+        self.voice_last_frame_count = 0
+        self.noise_last_frame_count = 0
+        self.hydre_frame_count = 0
+
+    def GetWinSize(self):
+        return self.win_size_frame
+
+    def DetectOneFrame(self, frameState, frame_count, cache={}):
+        cur_frame_state = 1 if frameState == FrameState.kFrameStateSpeech else 0
+        self.win_sum -= self.win_state[self.cur_win_pos]
+        self.win_sum += cur_frame_state
+        self.win_state[self.cur_win_pos] = cur_frame_state
+        self.cur_win_pos = (self.cur_win_pos + 1) % self.win_size_frame
+
+        if (self.pre_frame_state == FrameState.kFrameStateSil
+                and self.win_sum >= self.sil_to_speech_frmcnt_thres):
+            self.pre_frame_state = FrameState.kFrameStateSpeech
+            return AudioChangeState.kChangeStateSil2Speech
+        if (self.pre_frame_state == FrameState.kFrameStateSpeech
+                and self.win_sum <= self.speech_to_sil_frmcnt_thres):
+            self.pre_frame_state = FrameState.kFrameStateSil
+            return AudioChangeState.kChangeStateSpeech2Sil
+        if self.pre_frame_state == FrameState.kFrameStateSil:
+            return AudioChangeState.kChangeStateSil2Sil
+        if self.pre_frame_state == FrameState.kFrameStateSpeech:
+            return AudioChangeState.kChangeStateSpeech2Speech
+        return AudioChangeState.kChangeStateInvalid
+
+
+class Stats:
+    def __init__(self, sil_pdf_ids, max_end_sil_frame_cnt_thresh, speech_noise_thres):
+        self.data_buf_start_frame = 0
+        self.frm_cnt = 0
+        self.latest_confirmed_speech_frame = 0
+        self.lastest_confirmed_silence_frame = -1
+        self.continous_silence_frame_count = 0
+        self.vad_state_machine = VadStateMachine.kVadInStateStartPointNotDetected
+        self.confirmed_start_frame = -1
+        self.confirmed_end_frame = -1
+        self.number_end_time_detected = 0
+        self.sil_frame = 0
+        self.sil_pdf_ids = sil_pdf_ids
+        self.noise_average_decibel = -100.0
+        self.pre_end_silence_detected = False
+        self.next_seg = True
+        self.output_data_buf = []
+        self.output_data_buf_offset = 0
+        self.frame_probs = []
+        self.max_end_sil_frame_cnt_thresh = max_end_sil_frame_cnt_thresh
+        self.speech_noise_thres = speech_noise_thres
+        self.scores = None
+        self.max_time_out = False
+        self.decibel = []
+        self.data_buf = None
+        self.data_buf_all = None
+        self.waveform = None
+        self.last_drop_frames = 0
+
+
+class VADPostProcess:
+    """VAD 后处理: 帧级 scores + waveform → 语音段时间戳."""
+
+    def __init__(self, opts: VADXOptions):
+        self.vad_opts = opts
+
+    def init_cache(self):
+        cache = {}
+        cache["windows_detector"] = WindowDetector(
+            self.vad_opts.window_size_ms,
+            self.vad_opts.sil_to_speech_time_thres,
+            self.vad_opts.speech_to_sil_time_thres,
+            self.vad_opts.frame_in_ms,
+        )
+        cache["stats"] = Stats(
+            sil_pdf_ids=self.vad_opts.sil_pdf_ids,
+            max_end_sil_frame_cnt_thresh=(
+                self.vad_opts.max_end_silence_time - self.vad_opts.speech_to_sil_time_thres
+            ),
+            speech_noise_thres=self.vad_opts.speech_noise_thres,
+        )
+        return cache
+
+    def compute_decibel(self, waveform: np.ndarray, cache: dict):
+        """计算每帧分贝值. waveform: [samples] float32."""
+        sr = self.vad_opts.sample_rate
+        frame_sample_length = int(self.vad_opts.frame_length_ms * sr / 1000)
+        frame_shift_length = int(self.vad_opts.frame_in_ms * sr / 1000)
+
+        if cache["stats"].data_buf_all is None:
+            cache["stats"].data_buf_all = waveform.copy()
+            cache["stats"].data_buf = cache["stats"].data_buf_all
+        else:
+            cache["stats"].data_buf_all = np.concatenate([cache["stats"].data_buf_all, waveform])
+
+        offsets = np.arange(0, len(waveform) - frame_sample_length + 1, frame_shift_length)
+        if len(offsets) == 0:
+            return
+        frames = waveform[offsets[:, np.newaxis] + np.arange(frame_sample_length)]
+        decibel = 10 * np.log10(np.sum(np.square(frames), axis=1) + 1e-6)
+        cache["stats"].decibel.extend(decibel.tolist())
+
+    def compute_scores(self, scores: np.ndarray, cache: dict):
+        """累积 encoder 输出的 scores. scores: [1, T, D] numpy."""
+        num_frames = scores.shape[1]
+        self.vad_opts.nn_eval_block_size = num_frames
+        cache["stats"].frm_cnt += num_frames
+        if cache["stats"].scores is None:
+            cache["stats"].scores = scores
+        else:
+            cache["stats"].scores = np.concatenate([cache["stats"].scores, scores], axis=1)
+
+    def LatencyFrmNumAtStartPoint(self, cache):
+        vad_latency = cache["windows_detector"].GetWinSize()
+        if self.vad_opts.do_extend:
+            vad_latency += int(self.vad_opts.lookback_time_start_point / self.vad_opts.frame_in_ms)
+        return vad_latency
+
+    def PopDataBufTillFrame(self, frame_idx, cache):
+        while cache["stats"].data_buf_start_frame < frame_idx:
+            if len(cache["stats"].data_buf) >= int(
+                self.vad_opts.frame_in_ms * self.vad_opts.sample_rate / 1000
+            ):
+                cache["stats"].data_buf_start_frame += 1
+                cache["stats"].data_buf = cache["stats"].data_buf_all[
+                    (cache["stats"].data_buf_start_frame - cache["stats"].last_drop_frames)
+                    * int(self.vad_opts.frame_in_ms * self.vad_opts.sample_rate / 1000) :
+                ]
+            else:
+                break
+
+    def PopDataToOutputBuf(self, start_frm, frm_cnt, first_frm_is_start_point,
+                           last_frm_is_end_point, end_point_is_sent_end, cache):
+        self.PopDataBufTillFrame(start_frm, cache)
+        expected_sample_number = int(
+            frm_cnt * self.vad_opts.sample_rate * self.vad_opts.frame_in_ms / 1000
+        )
+        if last_frm_is_end_point:
+            extra_sample = max(0, int(
+                self.vad_opts.frame_length_ms * self.vad_opts.sample_rate / 1000
+                - self.vad_opts.sample_rate * self.vad_opts.frame_in_ms / 1000
+            ))
+            expected_sample_number += extra_sample
+        if end_point_is_sent_end:
+            expected_sample_number = max(expected_sample_number, len(cache["stats"].data_buf))
+
+        if len(cache["stats"].output_data_buf) == 0 or first_frm_is_start_point:
+            cache["stats"].output_data_buf.append(E2EVadSpeechBufWithDoa())
+            cache["stats"].output_data_buf[-1].Reset()
+            cache["stats"].output_data_buf[-1].start_ms = start_frm * self.vad_opts.frame_in_ms
+            cache["stats"].output_data_buf[-1].end_ms = cache["stats"].output_data_buf[-1].start_ms
+            cache["stats"].output_data_buf[-1].doa = 0
+        cur_seg = cache["stats"].output_data_buf[-1]
+        cache["stats"].data_buf_start_frame += frm_cnt
+        cur_seg.end_ms = (start_frm + frm_cnt) * self.vad_opts.frame_in_ms
+        if first_frm_is_start_point:
+            cur_seg.contain_seg_start_point = True
+        if last_frm_is_end_point:
+            cur_seg.contain_seg_end_point = True
+
+    def OnSilenceDetected(self, valid_frame, cache):
+        cache["stats"].lastest_confirmed_silence_frame = valid_frame
+        if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateStartPointNotDetected:
+            self.PopDataBufTillFrame(valid_frame, cache)
+
+    def OnVoiceDetected(self, valid_frame, cache):
+        cache["stats"].latest_confirmed_speech_frame = valid_frame
+        self.PopDataToOutputBuf(valid_frame, 1, False, False, False, cache)
+
+    def OnVoiceStart(self, start_frame, fake_result=False, cache=None):
+        if cache["stats"].confirmed_start_frame != -1:
+            pass
+        else:
+            cache["stats"].confirmed_start_frame = start_frame
+        if (not fake_result
+                and cache["stats"].vad_state_machine == VadStateMachine.kVadInStateStartPointNotDetected):
+            self.PopDataToOutputBuf(cache["stats"].confirmed_start_frame, 1, True, False, False, cache)
+
+    def OnVoiceEnd(self, end_frame, fake_result, is_last_frame, cache):
+        for t in range(cache["stats"].latest_confirmed_speech_frame + 1, end_frame):
+            self.OnVoiceDetected(t, cache)
+        if cache["stats"].confirmed_end_frame != -1:
+            pass
+        else:
+            cache["stats"].confirmed_end_frame = end_frame
+        if not fake_result:
+            cache["stats"].sil_frame = 0
+            self.PopDataToOutputBuf(cache["stats"].confirmed_end_frame, 1, False, True, is_last_frame, cache)
+        cache["stats"].number_end_time_detected += 1
+
+    def MaybeOnVoiceEndIfLastFrame(self, is_final_frame, cur_frm_idx, cache):
+        if is_final_frame:
+            self.OnVoiceEnd(cur_frm_idx, False, True, cache)
+            cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+
+    def ResetDetection(self, cache):
+        cache["stats"].continous_silence_frame_count = 0
+        cache["stats"].latest_confirmed_speech_frame = 0
+        cache["stats"].lastest_confirmed_silence_frame = -1
+        cache["stats"].confirmed_start_frame = -1
+        cache["stats"].confirmed_end_frame = -1
+        cache["stats"].vad_state_machine = VadStateMachine.kVadInStateStartPointNotDetected
+        cache["windows_detector"].Reset()
+        cache["stats"].sil_frame = 0
+        cache["stats"].frame_probs = []
+        if cache["stats"].output_data_buf:
+            assert cache["stats"].output_data_buf[-1].contain_seg_end_point
+            drop_frames = int(cache["stats"].output_data_buf[-1].end_ms / self.vad_opts.frame_in_ms)
+            real_drop_frames = drop_frames - cache["stats"].last_drop_frames
+            cache["stats"].last_drop_frames = drop_frames
+            cache["stats"].data_buf_all = cache["stats"].data_buf_all[
+                real_drop_frames * int(self.vad_opts.frame_in_ms * self.vad_opts.sample_rate / 1000) :
+            ]
+            cache["stats"].decibel = cache["stats"].decibel[real_drop_frames:]
+            cache["stats"].scores = cache["stats"].scores[:, real_drop_frames:, :]
+
+    def GetFrameState(self, t, cache):
+        frame_state = FrameState.kFrameStateInvalid
+        # Safe boundary check
+        if t < 0 or t >= len(cache["stats"].decibel):
+            return FrameState.kFrameStateSil
+        cur_decibel = cache["stats"].decibel[t]
+        cur_snr = cur_decibel - cache["stats"].noise_average_decibel
+        if cur_decibel < self.vad_opts.decibel_thres:
+            return FrameState.kFrameStateSil
+
+        sum_score = 0.0
+        if len(cache["stats"].sil_pdf_ids) > 0:
+            if len(cache["stats"].sil_pdf_ids) > 1:
+                sum_score = sum(
+                    float(cache["stats"].scores[0][t][sid])
+                    for sid in cache["stats"].sil_pdf_ids
+                )
+            else:
+                sum_score = float(cache["stats"].scores[0][t][cache["stats"].sil_pdf_ids[0]])
+            sum_score = max(min(sum_score, 1.0 - 1e-7), 1e-7)
+            noise_prob = math.log(sum_score) * self.vad_opts.speech_2_noise_ratio
+            sum_score = 1.0 - sum_score
+
+        speech_prob = math.log(sum_score)
+        if self.vad_opts.output_frame_probs:
+            fp = E2EVadFrameProb()
+            fp.noise_prob = noise_prob
+            fp.speech_prob = speech_prob
+            fp.score = sum_score
+            fp.frame_id = t
+            cache["stats"].frame_probs.append(fp)
+
+        if math.exp(speech_prob) >= math.exp(noise_prob) + cache["stats"].speech_noise_thres:
+            if cur_snr >= self.vad_opts.snr_thres and cur_decibel >= self.vad_opts.decibel_thres:
+                frame_state = FrameState.kFrameStateSpeech
+            else:
+                frame_state = FrameState.kFrameStateSil
+        else:
+            frame_state = FrameState.kFrameStateSil
+            if cache["stats"].noise_average_decibel < -99.9:
+                cache["stats"].noise_average_decibel = cur_decibel
+            else:
+                cache["stats"].noise_average_decibel = (
+                    cur_decibel
+                    + cache["stats"].noise_average_decibel
+                    * (self.vad_opts.noise_frame_num_used_for_snr - 1)
+                ) / self.vad_opts.noise_frame_num_used_for_snr
+
+        return frame_state
+
+    def DetectOneFrame(self, cur_frm_state, cur_frm_idx, is_final_frame, cache):
+        tmp_cur_frm_state = FrameState.kFrameStateInvalid
+        if cur_frm_state == FrameState.kFrameStateSpeech:
+            tmp_cur_frm_state = (FrameState.kFrameStateSpeech
+                                 if math.fabs(1.0) > self.vad_opts.fe_prior_thres
+                                 else FrameState.kFrameStateSil)
+        elif cur_frm_state == FrameState.kFrameStateSil:
+            tmp_cur_frm_state = FrameState.kFrameStateSil
+
+        state_change = cache["windows_detector"].DetectOneFrame(tmp_cur_frm_state, cur_frm_idx, cache)
+        frm_shift_in_ms = self.vad_opts.frame_in_ms
+
+        if state_change == AudioChangeState.kChangeStateSil2Speech:
+            cache["stats"].continous_silence_frame_count = 0
+            cache["stats"].pre_end_silence_detected = False
+            if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateStartPointNotDetected:
+                start_frame = max(
+                    cache["stats"].data_buf_start_frame,
+                    cur_frm_idx - self.LatencyFrmNumAtStartPoint(cache),
+                )
+                self.OnVoiceStart(start_frame, cache=cache)
+                cache["stats"].vad_state_machine = VadStateMachine.kVadInStateInSpeechSegment
+                for t in range(start_frame + 1, cur_frm_idx + 1):
+                    self.OnVoiceDetected(t, cache)
+            elif cache["stats"].vad_state_machine == VadStateMachine.kVadInStateInSpeechSegment:
+                for t in range(cache["stats"].latest_confirmed_speech_frame + 1, cur_frm_idx):
+                    self.OnVoiceDetected(t, cache)
+                if (cur_frm_idx - cache["stats"].confirmed_start_frame + 1
+                        > self.vad_opts.max_single_segment_time / frm_shift_in_ms):
+                    self.OnVoiceEnd(cur_frm_idx, False, False, cache)
+                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                elif not is_final_frame:
+                    self.OnVoiceDetected(cur_frm_idx, cache)
+                else:
+                    self.MaybeOnVoiceEndIfLastFrame(is_final_frame, cur_frm_idx, cache)
+
+        elif state_change == AudioChangeState.kChangeStateSpeech2Sil:
+            cache["stats"].continous_silence_frame_count = 0
+            if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateInSpeechSegment:
+                if (cur_frm_idx - cache["stats"].confirmed_start_frame + 1
+                        > self.vad_opts.max_single_segment_time / frm_shift_in_ms):
+                    self.OnVoiceEnd(cur_frm_idx, False, False, cache)
+                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                elif not is_final_frame:
+                    self.OnVoiceDetected(cur_frm_idx, cache)
+                else:
+                    self.MaybeOnVoiceEndIfLastFrame(is_final_frame, cur_frm_idx, cache)
+
+        elif state_change == AudioChangeState.kChangeStateSpeech2Speech:
+            cache["stats"].continous_silence_frame_count = 0
+            if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateInSpeechSegment:
+                if (cur_frm_idx - cache["stats"].confirmed_start_frame + 1
+                        > self.vad_opts.max_single_segment_time / frm_shift_in_ms):
+                    cache["stats"].max_time_out = True
+                    self.OnVoiceEnd(cur_frm_idx, False, False, cache)
+                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                elif not is_final_frame:
+                    self.OnVoiceDetected(cur_frm_idx, cache)
+                else:
+                    self.MaybeOnVoiceEndIfLastFrame(is_final_frame, cur_frm_idx, cache)
+
+        elif state_change == AudioChangeState.kChangeStateSil2Sil:
+            cache["stats"].continous_silence_frame_count += 1
+            if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateStartPointNotDetected:
+                if ((self.vad_opts.detect_mode == VadDetectMode.kVadSingleUtteranceDetectMode.value
+                     and cache["stats"].continous_silence_frame_count * frm_shift_in_ms
+                     > self.vad_opts.max_start_silence_time)
+                        or (is_final_frame and cache["stats"].number_end_time_detected == 0)):
+                    for t in range(cache["stats"].lastest_confirmed_silence_frame + 1, cur_frm_idx):
+                        self.OnSilenceDetected(t, cache)
+                    self.OnVoiceStart(0, True, cache)
+                    self.OnVoiceEnd(0, True, False, cache)
+                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                else:
+                    if cur_frm_idx >= self.LatencyFrmNumAtStartPoint(cache):
+                        self.OnSilenceDetected(
+                            cur_frm_idx - self.LatencyFrmNumAtStartPoint(cache), cache)
+            elif cache["stats"].vad_state_machine == VadStateMachine.kVadInStateInSpeechSegment:
+                if (cache["stats"].continous_silence_frame_count * frm_shift_in_ms
+                        >= cache["stats"].max_end_sil_frame_cnt_thresh):
+                    lookback_frame = int(cache["stats"].max_end_sil_frame_cnt_thresh / frm_shift_in_ms)
+                    if self.vad_opts.do_extend:
+                        lookback_frame -= int(self.vad_opts.lookahead_time_end_point / frm_shift_in_ms)
+                        lookback_frame -= 1
+                        lookback_frame = max(0, lookback_frame)
+                    self.OnVoiceEnd(cur_frm_idx - lookback_frame, False, False, cache)
+                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                elif (cur_frm_idx - cache["stats"].confirmed_start_frame + 1
+                      > self.vad_opts.max_single_segment_time / frm_shift_in_ms):
+                    self.OnVoiceEnd(cur_frm_idx, False, False, cache)
+                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                elif self.vad_opts.do_extend and not is_final_frame:
+                    if cache["stats"].continous_silence_frame_count <= int(
+                            self.vad_opts.lookahead_time_end_point / frm_shift_in_ms):
+                        self.OnVoiceDetected(cur_frm_idx, cache)
+                else:
+                    self.MaybeOnVoiceEndIfLastFrame(is_final_frame, cur_frm_idx, cache)
+
+        if (cache["stats"].vad_state_machine == VadStateMachine.kVadInStateEndPointDetected
+                and self.vad_opts.detect_mode == VadDetectMode.kVadMutipleUtteranceDetectMode.value):
+            self.ResetDetection(cache)
+
+    def DetectCommonFrames(self, cache):
+        if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateEndPointDetected:
+            return
+        for i in range(self.vad_opts.nn_eval_block_size - 1, -1, -1):
+            frame_state = self.GetFrameState(
+                cache["stats"].frm_cnt - 1 - i - cache["stats"].last_drop_frames, cache)
+            self.DetectOneFrame(frame_state, cache["stats"].frm_cnt - 1 - i, False, cache)
+
+    def DetectLastFrames(self, cache):
+        if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateEndPointDetected:
+            return
+        for i in range(self.vad_opts.nn_eval_block_size - 1, -1, -1):
+            frame_state = self.GetFrameState(
+                cache["stats"].frm_cnt - 1 - i - cache["stats"].last_drop_frames, cache)
+            if i != 0:
+                self.DetectOneFrame(frame_state, cache["stats"].frm_cnt - 1 - i, False, cache)
+            else:
+                self.DetectOneFrame(frame_state, cache["stats"].frm_cnt - 1, True, cache)
+
+    def forward(self, scores: np.ndarray, waveform: np.ndarray,
+                cache: dict, is_final: bool = True) -> List[List[int]]:
+        """
+        处理一个 chunk 的 scores 和 waveform.
+
+        Args:
+            scores: [1, T, D] numpy (encoder softmax 输出)
+            waveform: [samples] float32 numpy (原始波形)
+            cache: 状态缓存
+            is_final: 是否为最后一个 chunk
+
+        Returns:
+            segments: [[start_ms, end_ms], ...]
+        """
+        cache["stats"].waveform = waveform
+        self.compute_decibel(waveform, cache)
+        self.compute_scores(scores, cache)
+
+        if not is_final:
+            self.DetectCommonFrames(cache)
+        else:
+            self.DetectLastFrames(cache)
+
+        segments = []
+        if len(cache["stats"].output_data_buf) > 0:
+            for i in range(cache["stats"].output_data_buf_offset, len(cache["stats"].output_data_buf)):
+                if not is_final and (
+                    not cache["stats"].output_data_buf[i].contain_seg_start_point
+                    or not cache["stats"].output_data_buf[i].contain_seg_end_point
+                ):
+                    continue
+                segment = [
+                    cache["stats"].output_data_buf[i].start_ms,
+                    cache["stats"].output_data_buf[i].end_ms,
+                ]
+                cache["stats"].output_data_buf_offset += 1
+                segments.append(segment)
+
+        return segments

--- a/mlx_audio/vad/models/fsmn/postprocess.py
+++ b/mlx_audio/vad/models/fsmn/postprocess.py
@@ -4,10 +4,12 @@ FSMN-VAD 后处理状态机
 从 FunASR fsmn_vad_streaming/model.py 移植，去掉 torch 依赖。
 所有 tensor 操作改为 numpy / 纯 Python。
 """
+
 import math
-import numpy as np
 from enum import Enum
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
+
+import numpy as np
 
 
 class VadStateMachine(Enum):
@@ -37,20 +39,39 @@ class VadDetectMode(Enum):
 
 
 class VADXOptions:
-    def __init__(self, sample_rate=16000, detect_mode=1, snr_mode=0,
-                 max_end_silence_time=800, max_start_silence_time=3000,
-                 do_start_point_detection=True, do_end_point_detection=True,
-                 window_size_ms=200, sil_to_speech_time_thres=150,
-                 speech_to_sil_time_thres=150, speech_2_noise_ratio=1.0,
-                 do_extend=1, lookback_time_start_point=200,
-                 lookahead_time_end_point=100, max_single_segment_time=60000,
-                 nn_eval_block_size=8, dcd_block_size=4, snr_thres=-100.0,
-                 noise_frame_num_used_for_snr=100, decibel_thres=-100.0,
-                 speech_noise_thres=0.6, fe_prior_thres=1e-4,
-                 silence_pdf_num=1, sil_pdf_ids=None,
-                 speech_noise_thresh_low=-0.1, speech_noise_thresh_high=0.3,
-                 output_frame_probs=False, frame_in_ms=10, frame_length_ms=25,
-                 **kwargs):
+    def __init__(
+        self,
+        sample_rate=16000,
+        detect_mode=1,
+        snr_mode=0,
+        max_end_silence_time=800,
+        max_start_silence_time=3000,
+        do_start_point_detection=True,
+        do_end_point_detection=True,
+        window_size_ms=200,
+        sil_to_speech_time_thres=150,
+        speech_to_sil_time_thres=150,
+        speech_2_noise_ratio=1.0,
+        do_extend=1,
+        lookback_time_start_point=200,
+        lookahead_time_end_point=100,
+        max_single_segment_time=60000,
+        nn_eval_block_size=8,
+        dcd_block_size=4,
+        snr_thres=-100.0,
+        noise_frame_num_used_for_snr=100,
+        decibel_thres=-100.0,
+        speech_noise_thres=0.6,
+        fe_prior_thres=1e-4,
+        silence_pdf_num=1,
+        sil_pdf_ids=None,
+        speech_noise_thresh_low=-0.1,
+        speech_noise_thresh_high=0.3,
+        output_frame_probs=False,
+        frame_in_ms=10,
+        frame_length_ms=25,
+        **kwargs,
+    ):
         self.sample_rate = sample_rate
         self.detect_mode = detect_mode
         self.snr_mode = snr_mode
@@ -105,7 +126,9 @@ class E2EVadFrameProb:
 
 
 class WindowDetector:
-    def __init__(self, window_size_ms, sil_to_speech_time, speech_to_sil_time, frame_size_ms):
+    def __init__(
+        self, window_size_ms, sil_to_speech_time, speech_to_sil_time, frame_size_ms
+    ):
         self.window_size_ms = window_size_ms
         self.frame_size_ms = frame_size_ms
         self.win_size_frame = int(window_size_ms / frame_size_ms)
@@ -133,12 +156,16 @@ class WindowDetector:
         self.win_state[self.cur_win_pos] = cur_frame_state
         self.cur_win_pos = (self.cur_win_pos + 1) % self.win_size_frame
 
-        if (self.pre_frame_state == FrameState.kFrameStateSil
-                and self.win_sum >= self.sil_to_speech_frmcnt_thres):
+        if (
+            self.pre_frame_state == FrameState.kFrameStateSil
+            and self.win_sum >= self.sil_to_speech_frmcnt_thres
+        ):
             self.pre_frame_state = FrameState.kFrameStateSpeech
             return AudioChangeState.kChangeStateSil2Speech
-        if (self.pre_frame_state == FrameState.kFrameStateSpeech
-                and self.win_sum <= self.speech_to_sil_frmcnt_thres):
+        if (
+            self.pre_frame_state == FrameState.kFrameStateSpeech
+            and self.win_sum <= self.speech_to_sil_frmcnt_thres
+        ):
             self.pre_frame_state = FrameState.kFrameStateSil
             return AudioChangeState.kChangeStateSpeech2Sil
         if self.pre_frame_state == FrameState.kFrameStateSil:
@@ -195,7 +222,8 @@ class VADPostProcess:
         cache["stats"] = Stats(
             sil_pdf_ids=self.vad_opts.sil_pdf_ids,
             max_end_sil_frame_cnt_thresh=(
-                self.vad_opts.max_end_silence_time - self.vad_opts.speech_to_sil_time_thres
+                self.vad_opts.max_end_silence_time
+                - self.vad_opts.speech_to_sil_time_thres
             ),
             speech_noise_thres=self.vad_opts.speech_noise_thres,
         )
@@ -211,9 +239,13 @@ class VADPostProcess:
             cache["stats"].data_buf_all = waveform.copy()
             cache["stats"].data_buf = cache["stats"].data_buf_all
         else:
-            cache["stats"].data_buf_all = np.concatenate([cache["stats"].data_buf_all, waveform])
+            cache["stats"].data_buf_all = np.concatenate(
+                [cache["stats"].data_buf_all, waveform]
+            )
 
-        offsets = np.arange(0, len(waveform) - frame_sample_length + 1, frame_shift_length)
+        offsets = np.arange(
+            0, len(waveform) - frame_sample_length + 1, frame_shift_length
+        )
         if len(offsets) == 0:
             return
         frames = waveform[offsets[:, np.newaxis] + np.arange(frame_sample_length)]
@@ -228,12 +260,16 @@ class VADPostProcess:
         if cache["stats"].scores is None:
             cache["stats"].scores = scores
         else:
-            cache["stats"].scores = np.concatenate([cache["stats"].scores, scores], axis=1)
+            cache["stats"].scores = np.concatenate(
+                [cache["stats"].scores, scores], axis=1
+            )
 
     def LatencyFrmNumAtStartPoint(self, cache):
         vad_latency = cache["windows_detector"].GetWinSize()
         if self.vad_opts.do_extend:
-            vad_latency += int(self.vad_opts.lookback_time_start_point / self.vad_opts.frame_in_ms)
+            vad_latency += int(
+                self.vad_opts.lookback_time_start_point / self.vad_opts.frame_in_ms
+            )
         return vad_latency
 
     def PopDataBufTillFrame(self, frame_idx, cache):
@@ -243,32 +279,53 @@ class VADPostProcess:
             ):
                 cache["stats"].data_buf_start_frame += 1
                 cache["stats"].data_buf = cache["stats"].data_buf_all[
-                    (cache["stats"].data_buf_start_frame - cache["stats"].last_drop_frames)
-                    * int(self.vad_opts.frame_in_ms * self.vad_opts.sample_rate / 1000) :
+                    (
+                        cache["stats"].data_buf_start_frame
+                        - cache["stats"].last_drop_frames
+                    )
+                    * int(
+                        self.vad_opts.frame_in_ms * self.vad_opts.sample_rate / 1000
+                    ) :
                 ]
             else:
                 break
 
-    def PopDataToOutputBuf(self, start_frm, frm_cnt, first_frm_is_start_point,
-                           last_frm_is_end_point, end_point_is_sent_end, cache):
+    def PopDataToOutputBuf(
+        self,
+        start_frm,
+        frm_cnt,
+        first_frm_is_start_point,
+        last_frm_is_end_point,
+        end_point_is_sent_end,
+        cache,
+    ):
         self.PopDataBufTillFrame(start_frm, cache)
         expected_sample_number = int(
             frm_cnt * self.vad_opts.sample_rate * self.vad_opts.frame_in_ms / 1000
         )
         if last_frm_is_end_point:
-            extra_sample = max(0, int(
-                self.vad_opts.frame_length_ms * self.vad_opts.sample_rate / 1000
-                - self.vad_opts.sample_rate * self.vad_opts.frame_in_ms / 1000
-            ))
+            extra_sample = max(
+                0,
+                int(
+                    self.vad_opts.frame_length_ms * self.vad_opts.sample_rate / 1000
+                    - self.vad_opts.sample_rate * self.vad_opts.frame_in_ms / 1000
+                ),
+            )
             expected_sample_number += extra_sample
         if end_point_is_sent_end:
-            expected_sample_number = max(expected_sample_number, len(cache["stats"].data_buf))
+            expected_sample_number = max(
+                expected_sample_number, len(cache["stats"].data_buf)
+            )
 
         if len(cache["stats"].output_data_buf) == 0 or first_frm_is_start_point:
             cache["stats"].output_data_buf.append(E2EVadSpeechBufWithDoa())
             cache["stats"].output_data_buf[-1].Reset()
-            cache["stats"].output_data_buf[-1].start_ms = start_frm * self.vad_opts.frame_in_ms
-            cache["stats"].output_data_buf[-1].end_ms = cache["stats"].output_data_buf[-1].start_ms
+            cache["stats"].output_data_buf[-1].start_ms = (
+                start_frm * self.vad_opts.frame_in_ms
+            )
+            cache["stats"].output_data_buf[-1].end_ms = (
+                cache["stats"].output_data_buf[-1].start_ms
+            )
             cache["stats"].output_data_buf[-1].doa = 0
         cur_seg = cache["stats"].output_data_buf[-1]
         cache["stats"].data_buf_start_frame += frm_cnt
@@ -280,7 +337,10 @@ class VADPostProcess:
 
     def OnSilenceDetected(self, valid_frame, cache):
         cache["stats"].lastest_confirmed_silence_frame = valid_frame
-        if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateStartPointNotDetected:
+        if (
+            cache["stats"].vad_state_machine
+            == VadStateMachine.kVadInStateStartPointNotDetected
+        ):
             self.PopDataBufTillFrame(valid_frame, cache)
 
     def OnVoiceDetected(self, valid_frame, cache):
@@ -292,9 +352,14 @@ class VADPostProcess:
             pass
         else:
             cache["stats"].confirmed_start_frame = start_frame
-        if (not fake_result
-                and cache["stats"].vad_state_machine == VadStateMachine.kVadInStateStartPointNotDetected):
-            self.PopDataToOutputBuf(cache["stats"].confirmed_start_frame, 1, True, False, False, cache)
+        if (
+            not fake_result
+            and cache["stats"].vad_state_machine
+            == VadStateMachine.kVadInStateStartPointNotDetected
+        ):
+            self.PopDataToOutputBuf(
+                cache["stats"].confirmed_start_frame, 1, True, False, False, cache
+            )
 
     def OnVoiceEnd(self, end_frame, fake_result, is_last_frame, cache):
         for t in range(cache["stats"].latest_confirmed_speech_frame + 1, end_frame):
@@ -305,13 +370,17 @@ class VADPostProcess:
             cache["stats"].confirmed_end_frame = end_frame
         if not fake_result:
             cache["stats"].sil_frame = 0
-            self.PopDataToOutputBuf(cache["stats"].confirmed_end_frame, 1, False, True, is_last_frame, cache)
+            self.PopDataToOutputBuf(
+                cache["stats"].confirmed_end_frame, 1, False, True, is_last_frame, cache
+            )
         cache["stats"].number_end_time_detected += 1
 
     def MaybeOnVoiceEndIfLastFrame(self, is_final_frame, cur_frm_idx, cache):
         if is_final_frame:
             self.OnVoiceEnd(cur_frm_idx, False, True, cache)
-            cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+            cache["stats"].vad_state_machine = (
+                VadStateMachine.kVadInStateEndPointDetected
+            )
 
     def ResetDetection(self, cache):
         cache["stats"].continous_silence_frame_count = 0
@@ -319,17 +388,22 @@ class VADPostProcess:
         cache["stats"].lastest_confirmed_silence_frame = -1
         cache["stats"].confirmed_start_frame = -1
         cache["stats"].confirmed_end_frame = -1
-        cache["stats"].vad_state_machine = VadStateMachine.kVadInStateStartPointNotDetected
+        cache["stats"].vad_state_machine = (
+            VadStateMachine.kVadInStateStartPointNotDetected
+        )
         cache["windows_detector"].Reset()
         cache["stats"].sil_frame = 0
         cache["stats"].frame_probs = []
         if cache["stats"].output_data_buf:
             assert cache["stats"].output_data_buf[-1].contain_seg_end_point
-            drop_frames = int(cache["stats"].output_data_buf[-1].end_ms / self.vad_opts.frame_in_ms)
+            drop_frames = int(
+                cache["stats"].output_data_buf[-1].end_ms / self.vad_opts.frame_in_ms
+            )
             real_drop_frames = drop_frames - cache["stats"].last_drop_frames
             cache["stats"].last_drop_frames = drop_frames
             cache["stats"].data_buf_all = cache["stats"].data_buf_all[
-                real_drop_frames * int(self.vad_opts.frame_in_ms * self.vad_opts.sample_rate / 1000) :
+                real_drop_frames
+                * int(self.vad_opts.frame_in_ms * self.vad_opts.sample_rate / 1000) :
             ]
             cache["stats"].decibel = cache["stats"].decibel[real_drop_frames:]
             cache["stats"].scores = cache["stats"].scores[:, real_drop_frames:, :]
@@ -352,7 +426,9 @@ class VADPostProcess:
                     for sid in cache["stats"].sil_pdf_ids
                 )
             else:
-                sum_score = float(cache["stats"].scores[0][t][cache["stats"].sil_pdf_ids[0]])
+                sum_score = float(
+                    cache["stats"].scores[0][t][cache["stats"].sil_pdf_ids[0]]
+                )
             sum_score = max(min(sum_score, 1.0 - 1e-7), 1e-7)
             noise_prob = math.log(sum_score) * self.vad_opts.speech_2_noise_ratio
             sum_score = 1.0 - sum_score
@@ -366,8 +442,14 @@ class VADPostProcess:
             fp.frame_id = t
             cache["stats"].frame_probs.append(fp)
 
-        if math.exp(speech_prob) >= math.exp(noise_prob) + cache["stats"].speech_noise_thres:
-            if cur_snr >= self.vad_opts.snr_thres and cur_decibel >= self.vad_opts.decibel_thres:
+        if (
+            math.exp(speech_prob)
+            >= math.exp(noise_prob) + cache["stats"].speech_noise_thres
+        ):
+            if (
+                cur_snr >= self.vad_opts.snr_thres
+                and cur_decibel >= self.vad_opts.decibel_thres
+            ):
                 frame_state = FrameState.kFrameStateSpeech
             else:
                 frame_state = FrameState.kFrameStateSil
@@ -387,34 +469,52 @@ class VADPostProcess:
     def DetectOneFrame(self, cur_frm_state, cur_frm_idx, is_final_frame, cache):
         tmp_cur_frm_state = FrameState.kFrameStateInvalid
         if cur_frm_state == FrameState.kFrameStateSpeech:
-            tmp_cur_frm_state = (FrameState.kFrameStateSpeech
-                                 if math.fabs(1.0) > self.vad_opts.fe_prior_thres
-                                 else FrameState.kFrameStateSil)
+            tmp_cur_frm_state = (
+                FrameState.kFrameStateSpeech
+                if math.fabs(1.0) > self.vad_opts.fe_prior_thres
+                else FrameState.kFrameStateSil
+            )
         elif cur_frm_state == FrameState.kFrameStateSil:
             tmp_cur_frm_state = FrameState.kFrameStateSil
 
-        state_change = cache["windows_detector"].DetectOneFrame(tmp_cur_frm_state, cur_frm_idx, cache)
+        state_change = cache["windows_detector"].DetectOneFrame(
+            tmp_cur_frm_state, cur_frm_idx, cache
+        )
         frm_shift_in_ms = self.vad_opts.frame_in_ms
 
         if state_change == AudioChangeState.kChangeStateSil2Speech:
             cache["stats"].continous_silence_frame_count = 0
             cache["stats"].pre_end_silence_detected = False
-            if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateStartPointNotDetected:
+            if (
+                cache["stats"].vad_state_machine
+                == VadStateMachine.kVadInStateStartPointNotDetected
+            ):
                 start_frame = max(
                     cache["stats"].data_buf_start_frame,
                     cur_frm_idx - self.LatencyFrmNumAtStartPoint(cache),
                 )
                 self.OnVoiceStart(start_frame, cache=cache)
-                cache["stats"].vad_state_machine = VadStateMachine.kVadInStateInSpeechSegment
+                cache["stats"].vad_state_machine = (
+                    VadStateMachine.kVadInStateInSpeechSegment
+                )
                 for t in range(start_frame + 1, cur_frm_idx + 1):
                     self.OnVoiceDetected(t, cache)
-            elif cache["stats"].vad_state_machine == VadStateMachine.kVadInStateInSpeechSegment:
-                for t in range(cache["stats"].latest_confirmed_speech_frame + 1, cur_frm_idx):
+            elif (
+                cache["stats"].vad_state_machine
+                == VadStateMachine.kVadInStateInSpeechSegment
+            ):
+                for t in range(
+                    cache["stats"].latest_confirmed_speech_frame + 1, cur_frm_idx
+                ):
                     self.OnVoiceDetected(t, cache)
-                if (cur_frm_idx - cache["stats"].confirmed_start_frame + 1
-                        > self.vad_opts.max_single_segment_time / frm_shift_in_ms):
+                if (
+                    cur_frm_idx - cache["stats"].confirmed_start_frame + 1
+                    > self.vad_opts.max_single_segment_time / frm_shift_in_ms
+                ):
                     self.OnVoiceEnd(cur_frm_idx, False, False, cache)
-                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                    cache["stats"].vad_state_machine = (
+                        VadStateMachine.kVadInStateEndPointDetected
+                    )
                 elif not is_final_frame:
                     self.OnVoiceDetected(cur_frm_idx, cache)
                 else:
@@ -422,11 +522,18 @@ class VADPostProcess:
 
         elif state_change == AudioChangeState.kChangeStateSpeech2Sil:
             cache["stats"].continous_silence_frame_count = 0
-            if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateInSpeechSegment:
-                if (cur_frm_idx - cache["stats"].confirmed_start_frame + 1
-                        > self.vad_opts.max_single_segment_time / frm_shift_in_ms):
+            if (
+                cache["stats"].vad_state_machine
+                == VadStateMachine.kVadInStateInSpeechSegment
+            ):
+                if (
+                    cur_frm_idx - cache["stats"].confirmed_start_frame + 1
+                    > self.vad_opts.max_single_segment_time / frm_shift_in_ms
+                ):
                     self.OnVoiceEnd(cur_frm_idx, False, False, cache)
-                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                    cache["stats"].vad_state_machine = (
+                        VadStateMachine.kVadInStateEndPointDetected
+                    )
                 elif not is_final_frame:
                     self.OnVoiceDetected(cur_frm_idx, cache)
                 else:
@@ -434,12 +541,19 @@ class VADPostProcess:
 
         elif state_change == AudioChangeState.kChangeStateSpeech2Speech:
             cache["stats"].continous_silence_frame_count = 0
-            if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateInSpeechSegment:
-                if (cur_frm_idx - cache["stats"].confirmed_start_frame + 1
-                        > self.vad_opts.max_single_segment_time / frm_shift_in_ms):
+            if (
+                cache["stats"].vad_state_machine
+                == VadStateMachine.kVadInStateInSpeechSegment
+            ):
+                if (
+                    cur_frm_idx - cache["stats"].confirmed_start_frame + 1
+                    > self.vad_opts.max_single_segment_time / frm_shift_in_ms
+                ):
                     cache["stats"].max_time_out = True
                     self.OnVoiceEnd(cur_frm_idx, False, False, cache)
-                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                    cache["stats"].vad_state_machine = (
+                        VadStateMachine.kVadInStateEndPointDetected
+                    )
                 elif not is_final_frame:
                     self.OnVoiceDetected(cur_frm_idx, cache)
                 else:
@@ -447,66 +561,115 @@ class VADPostProcess:
 
         elif state_change == AudioChangeState.kChangeStateSil2Sil:
             cache["stats"].continous_silence_frame_count += 1
-            if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateStartPointNotDetected:
-                if ((self.vad_opts.detect_mode == VadDetectMode.kVadSingleUtteranceDetectMode.value
-                     and cache["stats"].continous_silence_frame_count * frm_shift_in_ms
-                     > self.vad_opts.max_start_silence_time)
-                        or (is_final_frame and cache["stats"].number_end_time_detected == 0)):
-                    for t in range(cache["stats"].lastest_confirmed_silence_frame + 1, cur_frm_idx):
+            if (
+                cache["stats"].vad_state_machine
+                == VadStateMachine.kVadInStateStartPointNotDetected
+            ):
+                if (
+                    self.vad_opts.detect_mode
+                    == VadDetectMode.kVadSingleUtteranceDetectMode.value
+                    and cache["stats"].continous_silence_frame_count * frm_shift_in_ms
+                    > self.vad_opts.max_start_silence_time
+                ) or (is_final_frame and cache["stats"].number_end_time_detected == 0):
+                    for t in range(
+                        cache["stats"].lastest_confirmed_silence_frame + 1, cur_frm_idx
+                    ):
                         self.OnSilenceDetected(t, cache)
                     self.OnVoiceStart(0, True, cache)
                     self.OnVoiceEnd(0, True, False, cache)
-                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                    cache["stats"].vad_state_machine = (
+                        VadStateMachine.kVadInStateEndPointDetected
+                    )
                 else:
                     if cur_frm_idx >= self.LatencyFrmNumAtStartPoint(cache):
                         self.OnSilenceDetected(
-                            cur_frm_idx - self.LatencyFrmNumAtStartPoint(cache), cache)
-            elif cache["stats"].vad_state_machine == VadStateMachine.kVadInStateInSpeechSegment:
-                if (cache["stats"].continous_silence_frame_count * frm_shift_in_ms
-                        >= cache["stats"].max_end_sil_frame_cnt_thresh):
-                    lookback_frame = int(cache["stats"].max_end_sil_frame_cnt_thresh / frm_shift_in_ms)
+                            cur_frm_idx - self.LatencyFrmNumAtStartPoint(cache), cache
+                        )
+            elif (
+                cache["stats"].vad_state_machine
+                == VadStateMachine.kVadInStateInSpeechSegment
+            ):
+                if (
+                    cache["stats"].continous_silence_frame_count * frm_shift_in_ms
+                    >= cache["stats"].max_end_sil_frame_cnt_thresh
+                ):
+                    lookback_frame = int(
+                        cache["stats"].max_end_sil_frame_cnt_thresh / frm_shift_in_ms
+                    )
                     if self.vad_opts.do_extend:
-                        lookback_frame -= int(self.vad_opts.lookahead_time_end_point / frm_shift_in_ms)
+                        lookback_frame -= int(
+                            self.vad_opts.lookahead_time_end_point / frm_shift_in_ms
+                        )
                         lookback_frame -= 1
                         lookback_frame = max(0, lookback_frame)
                     self.OnVoiceEnd(cur_frm_idx - lookback_frame, False, False, cache)
-                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
-                elif (cur_frm_idx - cache["stats"].confirmed_start_frame + 1
-                      > self.vad_opts.max_single_segment_time / frm_shift_in_ms):
+                    cache["stats"].vad_state_machine = (
+                        VadStateMachine.kVadInStateEndPointDetected
+                    )
+                elif (
+                    cur_frm_idx - cache["stats"].confirmed_start_frame + 1
+                    > self.vad_opts.max_single_segment_time / frm_shift_in_ms
+                ):
                     self.OnVoiceEnd(cur_frm_idx, False, False, cache)
-                    cache["stats"].vad_state_machine = VadStateMachine.kVadInStateEndPointDetected
+                    cache["stats"].vad_state_machine = (
+                        VadStateMachine.kVadInStateEndPointDetected
+                    )
                 elif self.vad_opts.do_extend and not is_final_frame:
                     if cache["stats"].continous_silence_frame_count <= int(
-                            self.vad_opts.lookahead_time_end_point / frm_shift_in_ms):
+                        self.vad_opts.lookahead_time_end_point / frm_shift_in_ms
+                    ):
                         self.OnVoiceDetected(cur_frm_idx, cache)
                 else:
                     self.MaybeOnVoiceEndIfLastFrame(is_final_frame, cur_frm_idx, cache)
 
-        if (cache["stats"].vad_state_machine == VadStateMachine.kVadInStateEndPointDetected
-                and self.vad_opts.detect_mode == VadDetectMode.kVadMutipleUtteranceDetectMode.value):
+        if (
+            cache["stats"].vad_state_machine
+            == VadStateMachine.kVadInStateEndPointDetected
+            and self.vad_opts.detect_mode
+            == VadDetectMode.kVadMutipleUtteranceDetectMode.value
+        ):
             self.ResetDetection(cache)
 
     def DetectCommonFrames(self, cache):
-        if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateEndPointDetected:
+        if (
+            cache["stats"].vad_state_machine
+            == VadStateMachine.kVadInStateEndPointDetected
+        ):
             return
         for i in range(self.vad_opts.nn_eval_block_size - 1, -1, -1):
             frame_state = self.GetFrameState(
-                cache["stats"].frm_cnt - 1 - i - cache["stats"].last_drop_frames, cache)
-            self.DetectOneFrame(frame_state, cache["stats"].frm_cnt - 1 - i, False, cache)
+                cache["stats"].frm_cnt - 1 - i - cache["stats"].last_drop_frames, cache
+            )
+            self.DetectOneFrame(
+                frame_state, cache["stats"].frm_cnt - 1 - i, False, cache
+            )
 
     def DetectLastFrames(self, cache):
-        if cache["stats"].vad_state_machine == VadStateMachine.kVadInStateEndPointDetected:
+        if (
+            cache["stats"].vad_state_machine
+            == VadStateMachine.kVadInStateEndPointDetected
+        ):
             return
         for i in range(self.vad_opts.nn_eval_block_size - 1, -1, -1):
             frame_state = self.GetFrameState(
-                cache["stats"].frm_cnt - 1 - i - cache["stats"].last_drop_frames, cache)
+                cache["stats"].frm_cnt - 1 - i - cache["stats"].last_drop_frames, cache
+            )
             if i != 0:
-                self.DetectOneFrame(frame_state, cache["stats"].frm_cnt - 1 - i, False, cache)
+                self.DetectOneFrame(
+                    frame_state, cache["stats"].frm_cnt - 1 - i, False, cache
+                )
             else:
-                self.DetectOneFrame(frame_state, cache["stats"].frm_cnt - 1, True, cache)
+                self.DetectOneFrame(
+                    frame_state, cache["stats"].frm_cnt - 1, True, cache
+                )
 
-    def forward(self, scores: np.ndarray, waveform: np.ndarray,
-                cache: dict, is_final: bool = True) -> List[List[int]]:
+    def forward(
+        self,
+        scores: np.ndarray,
+        waveform: np.ndarray,
+        cache: dict,
+        is_final: bool = True,
+    ) -> List[List[int]]:
         """
         处理一个 chunk 的 scores 和 waveform.
 
@@ -530,7 +693,10 @@ class VADPostProcess:
 
         segments = []
         if len(cache["stats"].output_data_buf) > 0:
-            for i in range(cache["stats"].output_data_buf_offset, len(cache["stats"].output_data_buf)):
+            for i in range(
+                cache["stats"].output_data_buf_offset,
+                len(cache["stats"].output_data_buf),
+            ):
                 if not is_final and (
                     not cache["stats"].output_data_buf[i].contain_seg_start_point
                     or not cache["stats"].output_data_buf[i].contain_seg_end_point

--- a/mlx_audio/vad/utils.py
+++ b/mlx_audio/vad/utils.py
@@ -8,8 +8,7 @@ from mlx_audio.utils import base_load_model
 MODEL_REMAPPING = {
     "silero": "silero_vad",
     "silero-vad": "silero_vad",
-    "fsmn": "fsmn",
-    "fsmn-vad-mlx": "fsmn"
+    "fsmn": "fsmn"
 }
 
 

--- a/mlx_audio/vad/utils.py
+++ b/mlx_audio/vad/utils.py
@@ -7,6 +7,7 @@ from mlx_audio.utils import base_load_model
 
 MODEL_REMAPPING = {"silero": "silero_vad", "silero-vad": "silero_vad", "fsmn": "fsmn"}
 
+
 def load_model(
     model_path: Union[str, Path], lazy: bool = False, strict: bool = False, **kwargs
 ) -> nn.Module:

--- a/mlx_audio/vad/utils.py
+++ b/mlx_audio/vad/utils.py
@@ -8,9 +8,7 @@ from mlx_audio.utils import base_load_model
 MODEL_REMAPPING = {
     "silero": "silero_vad",
     "silero-vad": "silero_vad",
-    "fsmn": "fsmn",
-    "fsmn-vad": "fsmn",
-    "fsmn_vad": "fsmn",
+    "fsmn": "fsmn"
 }
 
 

--- a/mlx_audio/vad/utils.py
+++ b/mlx_audio/vad/utils.py
@@ -8,7 +8,8 @@ from mlx_audio.utils import base_load_model
 MODEL_REMAPPING = {
     "silero": "silero_vad",
     "silero-vad": "silero_vad",
-    "fsmn": "fsmn"
+    "fsmn": "fsmn",
+    "fsmn-vad-mlx": "fsmn"
 }
 
 

--- a/mlx_audio/vad/utils.py
+++ b/mlx_audio/vad/utils.py
@@ -8,6 +8,9 @@ from mlx_audio.utils import base_load_model
 MODEL_REMAPPING = {
     "silero": "silero_vad",
     "silero-vad": "silero_vad",
+    "fsmn": "fsmn",
+    "fsmn-vad": "fsmn",
+    "fsmn_vad": "fsmn",
 }
 
 

--- a/mlx_audio/vad/utils.py
+++ b/mlx_audio/vad/utils.py
@@ -5,12 +5,7 @@ import mlx.nn as nn
 
 from mlx_audio.utils import base_load_model
 
-MODEL_REMAPPING = {
-    "silero": "silero_vad",
-    "silero-vad": "silero_vad",
-    "fsmn": "fsmn"
-}
-
+MODEL_REMAPPING = {"silero": "silero_vad", "silero-vad": "silero_vad", "fsmn": "fsmn"}
 
 def load_model(
     model_path: Union[str, Path], lazy: bool = False, strict: bool = False, **kwargs


### PR DESCRIPTION
## Summary

Add FSMN-VAD (Feedforward Sequential Memory Network) speech activity detection model for MLX.

Ported from [FunASR](https://github.com/modelscope/FunASR)'s PyTorch implementation with full MLX native support.

## What's included

- `mlx_audio/vad/models/fsmn/` — complete model implementation
  - **Encoder**: 4-layer FSMN blocks with depthwise Conv1d + affine transforms
  - **Frontend**: Kaldi-compatible fbank extraction + LFR (Low Frame Rate) + CMVN normalization
  - **Post-processing**: Streaming-capable VAD with configurable speech/silence thresholds
  - **Conversion script**: PyTorch `.pt` weights → MLX `.safetensors`
  - **README**: Architecture overview, usage examples, and API documentation
- Updated `vad/utils.py` MODEL_REMAPPING for FSMN detection

## Model weights

Pre-converted weights available at: https://huggingface.co/mlx-community/fsmn-vad

## Usage

```python
from mlx_audio.vad import load

model = load("mlx-community/fsmn-vad")
segments = model.detect("audio.wav")
# [[start_ms, end_ms], ...]
```

## Testing

- Verified end-to-end alignment with PyTorch FunASR reference implementation
- 12/12 speech segments match on test audio
- Per-segment timestamp difference ≤ 20ms
