### PR TITLE
Fix VoxCPM2 Chinese tokenization

### DIFF
--- a/mlx_audio/tts/models/voxcpm2/voxcpm2.py
+++ b/mlx_audio/tts/models/voxcpm2/voxcpm2.py
@@ -192,7 +192,22 @@ class Model(nn.Module):
     def _tokenize(self, text: str):
         """Tokenize text without BOS token (matching PyTorch behavior)."""
         tokens = self.tokenizer.tokenize(text)
+        tokens = self._split_multichar_chinese_tokens(tokens)
         return self.tokenizer.convert_tokens_to_ids(tokens)
+
+    @staticmethod
+    def _split_multichar_chinese_tokens(tokens: list[str]) -> list[str]:
+        """Split multi-character Chinese tokens to match OpenBMB VoxCPM2."""
+        processed = []
+        for token in tokens:
+            clean_token = token.replace("▁", "")
+            if len(clean_token) >= 2 and all(
+                "\u4e00" <= char <= "\u9fff" for char in clean_token
+            ):
+                processed.extend(list(clean_token))
+            else:
+                processed.append(token)
+        return processed
 
     def _encode_wav(
         self, audio_input, padding_mode: str = "right", trim_silence_vad: bool = False

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -7189,6 +7189,51 @@ class TestVoxCPM2Model(unittest.TestCase):
         emb = model.base_lm.embed_tokens(x)
         self.assertEqual(emb.shape, (1, 3, 64))
 
+    def test_tokenize_splits_multichar_chinese_tokens(self):
+        from unittest.mock import MagicMock
+
+        from mlx_audio.tts.models.voxcpm2.voxcpm2 import Model
+
+        args = _tiny_voxcpm2_args()
+        model = Model(args)
+        model.tokenizer = MagicMock()
+        model.tokenizer.tokenize.return_value = [
+            "▁",
+            "你好",
+            "，",
+            "这是",
+            "▁V",
+            "ox",
+            "CP",
+            "M",
+            "2",
+            "中文",
+            "。",
+        ]
+        model.tokenizer.convert_tokens_to_ids.side_effect = lambda tokens: tokens
+
+        tokens = model._tokenize("你好，这是 VoxCPM2 中文。")
+
+        self.assertEqual(
+            tokens,
+            [
+                "▁",
+                "你",
+                "好",
+                "，",
+                "这",
+                "是",
+                "▁V",
+                "ox",
+                "CP",
+                "M",
+                "2",
+                "中",
+                "文",
+                "。",
+            ],
+        )
+
     def test_inference_pipeline(self):
         """Test forward pass through the full inference pipeline (no tokenizer)."""
         from mlx_audio.tts.models.voxcpm2.voxcpm2 import Model


### PR DESCRIPTION
## Summary
- Split multi-character Chinese tokens in VoxCPM2 tokenization to match OpenBMB's official implementation.
- This prevents garbled Chinese TTS output when the tokenizer emits multi-character Chinese tokens.
- Add a focused unit test for mixed Chinese / ASCII VoxCPM2 text.

## Context
OpenBMB's VoxCPM2 tokenizer notes that the model was trained with `mask_multichar_chinese_tokens`, which splits multi-character Chinese tokens into single characters. Without this, downstream inference frameworks can produce garbled Chinese audio.

References:
- https://huggingface.co/openbmb/VoxCPM2/blob/main/tokenization_voxcpm2.py
- https://huggingface.co/openbmb/VoxCPM2/discussions/8

## Tests
- `python -m pytest mlx_audio/tts/tests/test_models.py -k VoxCPM2`
- `python -m pytest mlx_audio/tts/tests/test_models.py -k test_tokenize_splits_multichar_chinese_tokens`
- `python -m black --check mlx_audio/tts/models/voxcpm2/voxcpm2.py mlx_audio/tts/tests/test_models.py`
- `python -m isort --check-only --profile=black mlx_audio/tts/models/voxcpm2/voxcpm2.py mlx_audio/tts/tests/test_models.py`
