### PR TITLE
fix: is_valid_module_name rejects names containing '.'

### DIFF
--- a/mlx_audio/tests/test_utils.py
+++ b/mlx_audio/tests/test_utils.py
@@ -1,0 +1,29 @@
+"""Tests for mlx_audio.utils helpers."""
+
+from mlx_audio.utils import is_valid_module_name
+
+
+def test_is_valid_module_name_accepts_plain_identifiers():
+    assert is_valid_module_name("parakeet")
+    assert is_valid_module_name("whisper")
+    assert is_valid_module_name("parakeet_tdt")
+    assert is_valid_module_name("_private")
+    assert is_valid_module_name("model2")
+
+
+def test_is_valid_module_name_rejects_dots():
+    # Regression: candidates synthesized by get_model_name_parts can
+    # contain '.' (e.g. "parakeet_tdt_0.6b" built from "parakeet-tdt-0.6b-v3").
+    # importlib.util.find_spec would otherwise interpret the dot as a package
+    # separator and crash with ModuleNotFoundError on the synthetic parent.
+    assert not is_valid_module_name("parakeet_tdt_0.6b")
+    assert not is_valid_module_name("whisper.large.v3")
+    assert not is_valid_module_name("a.b")
+
+
+def test_is_valid_module_name_rejects_other_non_identifiers():
+    assert not is_valid_module_name("")
+    assert not is_valid_module_name("2model")        # leading digit
+    assert not is_valid_module_name("model-name")    # hyphen
+    assert not is_valid_module_name("model name")    # space
+    assert not is_valid_module_name(None)            # type: ignore[arg-type]

--- a/mlx_audio/utils.py
+++ b/mlx_audio/utils.py
@@ -721,11 +721,16 @@ __all__ = [
 
 
 def is_valid_module_name(name: str) -> bool:
-    """Check if a string is a valid Python module name."""
+    """Check if a string is a valid Python module name.
+
+    Rejects names containing '.' (e.g. "parakeet_tdt_0.6b"), which
+    importlib.util.find_spec would otherwise interpret as a package
+    path and crash with ModuleNotFoundError on the synthetic parent.
+    """
     if not name or not isinstance(name, str):
         return False
 
-    return name[0].isalpha() or name[0] == "_"
+    return name.isidentifier()
 
 
 def get_model_category(model_type: str, model_name: List[str]) -> Optional[str]:


### PR DESCRIPTION
## Summary

`is_valid_module_name` currently only validates the first character of a candidate, so it accepts strings that contain `.` (e.g. `parakeet_tdt_0.6b`). `get_model_category` passes such candidates straight into `importlib.util.find_spec(f"mlx_audio.{category}.models.{candidate}")`, which interprets the dot as a package separator and tries to import a parent module that doesn't exist — raising `ModuleNotFoundError` and aborting model resolution.

The result: every model whose repo name contains a `.` (which is nearly every parakeet variant — `*-0.6b-*`, `*-1.1b-*` — and most Whisper variants like `whisper-large-v3`) crashes during load, even though the `parakeet` / `whisper` candidate would have resolved correctly on a later iteration.

## Reproduction

```python
from mlx_audio.utils import load_model
load_model("mlx-community/parakeet-tdt-0.6b-v3")
```

```
Traceback (most recent call last):
  File ".../mlx_audio/utils.py", line 778, in get_model_category
    if importlib.util.find_spec(module_path) is not None:
  File ".../importlib/util.py", line 94, in find_spec
    parent = __import__(parent_name, fromlist=['__path__'])
ModuleNotFoundError: No module named 'mlx_audio.tts.models.parakeet_tdt_0'
```

The candidate `parakeet_tdt_0.6b` (synthesized by `get_model_name_parts` joining `parakeet`, `tdt`, and `0.6b` with `_`) is passed to `find_spec` which splits on `.` and looks for `mlx_audio.tts.models.parakeet_tdt_0`.

## Fix

Replace the partial first-character check in `is_valid_module_name` with Python's canonical identifier check, `str.isidentifier()`. This correctly rejects any string containing `.` (or other non-identifier characters), so `get_model_category`'s loops skip the dotted candidate and continue to the valid `parakeet` / `whisper` hint.

```diff
 def is_valid_module_name(name: str) -> bool:
     """Check if a string is a valid Python module name."""
     if not name or not isinstance(name, str):
         return False
 
-    return name[0].isalpha() or name[0] == "_"
+    # Must be a valid Python identifier: letter/underscore start, then
+    # only letters/digits/underscores. Crucially rejects names containing
+    # '.' (e.g. "parakeet_tdt_0.6b"), which importlib.util.find_spec would
+    # otherwise interpret as a package path and crash with
+    # ModuleNotFoundError on the synthetic parent.
+    return name.isidentifier()
```

After the fix, the same `load_model("mlx-community/parakeet-tdt-0.6b-v3")` call resolves via the `parakeet` candidate → `mlx_audio.stt.models.parakeet`, downloads weights, and serves transcription requests normally.

## Test plan

- [ ] Added `mlx_audio/tests/test_utils.py::test_is_valid_module_name_rejects_dots` covering the regression and a handful of valid/invalid identifier cases.
- [ ] Manually verified end-to-end: `mlx_audio.server` running on `:8890`, `POST /v1/audio/transcriptions` with `model=mlx-community/parakeet-tdt-0.6b-v3` and `model=mlx-community/parakeet-tdt_ctc-110m` both load and transcribe successfully.
- [ ] Existing tests pass (`uv run pytest mlx_audio/tests/`).

## Affected models (non-exhaustive)

Any HuggingFace repo whose name contains `.`, including:
- `mlx-community/parakeet-tdt-0.6b-v3`, `-v2`
- `mlx-community/parakeet-ctc-0.6b`, `parakeet-rnnt-0.6b`, `parakeet-tdt-1.1b`, `parakeet-rnnt-1.1b`, `parakeet-ctc-1.1b`
- `mlx-community/parakeet-tdt_ctc-0.6b-ja`, `parakeet-tdt_ctc-1.1b`
