### PR TITLE
Fix Kokoro usage from worker threads

### DIFF
--- a/mlx_audio/tts/models/interpolate.py
+++ b/mlx_audio/tts/models/interpolate.py
@@ -1,3 +1,4 @@
+import math
 from typing import List, Optional, Tuple, Union
 
 import mlx.core as mx
@@ -42,7 +43,10 @@ def interpolate(
         size = []
         for i in range(spatial_dims):
             # Use ceiling instead of floor to match PyTorch behavior
-            curr_size = max(1, int(mx.ceil(input.shape[i + 2] * scale_factor[i])))
+            curr_size = max(
+                1,
+                int(math.ceil(float(input.shape[i + 2]) * float(scale_factor[i]))),
+            )
             size.append(curr_size)
 
     # Handle 1D case (N, C, W)

--- a/mlx_audio/tts/models/kokoro/istftnet.py
+++ b/mlx_audio/tts/models/kokoro/istftnet.py
@@ -547,7 +547,7 @@ class SineGen:
         self.sampling_rate = samp_rate
         self.voiced_threshold = voiced_threshold
         self.flag_for_pulse = flag_for_pulse
-        self.upsample_scale = upsample_scale
+        self.upsample_scale = int(upsample_scale)
 
     def _f02uv(self, f0: mx.array) -> mx.array:
         return mx.array(f0 > self.voiced_threshold, dtype=mx.float32)
@@ -708,16 +708,15 @@ class Generator(nn.Module):
         super(Generator, self).__init__()
         self.num_kernels = len(resblock_kernel_sizes)
         self.num_upsamples = len(upsample_rates)
-        upsample_rates = mx.array(upsample_rates)
+        upsample_rates = tuple(int(rate) for rate in upsample_rates)
+        total_upsample = math.prod(upsample_rates) * int(gen_istft_hop_size)
         self.m_source = SourceModuleHnNSF(
             sampling_rate=24000,
-            upsample_scale=mx.prod(upsample_rates) * gen_istft_hop_size,
+            upsample_scale=total_upsample,
             harmonic_num=8,
             voiced_threshod=10,
         )
-        self.f0_upsamp = nn.Upsample(
-            scale_factor=mx.prod(upsample_rates) * gen_istft_hop_size
-        )
+        self.f0_upsamp = nn.Upsample(scale_factor=total_upsample)
         self.noise_convs = []
         self.noise_res = []
         self.ups = []
@@ -741,7 +740,7 @@ class Generator(nn.Module):
                 self.resblocks.append(AdaINResBlock1(ch, k, d, style_dim))
             c_cur = upsample_initial_channel // (2 ** (i + 1))
             if i + 1 < len(upsample_rates):
-                stride_f0 = int(mx.prod(upsample_rates[i + 1 :]))
+                stride_f0 = math.prod(upsample_rates[i + 1 :])
                 self.noise_convs.append(
                     nn.Conv1d(
                         gen_istft_n_fft + 2,

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -1,6 +1,7 @@
 import importlib.resources
 import importlib.util
 import json
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -201,6 +202,39 @@ class TestKokoroModel(unittest.TestCase):
         # Check that the output was created correctly
         self.assertIs(output.audio, audio)
         self.assertIs(output.pred_dur, pred_dur)
+
+    def test_sine_generator_uses_thread_safe_python_upsample_scale(self):
+        from mlx_audio.tts.models.kokoro.istftnet import Generator
+
+        generator = Generator(
+            style_dim=128,
+            resblock_kernel_sizes=[3, 7, 11],
+            upsample_rates=[8, 8, 2, 2],
+            upsample_initial_channel=512,
+            resblock_dilation_sizes=[[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+            upsample_kernel_sizes=[16, 16, 4, 4],
+            gen_istft_n_fft=16,
+            gen_istft_hop_size=4,
+        )
+
+        self.assertIsInstance(generator.m_source.l_sin_gen.upsample_scale, int)
+
+        errors = []
+
+        def run_sine_generator():
+            try:
+                f0 = mx.ones((1, generator.m_source.l_sin_gen.upsample_scale, 1))
+                outputs = generator.m_source.l_sin_gen(f0)
+                mx.eval(*outputs)
+            except Exception as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=run_sine_generator)
+        thread.start()
+        thread.join()
+
+        if errors:
+            raise errors[0]
 
 
 @patch("importlib.resources.open_text", patched_open_text)


### PR DESCRIPTION
Avoid creating un-eval'ed mx.arrays in the generator which fail when passed to a worker thread with a different stream. Resolves https://github.com/Blaizzy/mlx-audio/issues/744