### PR TITLE
feat(irodori-tts): add Irodori-TTS v3 VoiceDesign dual conditioning (speaker + caption)

### DIFF
--- a/mlx_audio/tts/models/irodori_tts/README.md
+++ b/mlx_audio/tts/models/irodori_tts/README.md
@@ -14,7 +14,8 @@ Original: [Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS)
 |---|---|---|
 | `mlx-community/Irodori-TTS-500M-v3-fp16` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-v3-fp16) | Voice cloning + automatic duration |
 | `mlx-community/Irodori-TTS-500M-v3-8bit` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-v3-8bit) | Voice cloning + automatic duration |
-| `mlx-community/Irodori-TTS-500M-v3-4bit` | [link](https://huggingface.co/mlx-community/Irodori-TTS-500M-v3-4bit) | Voice cloning + automatic duration |
+| `mlx-community/Irodori-TTS-600M-v3-VoiceDesign-fp16` | [link](https://huggingface.co/mlx-community/Irodori-TTS-600M-v3-VoiceDesign-fp16) | Voice cloning + VoiceDesign (dual conditioning) |
+| `mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit` | [link](https://huggingface.co/mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit) | Voice cloning + VoiceDesign (dual conditioning) |
 
 ### v2
 
@@ -57,7 +58,49 @@ python -m mlx_audio.tts.generate \
 
 ### VoiceDesign
 
-Describe the desired voice in text instead of providing reference audio:
+#### v3 VoiceDesign
+
+Caption only:
+
+```python
+generate_audio(
+    model="mlx-community/Irodori-TTS-600M-v3-VoiceDesign-fp16",
+    text="今日はいい天気ですね。",
+    instruct="落ち着いた女性の声で、近い距離感でやわらかく自然に読み上げてください。",
+    file_prefix="output",
+)
+```
+
+```bash
+python -m mlx_audio.tts.generate \
+  --model mlx-community/Irodori-TTS-600M-v3-VoiceDesign-fp16 \
+  --text "今日はいい天気ですね。" \
+  --instruct "落ち着いた女性の声で、近い距離感でやわらかく自然に読み上げてください。"
+```
+
+Style-controlled voice cloning with reference speech + caption:
+
+```python
+generate_audio(
+    model="mlx-community/Irodori-TTS-600M-v3-VoiceDesign-fp16",
+    text="今日はいい天気ですね。",
+    ref_audio="speaker.wav",
+    instruct="深く傷つき、今にも泣き出しそうな様子。声が震えており、悲痛なトーンで弱々しく話す。",
+    file_prefix="output",
+)
+```
+
+```bash
+python -m mlx_audio.tts.generate \
+  --model mlx-community/Irodori-TTS-600M-v3-VoiceDesign-fp16 \
+  --text "今日はいい天気ですね。" \
+  --ref_audio speaker.wav \
+  --instruct "深く傷つき、今にも泣き出しそうな様子。声が震えており、悲痛なトーンで弱々しく話す。"
+```
+
+#### v2 VoiceDesign
+
+Caption only (reference audio is not supported):
 
 ```python
 generate_audio(

--- a/mlx_audio/tts/models/irodori_tts/config.py
+++ b/mlx_audio/tts/models/irodori_tts/config.py
@@ -39,8 +39,9 @@ class IrodoriDiTConfig(BaseModelArgs):
     adaln_rank: int = 192
     norm_eps: float = 1e-5
 
-    # Caption (Voice Design) conditioning — mutually exclusive with speaker
+    # Caption (Voice Design) conditioning — can coexist with speaker (v3 VoiceDesign dual mode)
     use_caption_condition: bool = False
+    use_speaker_condition: Optional[bool] = None
     caption_vocab_size: Optional[int] = None
     caption_tokenizer_repo: Optional[str] = None
     caption_add_bos: Optional[bool] = None
@@ -59,10 +60,14 @@ class IrodoriDiTConfig(BaseModelArgs):
     duration_architecture: str = "token_sum_adarn_zero_no_aux"
     duration_token_init_frames: float = 9.0
     duration_speaker_fusion: str = "adarn_zero"
+    duration_caption_fusion: str = "adarn_zero"
+    duration_caption_pooling: str = "masked_mean"
 
     @property
-    def use_speaker_condition(self) -> bool:
-        return not self.use_caption_condition
+    def use_speaker_condition_resolved(self) -> bool:
+        if self.use_speaker_condition is None:
+            return not self.use_caption_condition
+        return bool(self.use_speaker_condition)
 
     @property
     def caption_vocab_size_resolved(self) -> int:

--- a/mlx_audio/tts/models/irodori_tts/irodori_tts.py
+++ b/mlx_audio/tts/models/irodori_tts/irodori_tts.py
@@ -238,7 +238,14 @@ class Model(nn.Module):
         if self.config.dit.use_caption_condition:
             cap = caption or ""
             caption_input_ids, caption_mask = self._prepare_caption(cap)
-        else:
+
+        if self.config.dit.use_speaker_condition_resolved:
+            if ref_latent is None:
+                ref_latent = mx.zeros((1, 1, self.config.dit.latent_dim))
+            if ref_mask is None:
+                ref_mask = mx.zeros((1, ref_latent.shape[1]), dtype=mx.bool_)
+        elif not self.config.dit.use_caption_condition:
+            # legacy speaker-only (use_speaker_condition=None, use_caption_condition=False)
             if ref_latent is None:
                 ref_latent = mx.zeros((1, 1, self.config.dit.latent_dim))
             if ref_mask is None:
@@ -266,18 +273,29 @@ class Model(nn.Module):
             )
 
             # Encode conditions for duration prediction
-            text_state, text_mask_full, speaker_state, speaker_mask, _, _ = (
-                self.model.encode_conditions_full(
-                    text_input_ids=text_input_ids,
-                    text_mask=text_mask,
-                    ref_latent=ref_latent,
-                    ref_mask=ref_mask,
-                    caption_input_ids=caption_input_ids,
-                    caption_mask=caption_mask,
-                )
+            (
+                text_state,
+                text_mask_full,
+                speaker_state,
+                speaker_mask,
+                caption_state_dur,
+                caption_mask_dur,
+            ) = self.model.encode_conditions_full(
+                text_input_ids=text_input_ids,
+                text_mask=text_mask,
+                ref_latent=ref_latent,
+                ref_mask=ref_mask,
+                caption_input_ids=caption_input_ids,
+                caption_mask=caption_mask,
             )
 
             has_speaker_arr = mx.array([has_speaker], dtype=mx.bool_)
+            has_caption = bool(
+                caption_input_ids is not None
+                and caption_mask is not None
+                and mx.any(caption_mask)
+            )
+            has_caption_arr = mx.array([has_caption], dtype=mx.bool_)
             pred_log_frames = self.model.predict_duration_log_frames(
                 text_state=text_state,
                 text_mask=text_mask_full,
@@ -285,6 +303,9 @@ class Model(nn.Module):
                 speaker_mask=speaker_mask,
                 duration_features=duration_features,
                 has_speaker=has_speaker_arr,
+                caption_state=caption_state_dur,
+                caption_mask=caption_mask_dur,
+                has_caption=has_caption_arr,
             )
             pred_frames = float(mx.expm1(pred_log_frames[0]).item())
             scaled_frames = pred_frames * duration_scale

--- a/mlx_audio/tts/models/irodori_tts/model.py
+++ b/mlx_audio/tts/models/irodori_tts/model.py
@@ -232,9 +232,9 @@ class JointAttention(nn.Module):
     Joint attention over latent self-tokens, text context, and speaker/caption context.
     Uses half-RoPE: RoPE applied to the first half of head dimensions.
 
-    Exactly one of speaker_ctx_dim or caption_ctx_dim must be provided.
-    The corresponding weight keys (wk_speaker/wv_speaker or wk_caption/wv_caption)
-    are created accordingly so that loaded PyTorch weights map directly.
+    speaker_ctx_dim and/or caption_ctx_dim may be provided independently.
+    For dual-mode (v3 VoiceDesign), both are set and keys for both branches
+    (wk_speaker/wv_speaker and wk_caption/wv_caption) are created.
     """
 
     def __init__(
@@ -259,16 +259,16 @@ class JointAttention(nn.Module):
         self.q_norm = RMSNorm((heads, self.head_dim), eps=norm_eps)
         self.k_norm = RMSNorm((heads, self.head_dim), eps=norm_eps)
 
+        self.has_speaker_condition = speaker_ctx_dim is not None
+        self.has_caption_condition = caption_ctx_dim is not None
+        if not self.has_speaker_condition and not self.has_caption_condition:
+            raise ValueError("At least one of speaker_ctx_dim or caption_ctx_dim must be set")
         if speaker_ctx_dim is not None:
             self.wk_speaker = nn.Linear(speaker_ctx_dim, dim, bias=False)
             self.wv_speaker = nn.Linear(speaker_ctx_dim, dim, bias=False)
-            self._context_mode = "speaker"
-        elif caption_ctx_dim is not None:
+        if caption_ctx_dim is not None:
             self.wk_caption = nn.Linear(caption_ctx_dim, dim, bias=False)
             self.wv_caption = nn.Linear(caption_ctx_dim, dim, bias=False)
-            self._context_mode = "caption"
-        else:
-            raise ValueError("Either speaker_ctx_dim or caption_ctx_dim must be set")
 
     def _apply_rotary_half(self, y: mx.array, freqs_cis: RotaryCache) -> mx.array:
         """Apply RoPE to the first half of head dimensions only."""
@@ -309,20 +309,16 @@ class JointAttention(nn.Module):
         k = self.k_norm(k)
         return k, v
 
-    def get_kv_cache_context(self, context_state: mx.array) -> KVCache:
-        """Dispatch to speaker or caption KV cache based on model mode."""
-        if self._context_mode == "caption":
-            return self.get_kv_cache_caption(context_state)
-        return self.get_kv_cache_speaker(context_state)
-
     def __call__(
         self,
         x: mx.array,
         text_mask: mx.array,
-        context_mask: mx.array,
         freqs_cis: RotaryCache,
         kv_cache_text: KVCache,
-        kv_cache_context: KVCache,
+        kv_cache_speaker: Optional[KVCache] = None,
+        speaker_mask: Optional[mx.array] = None,
+        kv_cache_caption: Optional[KVCache] = None,
+        caption_mask: Optional[mx.array] = None,
         start_pos: int = 0,
     ) -> mx.array:
         bsz, seq_len = x.shape[:2]
@@ -340,13 +336,27 @@ class JointAttention(nn.Module):
         k_self = self._apply_rotary_half(k_self, (q_cos, q_sin))
 
         k_text, v_text = kv_cache_text
-        k_ctx, v_ctx = kv_cache_context
-
-        k = mx.concatenate([k_self, k_text, k_ctx], axis=1)
-        v = mx.concatenate([v_self, v_text, v_ctx], axis=1)
-
         self_mask = mx.ones((bsz, seq_len), dtype=mx.bool_)
-        full_mask = mx.concatenate([self_mask, text_mask, context_mask], axis=1)
+
+        k_parts = [k_self, k_text]
+        v_parts = [v_self, v_text]
+        mask_parts = [self_mask, text_mask]
+
+        if kv_cache_speaker is not None:
+            k_spk, v_spk = kv_cache_speaker
+            k_parts.append(k_spk)
+            v_parts.append(v_spk)
+            mask_parts.append(speaker_mask)
+
+        if kv_cache_caption is not None:
+            k_cap, v_cap = kv_cache_caption
+            k_parts.append(k_cap)
+            v_parts.append(v_cap)
+            mask_parts.append(caption_mask)
+
+        k = mx.concatenate(k_parts, axis=1)
+        v = mx.concatenate(v_parts, axis=1)
+        full_mask = mx.concatenate(mask_parts, axis=1)
         full_mask = mx.broadcast_to(
             full_mask[:, None, :], (bsz, seq_len, full_mask.shape[1])
         )
@@ -509,20 +519,24 @@ class DiffusionBlock(nn.Module):
         x: mx.array,
         cond_embed: mx.array,
         text_mask: mx.array,
-        context_mask: mx.array,
         freqs_cis: RotaryCache,
         kv_cache_text: KVCache,
-        kv_cache_context: KVCache,
+        kv_cache_speaker: Optional[KVCache] = None,
+        speaker_mask: Optional[mx.array] = None,
+        kv_cache_caption: Optional[KVCache] = None,
+        caption_mask: Optional[mx.array] = None,
         start_pos: int = 0,
     ) -> mx.array:
         x_norm, attn_gate = self.attention_adaln(x, cond_embed)
         x = x + attn_gate * self.attention(
             x_norm,
             text_mask,
-            context_mask,
             freqs_cis,
             kv_cache_text,
-            kv_cache_context,
+            kv_cache_speaker,
+            speaker_mask,
+            kv_cache_caption,
+            caption_mask,
             start_pos,
         )
         x_norm, mlp_gate = self.mlp_adaln(x, cond_embed)
@@ -536,7 +550,11 @@ class DiffusionBlock(nn.Module):
 
 
 class DurationSwiGLUBlock(nn.Module):
-    """SwiGLU block with optional AdaRN-Zero modulation for duration predictor."""
+    """SwiGLU block with optional AdaRN-Zero modulation for duration predictor.
+
+    Supports dual modulation (speaker + caption) that are added together,
+    matching the token_sum_dual_adarn_zero_no_aux architecture.
+    """
 
     def __init__(
         self,
@@ -544,28 +562,53 @@ class DurationSwiGLUBlock(nn.Module):
         hidden_dim: int,
         norm_eps: float,
         cond_dim: Optional[int] = None,
+        caption_cond_dim: Optional[int] = None,
     ):
         super().__init__()
         self.norm = RMSNorm(dim, eps=norm_eps)
         self.mlp = SwiGLU(dim, hidden_dim)
         self.cond_dim = cond_dim
+        self.caption_cond_dim = caption_cond_dim
         self.modulation = None
+        self.caption_modulation = None
         if cond_dim is not None:
             self.modulation = nn.Linear(cond_dim, dim * 3)
-            # Zero-init for stable training
             self.modulation.weight = self.modulation.weight * 0.0
             self.modulation.bias = self.modulation.bias * 0.0
+        if caption_cond_dim is not None:
+            self.caption_modulation = nn.Linear(caption_cond_dim, dim * 3)
+            self.caption_modulation.weight = self.caption_modulation.weight * 0.0
+            self.caption_modulation.bias = self.caption_modulation.bias * 0.0
 
-    def __call__(self, x: mx.array, cond: Optional[mx.array] = None) -> mx.array:
+    def __call__(
+        self,
+        x: mx.array,
+        cond: Optional[mx.array] = None,
+        caption_cond: Optional[mx.array] = None,
+    ) -> mx.array:
         h = self.norm(x)
-        if self.modulation is not None:
-            if cond is None:
-                raise ValueError("cond is required for AdaRN-Zero duration blocks.")
-            shift, scale, gate = mx.split(self.modulation(nn.silu(cond)), 3, axis=-1)
-            if h.ndim == 3 and shift.ndim == 2:
-                shift = shift[:, None, :]
-                scale = scale[:, None, :]
-                gate = gate[:, None, :]
+        if self.modulation is not None or self.caption_modulation is not None:
+            shift = mx.zeros_like(h)
+            scale = mx.zeros_like(h)
+            gate = mx.zeros_like(h)
+            if self.modulation is not None:
+                if cond is None:
+                    raise ValueError("cond is required for AdaRN-Zero duration blocks.")
+                ds, dsc, dg = mx.split(self.modulation(nn.silu(cond)), 3, axis=-1)
+                if h.ndim == 3 and ds.ndim == 2:
+                    ds, dsc, dg = ds[:, None, :], dsc[:, None, :], dg[:, None, :]
+                shift = shift + ds
+                scale = scale + dsc
+                gate = gate + dg
+            if self.caption_modulation is not None:
+                if caption_cond is None:
+                    raise ValueError("caption_cond is required for caption AdaRN-Zero blocks.")
+                cs, csc, cg = mx.split(self.caption_modulation(nn.silu(caption_cond)), 3, axis=-1)
+                if h.ndim == 3 and cs.ndim == 2:
+                    cs, csc, cg = cs[:, None, :], csc[:, None, :], cg[:, None, :]
+                shift = shift + cs
+                scale = scale + csc
+                gate = gate + cg
             h = h * (1.0 + scale) + shift
             return x + mx.tanh(gate) * self.mlp(h)
         return x + self.mlp(h)
@@ -695,6 +738,9 @@ class DurationPredictor(nn.Module):
         norm_eps: float,
         speaker_dim: Optional[int] = None,
         speaker_fusion: str = "concat",
+        caption_dim: Optional[int] = None,
+        caption_fusion: str = "adarn_zero",
+        caption_pooling: str = "masked_mean",
         attention_heads: int = 8,
         architecture: str = "token_sum_adarn_zero_no_aux",
         token_init_frames: float = 9.0,
@@ -705,11 +751,18 @@ class DurationPredictor(nn.Module):
         self.hidden_dim = hidden_dim
         self.speaker_dim = speaker_dim
         self.speaker_fusion = speaker_fusion
+        self.caption_dim = caption_dim
+        self.caption_fusion = caption_fusion
+        self.caption_pooling = caption_pooling
         self.duration_architecture = architecture
 
         self.null_speaker = None
         if speaker_dim is not None:
             self.null_speaker = mx.zeros((speaker_dim,))
+
+        self.null_caption = None
+        if caption_dim is not None:
+            self.null_caption = mx.zeros((caption_dim,))
 
         # Token-sum architecture (v3 default)
         self.token_input_proj = None
@@ -736,6 +789,27 @@ class DurationPredictor(nn.Module):
                     hidden_dim=hidden_dim,
                     norm_eps=norm_eps,
                     cond_dim=speaker_dim,
+                )
+                for _ in range(layers)
+            ]
+            self.token_out_norm = RMSNorm(hidden_dim, eps=norm_eps)
+            self.token_out_proj = nn.Linear(hidden_dim, 1)
+            self.token_out_proj.weight = self.token_out_proj.weight * 0.0
+            bias_init = math.log(math.expm1(token_init_frames))
+            self.token_out_proj.bias = mx.full(
+                self.token_out_proj.bias.shape, bias_init
+            )
+            return
+
+        if architecture == "token_sum_dual_adarn_zero_no_aux":
+            self.token_input_proj = nn.Linear(text_dim, hidden_dim)
+            self.token_blocks = [
+                DurationSwiGLUBlock(
+                    dim=hidden_dim,
+                    hidden_dim=hidden_dim,
+                    norm_eps=norm_eps,
+                    cond_dim=speaker_dim,
+                    caption_cond_dim=caption_dim,
                 )
                 for _ in range(layers)
             ]
@@ -822,6 +896,30 @@ class DurationPredictor(nn.Module):
         speaker_vec = speaker_state[:, 0].astype(dtype)
         return mx.where(has_speaker[:, None], speaker_vec, null_vec)
 
+    def _caption_vec(
+        self,
+        batch_size: int,
+        dtype,
+        caption_state: Optional[mx.array],
+        caption_mask: Optional[mx.array],
+        has_caption: mx.array,
+    ) -> mx.array:
+        if self.null_caption is None or self.caption_dim is None:
+            raise RuntimeError("Duration caption modules are missing.")
+        null_vec = mx.broadcast_to(
+            self.null_caption.astype(dtype)[None, :], (batch_size, self.caption_dim)
+        )
+        if caption_state is None:
+            return null_vec
+        caption_state = caption_state.astype(dtype)
+        if caption_mask is not None:
+            mask_f = caption_mask[..., None].astype(dtype)
+            denom = mx.maximum(mx.sum(mask_f, axis=1), 1.0)
+            caption_vec = mx.sum(caption_state * mask_f, axis=1) / denom
+        else:
+            caption_vec = caption_state.mean(axis=1)
+        return mx.where(has_caption[:, None], caption_vec, null_vec)
+
     def __call__(
         self,
         text_state: mx.array,
@@ -830,6 +928,9 @@ class DurationPredictor(nn.Module):
         speaker_state: Optional[mx.array] = None,
         speaker_mask: Optional[mx.array] = None,
         has_speaker: Optional[mx.array] = None,
+        caption_state: Optional[mx.array] = None,
+        caption_mask: Optional[mx.array] = None,
+        has_caption: Optional[mx.array] = None,
     ) -> mx.array:
         if text_state.ndim != 3 or text_state.shape[-1] != self.text_dim:
             raise ValueError(
@@ -842,7 +943,7 @@ class DurationPredictor(nn.Module):
         text_state, text_mask = _safe_attention_mask(text_state, text_mask)
         aux_features = aux_features.astype(text_state.dtype)
 
-        # Token-sum architecture
+        # Token-sum architecture (speaker-only)
         if self.duration_architecture == "token_sum_adarn_zero_no_aux":
             if self.speaker_dim is None:
                 raise RuntimeError(
@@ -864,6 +965,41 @@ class DurationPredictor(nn.Module):
                 h = block(h, cond=speaker_vec)
             token_logits = self.token_out_proj(self.token_out_norm(h)).squeeze(-1)
             # NOTE: MLX lacks mx.softplus; equivalent to log(1 + exp(x))
+            token_frames = mx.log(1.0 + mx.exp(token_logits.astype(mx.float32)))
+            total_frames = mx.sum(
+                token_frames * text_mask.astype(token_frames.dtype), axis=1
+            )
+            return mx.log1p(mx.maximum(total_frames, 0.0))
+
+        # Token-sum dual architecture (speaker + caption, v3 VoiceDesign)
+        if self.duration_architecture == "token_sum_dual_adarn_zero_no_aux":
+            if self.speaker_dim is None or self.caption_dim is None:
+                raise RuntimeError(
+                    "Dual token-sum architecture requires both speaker and caption modules."
+                )
+            if has_speaker is None:
+                raise ValueError("has_speaker is required for dual duration prediction.")
+            if has_caption is None:
+                raise ValueError("has_caption is required for dual duration prediction.")
+            has_speaker = has_speaker.astype(mx.bool_)
+            has_caption = has_caption.astype(mx.bool_)
+            speaker_vec = self._speaker_vec(
+                batch_size=text_state.shape[0],
+                dtype=text_state.dtype,
+                speaker_state=speaker_state,
+                has_speaker=has_speaker,
+            )
+            caption_vec = self._caption_vec(
+                batch_size=text_state.shape[0],
+                dtype=text_state.dtype,
+                caption_state=caption_state,
+                caption_mask=caption_mask,
+                has_caption=has_caption,
+            )
+            h = self.token_input_proj(text_state)
+            for block in self.token_blocks:
+                h = block(h, cond=speaker_vec, caption_cond=caption_vec)
+            token_logits = self.token_out_proj(self.token_out_norm(h)).squeeze(-1)
             token_frames = mx.log(1.0 + mx.exp(token_logits.astype(mx.float32)))
             total_frames = mx.sum(
                 token_frames * text_mask.astype(token_frames.dtype), axis=1
@@ -995,9 +1131,10 @@ class IrodoriDiT(nn.Module):
     """
     Irodori-TTS DiT model (MLX port of TextToLatentRFDiT).
 
-    Supports two conditioning modes (mutually exclusive):
-      - Speaker mode (use_speaker_condition=True): ref audio latent → speaker embedding
-      - Caption mode (use_caption_condition=True): style text → caption embedding
+    Supports three conditioning modes:
+      - Speaker mode (use_speaker_condition_resolved=True, use_caption_condition=False)
+      - Caption mode (use_caption_condition=True, use_speaker_condition_resolved=False)
+      - Dual mode (both True, v3 VoiceDesign): speaker + caption simultaneously
 
     Input x_t : (B, S, latent_dim * latent_patch_size)
     Output v_t : same shape — velocity prediction for Rectified Flow ODE.
@@ -1018,7 +1155,10 @@ class IrodoriDiT(nn.Module):
         )
         self.text_norm = RMSNorm(cfg.text_dim, eps=cfg.norm_eps)
 
-        if cfg.use_speaker_condition:
+        speaker_ctx_dim: Optional[int] = None
+        caption_ctx_dim: Optional[int] = None
+
+        if cfg.use_speaker_condition_resolved:
             self.speaker_encoder = ReferenceLatentEncoder(
                 in_dim=cfg.speaker_patched_latent_dim,
                 dim=cfg.speaker_dim,
@@ -1028,10 +1168,9 @@ class IrodoriDiT(nn.Module):
                 norm_eps=cfg.norm_eps,
             )
             self.speaker_norm = RMSNorm(cfg.speaker_dim, eps=cfg.norm_eps)
-            context_dim = cfg.speaker_dim
-            speaker_ctx_dim: Optional[int] = cfg.speaker_dim
-            caption_ctx_dim: Optional[int] = None
-        else:
+            speaker_ctx_dim = cfg.speaker_dim
+
+        if cfg.use_caption_condition:
             self.caption_encoder = TextEncoder(
                 vocab_size=cfg.caption_vocab_size_resolved,
                 dim=cfg.caption_dim_resolved,
@@ -1041,16 +1180,13 @@ class IrodoriDiT(nn.Module):
                 norm_eps=cfg.norm_eps,
             )
             self.caption_norm = RMSNorm(cfg.caption_dim_resolved, eps=cfg.norm_eps)
-            context_dim = cfg.caption_dim_resolved
-            speaker_ctx_dim = None
             caption_ctx_dim = cfg.caption_dim_resolved
 
         # Duration predictor (v3)
         self.duration_predictor = None
         if cfg.use_duration_predictor:
-            duration_speaker_dim = None
-            if cfg.use_speaker_condition:
-                duration_speaker_dim = cfg.speaker_dim
+            duration_speaker_dim = cfg.speaker_dim if cfg.use_speaker_condition_resolved else None
+            duration_caption_dim = cfg.caption_dim_resolved if cfg.use_caption_condition else None
             self.duration_predictor = DurationPredictor(
                 text_dim=cfg.text_dim,
                 aux_dim=cfg.duration_aux_dim,
@@ -1059,6 +1195,9 @@ class IrodoriDiT(nn.Module):
                 norm_eps=cfg.norm_eps,
                 speaker_dim=duration_speaker_dim,
                 speaker_fusion=cfg.duration_speaker_fusion,
+                caption_dim=duration_caption_dim,
+                caption_fusion=cfg.duration_caption_fusion,
+                caption_pooling=cfg.duration_caption_pooling,
                 attention_heads=cfg.duration_attention_heads,
                 architecture=cfg.duration_architecture,
                 token_init_frames=cfg.duration_token_init_frames,
@@ -1091,8 +1230,6 @@ class IrodoriDiT(nn.Module):
         self.out_norm = RMSNorm(cfg.model_dim, eps=cfg.norm_eps)
         self.out_proj = nn.Linear(cfg.model_dim, cfg.patched_latent_dim, bias=True)
 
-        self._context_dim = context_dim
-
     # ------------------------------------------------------------------
     # Condition encoding (text + speaker/caption) — cached across steps
     # ------------------------------------------------------------------
@@ -1112,7 +1249,7 @@ class IrodoriDiT(nn.Module):
         """
         text_state = self.text_norm(self.text_encoder(text_input_ids, text_mask))
 
-        if self.cfg.use_speaker_condition:
+        if self.cfg.use_speaker_condition_resolved:
             assert ref_latent is not None and ref_mask is not None
             ref_latent_p, ref_mask_p = patch_sequence_with_mask(
                 ref_latent, ref_mask, self.cfg.speaker_patch_size
@@ -1154,7 +1291,7 @@ class IrodoriDiT(nn.Module):
 
         speaker_state = None
         speaker_mask = None
-        if self.cfg.use_speaker_condition:
+        if self.cfg.use_speaker_condition_resolved:
             if ref_latent is not None and ref_mask is not None:
                 ref_latent_p, ref_mask_p = patch_sequence_with_mask(
                     ref_latent, ref_mask, self.cfg.speaker_patch_size
@@ -1174,37 +1311,47 @@ class IrodoriDiT(nn.Module):
                     dtype=mx.bool_,
                 )
 
-        caption_state = None
-        caption_mask = None
+        out_caption_state = None
+        out_caption_mask = None
         if self.cfg.use_caption_condition:
             if caption_input_ids is not None and caption_mask is not None:
-                caption_state = self.caption_norm(
+                out_caption_state = self.caption_norm(
                     self.caption_encoder(caption_input_ids, caption_mask)
                 )
-                caption_mask = caption_mask
+                out_caption_mask = caption_mask
 
         return (
             text_state,
             text_mask,
             speaker_state,
             speaker_mask,
-            caption_state,
-            caption_mask,
+            out_caption_state,
+            out_caption_mask,
         )
 
     def build_kv_cache(
         self,
         text_state: mx.array,
-        context_state: mx.array,
-    ) -> Tuple[List[KVCache], List[KVCache]]:
-        """Pre-compute per-layer text/context KV projections for fast sampling."""
+        speaker_state: Optional[mx.array] = None,
+        caption_state: Optional[mx.array] = None,
+    ) -> Tuple[List[KVCache], Optional[List[KVCache]], Optional[List[KVCache]]]:
+        """Pre-compute per-layer text/speaker/caption KV projections for fast sampling."""
         kv_text = [
             block.attention.get_kv_cache_text(text_state) for block in self.blocks
         ]
-        kv_context = [
-            block.attention.get_kv_cache_context(context_state) for block in self.blocks
-        ]
-        return kv_text, kv_context
+        kv_speaker = None
+        if speaker_state is not None and self.cfg.use_speaker_condition_resolved:
+            kv_speaker = [
+                block.attention.get_kv_cache_speaker(speaker_state)
+                for block in self.blocks
+            ]
+        kv_caption = None
+        if caption_state is not None and self.cfg.use_caption_condition:
+            kv_caption = [
+                block.attention.get_kv_cache_caption(caption_state)
+                for block in self.blocks
+            ]
+        return kv_text, kv_speaker, kv_caption
 
     @staticmethod
     def masked_mean(state: mx.array, mask: mx.array) -> mx.array:
@@ -1221,6 +1368,9 @@ class IrodoriDiT(nn.Module):
         speaker_mask: Optional[mx.array],
         duration_features: mx.array,
         has_speaker: Optional[mx.array],
+        caption_state: Optional[mx.array] = None,
+        caption_mask: Optional[mx.array] = None,
+        has_caption: Optional[mx.array] = None,
     ) -> mx.array:
         """
         Predict log1p(num_frames) from text state and duration features.
@@ -1244,6 +1394,9 @@ class IrodoriDiT(nn.Module):
             speaker_state=speaker_state,
             speaker_mask=speaker_mask,
             has_speaker=has_speaker,
+            caption_state=caption_state,
+            caption_mask=caption_mask,
+            has_caption=has_caption,
         )
         return pred.astype(mx.float32)
 
@@ -1262,9 +1415,18 @@ class IrodoriDiT(nn.Module):
         kv_text: Optional[List[KVCache]] = None,
         kv_speaker: Optional[List[KVCache]] = None,
         start_pos: int = 0,
+        caption_state: Optional[mx.array] = None,
+        caption_mask: Optional[mx.array] = None,
+        kv_caption: Optional[List[KVCache]] = None,
     ) -> mx.array:
-        # NOTE: speaker_state/speaker_mask/kv_speaker are the generic "context"
-        # (either speaker or caption depending on cfg.use_caption_condition).
+        """
+        Forward pass with pre-encoded conditions.
+
+        For speaker-only models: speaker_state/mask carry the speaker context.
+        For caption-only models: speaker_state/mask carry the caption context
+            (backward-compat; internally routed to caption branch).
+        For dual models (v3 VoiceDesign): speaker_state=speaker, caption_state=caption.
+        """
         t_embed = get_timestep_embedding(t, self.cfg.timestep_embed_dim).astype(
             x_t.dtype
         )
@@ -1273,25 +1435,55 @@ class IrodoriDiT(nn.Module):
         x = self.in_proj(x_t)
         freqs_cis = precompute_freqs_cis(self.head_dim, start_pos + x.shape[1])
 
+        use_spk = self.cfg.use_speaker_condition_resolved
+        use_cap = self.cfg.use_caption_condition
+
+        # For caption-only models: speaker_state arg contains caption context (backward compat)
+        if not use_spk and use_cap:
+            actual_caption_state = caption_state if caption_state is not None else speaker_state
+            actual_caption_mask = caption_mask if caption_mask is not None else speaker_mask
+            actual_kv_caption = kv_caption if kv_caption is not None else kv_speaker
+            actual_speaker_state = None
+            actual_speaker_mask = None
+            actual_kv_speaker = None
+        else:
+            actual_speaker_state = speaker_state
+            actual_speaker_mask = speaker_mask
+            actual_kv_speaker = kv_speaker
+            actual_caption_state = caption_state
+            actual_caption_mask = caption_mask
+            actual_kv_caption = kv_caption
+
         for i, block in enumerate(self.blocks):
             kv_t = (
                 kv_text[i]
                 if kv_text is not None
                 else block.attention.get_kv_cache_text(text_state)
             )
-            kv_s = (
-                kv_speaker[i]
-                if kv_speaker is not None
-                else block.attention.get_kv_cache_context(speaker_state)
-            )
+            kv_s = None
+            if use_spk and actual_speaker_state is not None:
+                kv_s = (
+                    actual_kv_speaker[i]
+                    if actual_kv_speaker is not None
+                    else block.attention.get_kv_cache_speaker(actual_speaker_state)
+                )
+            kv_c = None
+            if use_cap and actual_caption_state is not None:
+                kv_c = (
+                    actual_kv_caption[i]
+                    if actual_kv_caption is not None
+                    else block.attention.get_kv_cache_caption(actual_caption_state)
+                )
             x = block(
                 x,
                 cond_embed,
                 text_mask,
-                speaker_mask,
                 freqs_cis,
                 kv_t,
                 kv_s,
+                actual_speaker_mask,
+                kv_c,
+                actual_caption_mask,
                 start_pos,
             )
 

--- a/mlx_audio/tts/models/irodori_tts/model.py
+++ b/mlx_audio/tts/models/irodori_tts/model.py
@@ -262,7 +262,9 @@ class JointAttention(nn.Module):
         self.has_speaker_condition = speaker_ctx_dim is not None
         self.has_caption_condition = caption_ctx_dim is not None
         if not self.has_speaker_condition and not self.has_caption_condition:
-            raise ValueError("At least one of speaker_ctx_dim or caption_ctx_dim must be set")
+            raise ValueError(
+                "At least one of speaker_ctx_dim or caption_ctx_dim must be set"
+            )
         if speaker_ctx_dim is not None:
             self.wk_speaker = nn.Linear(speaker_ctx_dim, dim, bias=False)
             self.wv_speaker = nn.Linear(speaker_ctx_dim, dim, bias=False)
@@ -602,8 +604,12 @@ class DurationSwiGLUBlock(nn.Module):
                 gate = gate + dg
             if self.caption_modulation is not None:
                 if caption_cond is None:
-                    raise ValueError("caption_cond is required for caption AdaRN-Zero blocks.")
-                cs, csc, cg = mx.split(self.caption_modulation(nn.silu(caption_cond)), 3, axis=-1)
+                    raise ValueError(
+                        "caption_cond is required for caption AdaRN-Zero blocks."
+                    )
+                cs, csc, cg = mx.split(
+                    self.caption_modulation(nn.silu(caption_cond)), 3, axis=-1
+                )
                 if h.ndim == 3 and cs.ndim == 2:
                     cs, csc, cg = cs[:, None, :], csc[:, None, :], cg[:, None, :]
                 shift = shift + cs
@@ -978,9 +984,13 @@ class DurationPredictor(nn.Module):
                     "Dual token-sum architecture requires both speaker and caption modules."
                 )
             if has_speaker is None:
-                raise ValueError("has_speaker is required for dual duration prediction.")
+                raise ValueError(
+                    "has_speaker is required for dual duration prediction."
+                )
             if has_caption is None:
-                raise ValueError("has_caption is required for dual duration prediction.")
+                raise ValueError(
+                    "has_caption is required for dual duration prediction."
+                )
             has_speaker = has_speaker.astype(mx.bool_)
             has_caption = has_caption.astype(mx.bool_)
             speaker_vec = self._speaker_vec(
@@ -1185,8 +1195,12 @@ class IrodoriDiT(nn.Module):
         # Duration predictor (v3)
         self.duration_predictor = None
         if cfg.use_duration_predictor:
-            duration_speaker_dim = cfg.speaker_dim if cfg.use_speaker_condition_resolved else None
-            duration_caption_dim = cfg.caption_dim_resolved if cfg.use_caption_condition else None
+            duration_speaker_dim = (
+                cfg.speaker_dim if cfg.use_speaker_condition_resolved else None
+            )
+            duration_caption_dim = (
+                cfg.caption_dim_resolved if cfg.use_caption_condition else None
+            )
             self.duration_predictor = DurationPredictor(
                 text_dim=cfg.text_dim,
                 aux_dim=cfg.duration_aux_dim,
@@ -1440,8 +1454,12 @@ class IrodoriDiT(nn.Module):
 
         # For caption-only models: speaker_state arg contains caption context (backward compat)
         if not use_spk and use_cap:
-            actual_caption_state = caption_state if caption_state is not None else speaker_state
-            actual_caption_mask = caption_mask if caption_mask is not None else speaker_mask
+            actual_caption_state = (
+                caption_state if caption_state is not None else speaker_state
+            )
+            actual_caption_mask = (
+                caption_mask if caption_mask is not None else speaker_mask
+            )
             actual_kv_caption = kv_caption if kv_caption is not None else kv_speaker
             actual_speaker_state = None
             actual_speaker_mask = None

--- a/mlx_audio/tts/models/irodori_tts/sampling.py
+++ b/mlx_audio/tts/models/irodori_tts/sampling.py
@@ -115,10 +115,15 @@ def sample_euler_cfg(
         cfg_scale_speaker = float(cfg_scale)
         cfg_scale_caption = float(cfg_scale)
 
-    # Resolve context CFG scale based on conditioning mode
-    cfg_scale_context = (
-        cfg_scale_caption if model.cfg.use_caption_condition else cfg_scale_speaker
-    )
+    use_spk = model.cfg.use_speaker_condition_resolved
+    use_cap = model.cfg.use_caption_condition
+    is_dual = use_spk and use_cap
+
+    # Resolve context CFG scale for single-context models
+    if not is_dual:
+        cfg_scale_context = cfg_scale_caption if use_cap else cfg_scale_speaker
+    else:
+        cfg_scale_context = cfg_scale_speaker  # unused in dual, kept for compat
 
     cfg_guidance_mode = cfg_guidance_mode.strip().lower()
     if cfg_guidance_mode not in {"independent", "joint", "alternating"}:
@@ -129,94 +134,169 @@ def sample_euler_cfg(
 
     batch_size = text_input_ids.shape[0]
     has_text_cfg = cfg_scale_text > 0
-    has_speaker_cfg = cfg_scale_context > 0
+    has_speaker_cfg = cfg_scale_speaker > 0 and use_spk
+    has_caption_cfg = cfg_scale_caption > 0 and use_cap
+    # For single-context backward compat
+    if not is_dual:
+        has_context_cfg = cfg_scale_context > 0
+    else:
+        has_context_cfg = False  # not used in dual path
 
-    # ---- encode conditions once ----
-    text_state_cond, text_mask_cond, speaker_state_cond, speaker_mask_cond = (
-        model.encode_conditions(
-            text_input_ids=text_input_ids,
-            text_mask=text_mask,
-            ref_latent=ref_latent,
-            ref_mask=ref_mask,
-            caption_input_ids=caption_input_ids,
-            caption_mask=caption_mask,
-        )
+    # ---- encode all conditions ----
+    (
+        text_state_cond,
+        text_mask_cond,
+        spk_state_full,
+        spk_mask_full,
+        cap_state_full,
+        cap_mask_full,
+    ) = model.encode_conditions_full(
+        text_input_ids=text_input_ids,
+        text_mask=text_mask,
+        ref_latent=ref_latent,
+        ref_mask=ref_mask,
+        caption_input_ids=caption_input_ids,
+        caption_mask=caption_mask,
     )
-    mx.eval(text_state_cond, speaker_state_cond)
 
-    # unconditioned states: zero arrays of same shape
-    # (TextEncoder/SpeakerEncoder zero-masks any position, so feeding zero mask
-    #  gives zero state; using explicit zeros is equivalent and avoids recomputation)
+    # For single-context models, alias context into "speaker" slot (backward compat)
+    if not is_dual and use_cap:
+        speaker_state_cond = cap_state_full
+        speaker_mask_cond = cap_mask_full
+        caption_state_cond = None
+        caption_mask_cond = None
+    else:
+        speaker_state_cond = spk_state_full
+        speaker_mask_cond = spk_mask_full
+        caption_state_cond = cap_state_full
+        caption_mask_cond = cap_mask_full
+
+    mx.eval(text_state_cond)
+    if speaker_state_cond is not None:
+        mx.eval(speaker_state_cond)
+    if caption_state_cond is not None:
+        mx.eval(caption_state_cond)
+
+    # unconditioned states
     text_state_uncond = mx.zeros_like(text_state_cond)
     text_mask_uncond = mx.zeros_like(text_mask_cond)
-    speaker_state_uncond = mx.zeros_like(speaker_state_cond)
-    speaker_mask_uncond = mx.zeros_like(speaker_mask_cond)
+    speaker_state_uncond = (
+        mx.zeros_like(speaker_state_cond) if speaker_state_cond is not None else None
+    )
+    speaker_mask_uncond = (
+        mx.zeros_like(speaker_mask_cond) if speaker_mask_cond is not None else None
+    )
+    caption_state_uncond = (
+        mx.zeros_like(caption_state_cond) if caption_state_cond is not None else None
+    )
+    caption_mask_uncond = (
+        mx.zeros_like(caption_mask_cond) if caption_mask_cond is not None else None
+    )
 
     # ---- build KV caches ----
     use_kv_cache = context_kv_cache or (speaker_kv_scale is not None)
 
     kv_text_cond: Optional[KVCache] = None
     kv_speaker_cond: Optional[KVCache] = None
+    kv_caption_cond: Optional[KVCache] = None
     kv_text_cfg: Optional[KVCache] = None
     kv_speaker_cfg: Optional[KVCache] = None
+    kv_caption_cfg: Optional[KVCache] = None
     # extra caches for joint/alternating
     kv_text_uncond_joint: Optional[KVCache] = None
     kv_speaker_uncond_joint: Optional[KVCache] = None
+    kv_caption_uncond_joint: Optional[KVCache] = None
     kv_text_uncond_alt: Optional[KVCache] = None
     kv_speaker_uncond_alt: Optional[KVCache] = None
+    kv_caption_uncond_alt: Optional[KVCache] = None
 
     if use_kv_cache:
-        kv_text_cond, kv_speaker_cond = model.build_kv_cache(
-            text_state_cond, speaker_state_cond
+        kv_text_cond, kv_speaker_cond, kv_caption_cond = model.build_kv_cache(
+            text_state_cond, speaker_state_cond, caption_state_cond
         )
-        if speaker_kv_scale is not None:
+        if speaker_kv_scale is not None and kv_speaker_cond is not None:
             kv_speaker_cond = _scale_kv_cache(
                 kv_speaker_cond, speaker_kv_scale, max_layers=speaker_kv_max_layers
             )
 
         if cfg_guidance_mode == "independent":
-            if has_text_cfg and has_speaker_cfg:
-                # batch order: [cond, text-uncond, speaker-uncond]
-                kv_text_cfg = _concat_kv_caches(
-                    kv_text_cond, kv_text_cond, kv_text_cond
-                )
-                kv_speaker_cfg = _concat_kv_caches(
-                    kv_speaker_cond, kv_speaker_cond, kv_speaker_cond
-                )
-            elif has_text_cfg:
-                kv_text_cfg = _concat_kv_caches(kv_text_cond, kv_text_cond)
-                kv_speaker_cfg = _concat_kv_caches(kv_speaker_cond, kv_speaker_cond)
-            elif has_speaker_cfg:
-                kv_text_cfg = _concat_kv_caches(kv_text_cond, kv_text_cond)
-                kv_speaker_cfg = _concat_kv_caches(kv_speaker_cond, kv_speaker_cond)
+            if is_dual:
+                # Dual mode: up to 4x batch [cond, text-uncond, spk-uncond, cap-uncond]
+                active = [True]  # always include cond
+                if has_text_cfg:
+                    active.append("text")
+                if has_speaker_cfg:
+                    active.append("speaker")
+                if has_caption_cfg:
+                    active.append("caption")
+                # Build concatenated caches with per-slot uncond entries
+                n_bundles = 1 + sum([has_text_cfg, has_speaker_cfg, has_caption_cfg])
+                kv_text_parts = [kv_text_cond] * n_bundles
+                kv_spk_parts = [kv_speaker_cond] * n_bundles
+                kv_cap_parts = [kv_caption_cond] * n_bundles
+                if n_bundles > 1:
+                    kv_text_cfg = _concat_kv_caches(*kv_text_parts)
+                    kv_speaker_cfg = _concat_kv_caches(*kv_spk_parts)
+                    kv_caption_cfg = _concat_kv_caches(*kv_cap_parts)
+            else:
+                # Single-context backward compat
+                if has_text_cfg and has_context_cfg:
+                    kv_text_cfg = _concat_kv_caches(
+                        kv_text_cond, kv_text_cond, kv_text_cond
+                    )
+                    if kv_speaker_cond is not None:
+                        kv_speaker_cfg = _concat_kv_caches(
+                            kv_speaker_cond, kv_speaker_cond, kv_speaker_cond
+                        )
+                elif has_text_cfg:
+                    kv_text_cfg = _concat_kv_caches(kv_text_cond, kv_text_cond)
+                    if kv_speaker_cond is not None:
+                        kv_speaker_cfg = _concat_kv_caches(
+                            kv_speaker_cond, kv_speaker_cond
+                        )
+                elif has_context_cfg:
+                    kv_text_cfg = _concat_kv_caches(kv_text_cond, kv_text_cond)
+                    if kv_speaker_cond is not None:
+                        kv_speaker_cfg = _concat_kv_caches(
+                            kv_speaker_cond, kv_speaker_cond
+                        )
 
         elif cfg_guidance_mode == "joint":
-            if has_text_cfg or has_speaker_cfg:
-                kv_text_uncond_joint, kv_speaker_uncond_joint = model.build_kv_cache(
-                    text_state_uncond, speaker_state_uncond
-                )
-
-        elif cfg_guidance_mode == "alternating":
-            if has_text_cfg:
-                kv_text_uncond_alt, _ = model.build_kv_cache(
-                    text_state_uncond, speaker_state_cond
-                )
-                kv_text_uncond_alt = kv_text_uncond_alt
-                _, kv_speaker_uncond_alt_sp = model.build_kv_cache(
-                    text_state_uncond, speaker_state_cond
-                )
-            if has_speaker_cfg:
-                _, kv_speaker_uncond_alt = model.build_kv_cache(
-                    text_state_cond, speaker_state_uncond
-                )
-                if speaker_kv_scale is not None:
-                    kv_speaker_uncond_alt = _scale_kv_cache(
-                        kv_speaker_uncond_alt,
-                        speaker_kv_scale,
-                        max_layers=speaker_kv_max_layers,
+            if is_dual:
+                if has_text_cfg or has_speaker_cfg or has_caption_cfg:
+                    kv_text_uncond_joint, kv_speaker_uncond_joint, kv_caption_uncond_joint = (
+                        model.build_kv_cache(
+                            text_state_uncond, speaker_state_uncond, caption_state_uncond
+                        )
+                    )
+            else:
+                if has_text_cfg or has_context_cfg:
+                    kv_text_uncond_joint, kv_speaker_uncond_joint, _ = model.build_kv_cache(
+                        text_state_uncond, speaker_state_uncond
                     )
 
-        mx.eval(kv_text_cond, kv_speaker_cond)
+        elif cfg_guidance_mode == "alternating":
+            if not is_dual:
+                if has_text_cfg:
+                    kv_text_uncond_alt, _, _ = model.build_kv_cache(
+                        text_state_uncond, speaker_state_cond
+                    )
+                if has_context_cfg:
+                    _, kv_speaker_uncond_alt, _ = model.build_kv_cache(
+                        text_state_cond, speaker_state_uncond
+                    )
+                    if speaker_kv_scale is not None and kv_speaker_uncond_alt is not None:
+                        kv_speaker_uncond_alt = _scale_kv_cache(
+                            kv_speaker_uncond_alt,
+                            speaker_kv_scale,
+                            max_layers=speaker_kv_max_layers,
+                        )
+
+        mx.eval(kv_text_cond)
+        if kv_speaker_cond is not None:
+            mx.eval(kv_speaker_cond)
+        if kv_caption_cond is not None:
+            mx.eval(kv_caption_cond)
 
     # ---- initial noise ----
     mx.random.seed(rng_seed)
@@ -249,8 +329,70 @@ def sample_euler_cfg(
 
         if use_cfg:
             if cfg_guidance_mode == "independent":
-                if has_text_cfg and has_speaker_cfg:
-                    # 3x batch: [cond, text-uncond, speaker-uncond]
+                if is_dual:
+                    # Dual mode: build bundle list [cond, text-uncond?, spk-uncond?, cap-uncond?]
+                    bundles_x = [x_t]
+                    bundles_t = [text_state_cond]
+                    bundles_tm = [text_mask_cond]
+                    bundles_s = [speaker_state_cond]
+                    bundles_sm = [speaker_mask_cond]
+                    bundles_c = [caption_state_cond]
+                    bundles_cm = [caption_mask_cond]
+                    if has_text_cfg:
+                        bundles_x.append(x_t)
+                        bundles_t.append(text_state_uncond)
+                        bundles_tm.append(text_mask_uncond)
+                        bundles_s.append(speaker_state_cond)
+                        bundles_sm.append(speaker_mask_cond)
+                        bundles_c.append(caption_state_cond)
+                        bundles_cm.append(caption_mask_cond)
+                    if has_speaker_cfg:
+                        bundles_x.append(x_t)
+                        bundles_t.append(text_state_cond)
+                        bundles_tm.append(text_mask_cond)
+                        bundles_s.append(speaker_state_uncond)
+                        bundles_sm.append(speaker_mask_uncond)
+                        bundles_c.append(caption_state_cond)
+                        bundles_cm.append(caption_mask_cond)
+                    if has_caption_cfg:
+                        bundles_x.append(x_t)
+                        bundles_t.append(text_state_cond)
+                        bundles_tm.append(text_mask_cond)
+                        bundles_s.append(speaker_state_cond)
+                        bundles_sm.append(speaker_mask_cond)
+                        bundles_c.append(caption_state_uncond)
+                        bundles_cm.append(caption_mask_uncond)
+                    n_b = len(bundles_x)
+                    x_cfg = mx.concatenate(bundles_x, axis=0)
+                    t_cfg = mx.full((batch_size * n_b,), t, dtype=mx.float32)
+                    v_out = model.forward_with_conditions(
+                        x_t=x_cfg,
+                        t=t_cfg,
+                        text_state=mx.concatenate(bundles_t, axis=0),
+                        text_mask=mx.concatenate(bundles_tm, axis=0),
+                        speaker_state=mx.concatenate(bundles_s, axis=0),
+                        speaker_mask=mx.concatenate(bundles_sm, axis=0),
+                        kv_text=kv_text_cfg,
+                        kv_speaker=kv_speaker_cfg,
+                        caption_state=mx.concatenate(bundles_c, axis=0),
+                        caption_mask=mx.concatenate(bundles_cm, axis=0),
+                        kv_caption=kv_caption_cfg,
+                    )
+                    splits = mx.split(v_out, n_b, axis=0)
+                    v_cond = splits[0]
+                    v_pred = v_cond
+                    idx = 1
+                    if has_text_cfg:
+                        v_pred = v_pred + cfg_scale_text * (v_cond - splits[idx])
+                        idx += 1
+                    if has_speaker_cfg:
+                        v_pred = v_pred + cfg_scale_speaker * (v_cond - splits[idx])
+                        idx += 1
+                    if has_caption_cfg:
+                        v_pred = v_pred + cfg_scale_caption * (v_cond - splits[idx])
+
+                elif has_text_cfg and has_context_cfg:
+                    # 3x batch: [cond, text-uncond, context-uncond]
                     x_cfg = mx.concatenate([x_t, x_t, x_t], axis=0)
                     t_cfg = mx.full((batch_size * 3,), t, dtype=mx.float32)
                     text_mask_cfg = mx.concatenate(
@@ -311,7 +453,7 @@ def sample_euler_cfg(
                     v_cond, v_uncond_text = mx.split(v_out, 2, axis=0)
                     v_pred = v_cond + cfg_scale_text * (v_cond - v_uncond_text)
 
-                else:  # has_speaker_cfg only
+                else:  # has_context_cfg only
                     x_cfg = mx.concatenate([x_t, x_t], axis=0)
                     t_cfg = mx.full((batch_size * 2,), t, dtype=mx.float32)
                     v_out = model.forward_with_conditions(
@@ -336,7 +478,21 @@ def sample_euler_cfg(
                     v_pred = v_cond + cfg_scale_context * (v_cond - v_uncond_speaker)
 
             elif cfg_guidance_mode == "joint":
-                if has_text_cfg and has_speaker_cfg:
+                has_any_cfg = (
+                    (has_text_cfg or has_speaker_cfg or has_caption_cfg)
+                    if is_dual
+                    else (has_text_cfg or has_context_cfg)
+                )
+                if is_dual:
+                    all_scales = [
+                        s for s, a in [
+                            (cfg_scale_text, has_text_cfg),
+                            (cfg_scale_speaker, has_speaker_cfg),
+                            (cfg_scale_caption, has_caption_cfg),
+                        ] if a
+                    ]
+                    joint_scale = all_scales[0] if all_scales else cfg_scale_text
+                elif has_text_cfg and has_context_cfg:
                     if abs(cfg_scale_text - cfg_scale_context) > 1e-6:
                         raise ValueError(
                             "cfg_guidance_mode='joint' requires equal text/speaker scales. "
@@ -355,6 +511,9 @@ def sample_euler_cfg(
                     speaker_mask=speaker_mask_cond,
                     kv_text=kv_text_cond,
                     kv_speaker=kv_speaker_cond,
+                    caption_state=caption_state_cond,
+                    caption_mask=caption_mask_cond,
+                    kv_caption=kv_caption_cond,
                 )
                 v_uncond = model.forward_with_conditions(
                     x_t=x_t,
@@ -365,10 +524,13 @@ def sample_euler_cfg(
                     speaker_mask=speaker_mask_uncond,
                     kv_text=kv_text_uncond_joint,
                     kv_speaker=kv_speaker_uncond_joint,
+                    caption_state=caption_state_uncond,
+                    caption_mask=caption_mask_uncond,
+                    kv_caption=kv_caption_uncond_joint,
                 )
                 v_pred = v_cond + joint_scale * (v_cond - v_uncond)
 
-            else:  # alternating
+            else:  # alternating (single-context only)
                 v_cond = model.forward_with_conditions(
                     x_t=x_t,
                     t=t_arr,
@@ -379,8 +541,8 @@ def sample_euler_cfg(
                     kv_text=kv_text_cond,
                     kv_speaker=kv_speaker_cond,
                 )
-                use_text_uncond = (has_text_cfg and has_speaker_cfg and i % 2 == 0) or (
-                    has_text_cfg and not has_speaker_cfg
+                use_text_uncond = (has_text_cfg and has_context_cfg and i % 2 == 0) or (
+                    has_text_cfg and not has_context_cfg
                 )
                 if use_text_uncond:
                     v_uncond = model.forward_with_conditions(
@@ -418,6 +580,9 @@ def sample_euler_cfg(
                 speaker_mask=speaker_mask_cond,
                 kv_text=kv_text_cond,
                 kv_speaker=kv_speaker_cond,
+                caption_state=caption_state_cond,
+                caption_mask=caption_mask_cond,
+                kv_caption=kv_caption_cond,
             )
 
         # optional temporal score rescaling
@@ -429,14 +594,16 @@ def sample_euler_cfg(
             speaker_kv_active
             and speaker_kv_min_t is not None
             and t_next < speaker_kv_min_t <= t
+            and kv_speaker_cond is not None
         ):
             inv = 1.0 / speaker_kv_scale
             kv_speaker_cond = _scale_kv_cache(
                 kv_speaker_cond, inv, max_layers=speaker_kv_max_layers
             )
             if kv_speaker_cfg is not None:
+                n_rep = 3 if (not is_dual and has_text_cfg and has_context_cfg) else 2
                 kv_speaker_cfg = _concat_kv_caches(
-                    kv_speaker_cond, kv_speaker_cond, kv_speaker_cond
+                    *([kv_speaker_cond] * n_rep)
                 )
             if kv_speaker_uncond_alt is not None:
                 kv_speaker_uncond_alt = _scale_kv_cache(

--- a/mlx_audio/tts/models/irodori_tts/sampling.py
+++ b/mlx_audio/tts/models/irodori_tts/sampling.py
@@ -264,15 +264,17 @@ def sample_euler_cfg(
         elif cfg_guidance_mode == "joint":
             if is_dual:
                 if has_text_cfg or has_speaker_cfg or has_caption_cfg:
-                    kv_text_uncond_joint, kv_speaker_uncond_joint, kv_caption_uncond_joint = (
-                        model.build_kv_cache(
-                            text_state_uncond, speaker_state_uncond, caption_state_uncond
-                        )
+                    (
+                        kv_text_uncond_joint,
+                        kv_speaker_uncond_joint,
+                        kv_caption_uncond_joint,
+                    ) = model.build_kv_cache(
+                        text_state_uncond, speaker_state_uncond, caption_state_uncond
                     )
             else:
                 if has_text_cfg or has_context_cfg:
-                    kv_text_uncond_joint, kv_speaker_uncond_joint, _ = model.build_kv_cache(
-                        text_state_uncond, speaker_state_uncond
+                    kv_text_uncond_joint, kv_speaker_uncond_joint, _ = (
+                        model.build_kv_cache(text_state_uncond, speaker_state_uncond)
                     )
 
         elif cfg_guidance_mode == "alternating":
@@ -285,7 +287,10 @@ def sample_euler_cfg(
                     _, kv_speaker_uncond_alt, _ = model.build_kv_cache(
                         text_state_cond, speaker_state_uncond
                     )
-                    if speaker_kv_scale is not None and kv_speaker_uncond_alt is not None:
+                    if (
+                        speaker_kv_scale is not None
+                        and kv_speaker_uncond_alt is not None
+                    ):
                         kv_speaker_uncond_alt = _scale_kv_cache(
                             kv_speaker_uncond_alt,
                             speaker_kv_scale,
@@ -485,11 +490,13 @@ def sample_euler_cfg(
                 )
                 if is_dual:
                     all_scales = [
-                        s for s, a in [
+                        s
+                        for s, a in [
                             (cfg_scale_text, has_text_cfg),
                             (cfg_scale_speaker, has_speaker_cfg),
                             (cfg_scale_caption, has_caption_cfg),
-                        ] if a
+                        ]
+                        if a
                     ]
                     joint_scale = all_scales[0] if all_scales else cfg_scale_text
                 elif has_text_cfg and has_context_cfg:
@@ -602,9 +609,7 @@ def sample_euler_cfg(
             )
             if kv_speaker_cfg is not None:
                 n_rep = 3 if (not is_dual and has_text_cfg and has_context_cfg) else 2
-                kv_speaker_cfg = _concat_kv_caches(
-                    *([kv_speaker_cond] * n_rep)
-                )
+                kv_speaker_cfg = _concat_kv_caches(*([kv_speaker_cond] * n_rep))
             if kv_speaker_uncond_alt is not None:
                 kv_speaker_uncond_alt = _scale_kv_cache(
                     kv_speaker_uncond_alt, inv, max_layers=speaker_kv_max_layers

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -4173,9 +4173,10 @@ class TestIrodoriDiTShapes(unittest.TestCase):
         t_state, t_mask, s_state, s_mask = self.model.encode_conditions(
             text_ids, text_mask, ref_latent, ref_mask
         )
-        kv_text, kv_speaker = self.model.build_kv_cache(t_state, s_state)
+        kv_text, kv_speaker, kv_caption = self.model.build_kv_cache(t_state, s_state)
         self.assertEqual(len(kv_text), self.cfg.num_layers)
         self.assertEqual(len(kv_speaker), self.cfg.num_layers)
+        self.assertIsNone(kv_caption)
 
         x_t = mx.random.normal((B, S, self.cfg.patched_latent_dim))
         t = mx.array([0.3], dtype=mx.float32)
@@ -4729,6 +4730,226 @@ class TestIrodoriSwaySampling(unittest.TestCase):
         )
         mx.eval(out)
         self.assertEqual(tuple(out.shape), (1, 4, cfg.patched_latent_dim))
+
+
+# ---------------------------------------------------------------------------
+# Irodori-TTS v3 VoiceDesign helpers (dual speaker + caption)
+# ---------------------------------------------------------------------------
+
+
+def _small_irodori_dit_config_v3_voicedesign(**overrides):
+    from mlx_audio.tts.models.irodori_tts.config import IrodoriDiTConfig
+
+    defaults = dict(
+        latent_dim=8,
+        latent_patch_size=1,
+        model_dim=32,
+        num_layers=2,
+        num_heads=4,
+        mlp_ratio=2.0,
+        text_mlp_ratio=2.0,
+        speaker_mlp_ratio=2.0,
+        text_vocab_size=64,
+        text_dim=32,
+        text_layers=1,
+        text_heads=4,
+        speaker_dim=32,
+        speaker_layers=1,
+        speaker_heads=4,
+        speaker_patch_size=1,
+        timestep_embed_dim=16,
+        adaln_rank=8,
+        norm_eps=1e-5,
+        use_duration_predictor=True,
+        use_caption_condition=True,
+        use_speaker_condition=True,
+        caption_vocab_size=64,
+        caption_dim=32,
+        caption_layers=1,
+        caption_heads=4,
+        caption_mlp_ratio=2.0,
+        duration_aux_dim=14,
+        duration_hidden_dim=16,
+        duration_layers=1,
+        duration_dropout=0.0,
+        duration_attention_heads=4,
+        duration_architecture="token_sum_dual_adarn_zero_no_aux",
+        duration_token_init_frames=9.0,
+        duration_speaker_fusion="adarn_zero",
+        duration_caption_fusion="adarn_zero",
+        duration_caption_pooling="masked_mean",
+    )
+    defaults.update(overrides)
+    return IrodoriDiTConfig(**defaults)
+
+
+def _small_irodori_model_config_v3_voicedesign(**sampler_overrides):
+    from mlx_audio.tts.models.irodori_tts.config import ModelConfig, SamplerConfig
+
+    sampler_defaults = dict(
+        num_steps=1,
+        cfg_scale_text=1.0,
+        cfg_scale_speaker=1.0,
+        cfg_scale_caption=1.0,
+        sequence_length=4,
+        t_schedule_mode="sway",
+        sway_coeff=-1.0,
+    )
+    sampler_defaults.update(sampler_overrides)
+    return ModelConfig(
+        dit=_small_irodori_dit_config_v3_voicedesign(),
+        sampler=SamplerConfig(**sampler_defaults),
+    )
+
+
+class TestIrodoriV3VoiceDesignShapes(unittest.TestCase):
+    def setUp(self):
+        from mlx_audio.tts.models.irodori_tts.model import IrodoriDiT
+
+        self.cfg = _small_irodori_dit_config_v3_voicedesign()
+        self.model = IrodoriDiT(self.cfg)
+
+    def test_both_encoders_present(self):
+        self.assertTrue(hasattr(self.model, "speaker_encoder"))
+        self.assertTrue(hasattr(self.model, "caption_encoder"))
+
+    def test_duration_predictor_present(self):
+        self.assertIsNotNone(self.model.duration_predictor)
+        self.assertEqual(
+            self.model.duration_predictor.duration_architecture,
+            "token_sum_dual_adarn_zero_no_aux",
+        )
+
+    def test_encode_conditions_full_returns_six(self):
+        B = 1
+        text_ids = mx.zeros((B, 5), dtype=mx.int32)
+        text_mask = mx.ones((B, 5), dtype=mx.bool_)
+        ref_latent = mx.random.normal((B, 8, self.cfg.latent_dim))
+        ref_mask = mx.ones((B, 8), dtype=mx.bool_)
+        cap_ids = mx.zeros((B, 5), dtype=mx.int32)
+        cap_mask = mx.ones((B, 5), dtype=mx.bool_)
+
+        result = self.model.encode_conditions_full(
+            text_ids, text_mask, ref_latent, ref_mask, cap_ids, cap_mask
+        )
+        self.assertEqual(len(result), 6)
+        text_state, _, spk_state, _, cap_state, _ = result
+        self.assertIsNotNone(spk_state)
+        self.assertIsNotNone(cap_state)
+        mx.eval(text_state, spk_state, cap_state)
+        self.assertEqual(tuple(text_state.shape), (B, 5, self.cfg.text_dim))
+        self.assertEqual(tuple(spk_state.shape[:2]), (B, 8))
+        self.assertEqual(tuple(cap_state.shape), (B, 5, self.cfg.caption_dim_resolved))
+
+    def test_build_kv_cache_dual(self):
+        B = 1
+        text_ids = mx.zeros((B, 5), dtype=mx.int32)
+        text_mask = mx.ones((B, 5), dtype=mx.bool_)
+        ref_latent = mx.zeros((B, 8, self.cfg.latent_dim))
+        ref_mask = mx.ones((B, 8), dtype=mx.bool_)
+        cap_ids = mx.zeros((B, 5), dtype=mx.int32)
+        cap_mask = mx.ones((B, 5), dtype=mx.bool_)
+
+        _, _, spk_state, _, cap_state, _ = self.model.encode_conditions_full(
+            text_ids, text_mask, ref_latent, ref_mask, cap_ids, cap_mask
+        )
+        text_state = self.model.text_norm(self.model.text_encoder(text_ids, text_mask))
+        kv_text, kv_spk, kv_cap = self.model.build_kv_cache(
+            text_state, spk_state, cap_state
+        )
+        self.assertEqual(len(kv_text), self.cfg.num_layers)
+        self.assertIsNotNone(kv_spk)
+        self.assertIsNotNone(kv_cap)
+        self.assertEqual(len(kv_spk), self.cfg.num_layers)
+        self.assertEqual(len(kv_cap), self.cfg.num_layers)
+
+    def test_predict_duration_dual(self):
+        from mlx_audio.tts.models.irodori_tts.duration import build_duration_features
+
+        B = 1
+        text_ids = mx.zeros((B, 5), dtype=mx.int32)
+        text_mask = mx.ones((B, 5), dtype=mx.bool_)
+        ref_latent = mx.random.normal((B, 8, self.cfg.latent_dim))
+        ref_mask = mx.ones((B, 8), dtype=mx.bool_)
+        cap_ids = mx.zeros((B, 5), dtype=mx.int32)
+        cap_mask = mx.ones((B, 5), dtype=mx.bool_)
+
+        text_state, text_mask_out, spk_state, spk_mask, cap_state, cap_mask_out = (
+            self.model.encode_conditions_full(
+                text_ids, text_mask, ref_latent, ref_mask, cap_ids, cap_mask
+            )
+        )
+        dur_feats = build_duration_features(
+            ["テスト"], token_counts=[5], max_text_len=256, has_speaker=[True]
+        )
+        log_frames = self.model.predict_duration_log_frames(
+            text_state=text_state,
+            text_mask=text_mask_out,
+            speaker_state=spk_state,
+            speaker_mask=spk_mask,
+            duration_features=dur_feats,
+            has_speaker=mx.array([True], dtype=mx.bool_),
+            caption_state=cap_state,
+            caption_mask=cap_mask_out,
+            has_caption=mx.array([True], dtype=mx.bool_),
+        )
+        mx.eval(log_frames)
+        self.assertEqual(tuple(log_frames.shape), (B,))
+        self.assertGreaterEqual(float(log_frames[0]), 0.0)
+
+    def test_forward_with_conditions_dual(self):
+        B, S = 1, 4
+        text_ids = mx.zeros((B, 5), dtype=mx.int32)
+        text_mask = mx.ones((B, 5), dtype=mx.bool_)
+        ref_latent = mx.zeros((B, 8, self.cfg.latent_dim))
+        ref_mask = mx.ones((B, 8), dtype=mx.bool_)
+        cap_ids = mx.zeros((B, 5), dtype=mx.int32)
+        cap_mask = mx.ones((B, 5), dtype=mx.bool_)
+
+        text_state, t_mask, spk_state, spk_mask, cap_state, c_mask = (
+            self.model.encode_conditions_full(
+                text_ids, text_mask, ref_latent, ref_mask, cap_ids, cap_mask
+            )
+        )
+        x_t = mx.random.normal((B, S, self.cfg.patched_latent_dim))
+        t = mx.array([0.5], dtype=mx.float32)
+        out = self.model.forward_with_conditions(
+            x_t, t, text_state, t_mask, spk_state, spk_mask,
+            caption_state=cap_state, caption_mask=c_mask
+        )
+        mx.eval(out)
+        self.assertEqual(tuple(out.shape), (B, S, self.cfg.patched_latent_dim))
+
+
+class TestIrodoriV3VoiceDesignGenerate(unittest.TestCase):
+    def _make_model(self):
+        from mlx_audio.tts.models.irodori_tts.irodori_tts import Model
+
+        cfg = _small_irodori_model_config_v3_voicedesign()
+        model = Model(cfg)
+        model.dacvae = _FakeDACVAE(
+            latent_dim=cfg.dit.latent_dim,
+            downsample_factor=cfg.audio_downsample_factor,
+        )
+        model._tokenizer = _MockTokenizer()
+        model._caption_tokenizer = _MockTokenizer()
+        return model
+
+    def test_generate_dual_caption_and_ref(self):
+        model = self._make_model()
+        cfg = model.config
+        ref = mx.zeros((1, cfg.audio_downsample_factor * 4), dtype=mx.float32)
+        results = list(
+            model.generate("こんにちは", ref_audio=ref, caption="穏やかな声", rng_seed=0)
+        )
+        self.assertEqual(len(results), 1)
+        self.assertGreater(results[0].samples, 0)
+
+    def test_generate_duration_predictor_used(self):
+        model = self._make_model()
+        results = list(model.generate("テスト", caption="低い声", rng_seed=0))
+        self.assertEqual(len(results), 1)
+        self.assertGreater(results[0].samples, 0)
 
 
 class TestKugelAudioModel(unittest.TestCase):

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -4914,8 +4914,14 @@ class TestIrodoriV3VoiceDesignShapes(unittest.TestCase):
         x_t = mx.random.normal((B, S, self.cfg.patched_latent_dim))
         t = mx.array([0.5], dtype=mx.float32)
         out = self.model.forward_with_conditions(
-            x_t, t, text_state, t_mask, spk_state, spk_mask,
-            caption_state=cap_state, caption_mask=c_mask
+            x_t,
+            t,
+            text_state,
+            t_mask,
+            spk_state,
+            spk_mask,
+            caption_state=cap_state,
+            caption_mask=c_mask,
         )
         mx.eval(out)
         self.assertEqual(tuple(out.shape), (B, S, self.cfg.patched_latent_dim))
@@ -4940,7 +4946,9 @@ class TestIrodoriV3VoiceDesignGenerate(unittest.TestCase):
         cfg = model.config
         ref = mx.zeros((1, cfg.audio_downsample_factor * 4), dtype=mx.float32)
         results = list(
-            model.generate("こんにちは", ref_audio=ref, caption="穏やかな声", rng_seed=0)
+            model.generate(
+                "こんにちは", ref_audio=ref, caption="穏やかな声", rng_seed=0
+            )
         )
         self.assertEqual(len(results), 1)
         self.assertGreater(results[0].samples, 0)


### PR DESCRIPTION
## Summary

Ports [Aratako/Irodori-TTS-600M-v3-VoiceDesign](https://huggingface.co/Aratako/Irodori-TTS-600M-v3-VoiceDesign) to mlx-audio, adding **dual conditioning** — simultaneous reference audio (speaker) and style text (caption) — on top of the existing v3 Sway Sampling support.

The converted MLX model is available at [mlx-community/Irodori-TTS-600M-v3-VoiceDesign-fp16](https://huggingface.co/mlx-community/Irodori-TTS-600M-v3-VoiceDesign-fp16).

### Architecture changes (`model.py`, `config.py`)

- **`JointAttention`**: now supports speaker and caption KV paths independently and simultaneously. Separate `wk_speaker`/`wv_speaker` and `wk_caption`/`wv_caption` projections; both are concatenated into the KV sequence when present.
- **`DurationPredictor`**: adds `token_sum_dual_adarn_zero_no_aux` architecture — AdaRN-Zero modulation from both speaker and caption (additive), no auxiliary loss head.
- **`IrodoriDiTConfig`**: `use_speaker_condition` promoted from a derived property (`return not use_caption_condition`) to `Optional[bool]` field with a new `use_speaker_condition_resolved` property for backward-compatible defaulting.
- **`build_kv_cache`**: returns a 3-tuple `(kv_text, kv_speaker, kv_caption)`.
- **Bug fix**: `encode_conditions_full` — local `caption_mask = None` was shadowing the function parameter, causing caption state to silently drop on every call.

### Sampling changes (`sampling.py`)

- Detects `is_dual = use_speaker_condition_resolved and use_caption_condition`.
- Dual mode: up to 4× batch CFG `[cond, text-uncond, spk-uncond, cap-uncond]` in independent mode.
- Single-context backward compat: caption-only models alias caption state into the speaker slot; `forward_with_conditions` internally reroutes based on `use_spk`/`use_cap` flags.
- Guards `_concat_kv_caches` calls against `None` KV caches.

### Tests (`test_models.py`)

- Updated existing `build_kv_cache` unpack to 3-tuple.
- Added `TestIrodoriV3VoiceDesignShapes` (6 tests): encoder presence, `encode_conditions_full` 6-tuple, dual KV cache, dual duration prediction, dual forward pass.
- Added `TestIrodoriV3VoiceDesignGenerate` (2 tests): dual caption+ref generation, duration predictor integration.
- All 55 Irodori tests pass.

## Test plan

- [x] `uv run pytest mlx_audio/tts/tests/test_models.py -k "Irodori" -q` — 55 passed
- [x] End-to-end inference with caption only (no ref audio)
- [x] End-to-end inference with ref audio + caption (dual mode)
- [x] Challenging style captions (emotional, whisper, elderly, fast technical, sarcastic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)