### PR TITLE
Add support for Miso TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ for result in model.generate(
 | **KittenTTS** | Compact KittenTTS 0.8 models for edge-friendly TTS | EN | [nano](https://huggingface.co/mlx-community/kitten-tts-nano-0.8), [micro](https://huggingface.co/mlx-community/kitten-tts-micro-0.8), [mini](https://huggingface.co/mlx-community/kitten-tts-mini-0.8), [collection](https://huggingface.co/collections/mlx-community/kittentts) |
 | **Qwen3-TTS** | Alibaba's multilingual TTS with voice design | ZH, EN, JA, KO, + more | [mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16) |
 | **OmniVoice** | Zero-shot multilingual TTS with voice cloning, batch generation, and nonverbal tags | 646+ languages | [mlx-community/OmniVoice-bf16](https://huggingface.co/mlx-community/OmniVoice-bf16) |
-| **CSM** | Conversational Speech Model with voice cloning | EN | [mlx-community/csm-1b](https://huggingface.co/mlx-community/csm-1b) |
+| **CSM / MisoTTS** | Sesame-style conversational speech models with voice cloning | EN | [mlx-community/csm-1b](https://huggingface.co/mlx-community/csm-1b), [MisoTTS bf16](https://huggingface.co/mlx-community/MisoLabs-MisoTTS-bf16), [MisoTTS 8bit](https://huggingface.co/mlx-community/MisoLabs-MisoTTS-8bit) |
 | **Dia** | Dialogue-focused TTS | EN | [mlx-community/Dia-1.6B-fp16](https://huggingface.co/mlx-community/Dia-1.6B-fp16) |
 | **OuteTTS** | Efficient TTS model | EN | [mlx-community/OuteTTS-1.0-0.6B-fp16](https://huggingface.co/mlx-community/OuteTTS-1.0-0.6B-fp16) |
 | **Spark** | SparkTTS model | EN, ZH | [mlx-community/Spark-TTS-0.5B-bf16](https://huggingface.co/mlx-community/Spark-TTS-0.5B-bf16) |

--- a/docs/guides/voice-cloning.md
+++ b/docs/guides/voice-cloning.md
@@ -6,7 +6,7 @@ Several MLX Audio models can clone a speaker's voice from a short reference audi
 
 | Model | Method | Reference Audio Required | Notes |
 |-------|--------|--------------------------|-------|
-| **CSM** | `--ref_audio` CLI / `ref_audio` kwarg | Yes (WAV) | Conversational Speech Model from Sesame |
+| **CSM / MisoTTS** | `--ref_audio` CLI / `ref_audio` kwarg | Yes (WAV) | Sesame-style conversational speech models |
 | **Qwen3-TTS Base** | `ref_audio` + `ref_text` kwargs | Yes (WAV) + transcript | Alibaba multilingual TTS |
 | **OmniVoice** | `ref_audio` + `ref_text` kwargs | Yes (WAV) + transcript recommended | 646+ language zero-shot cloning, best with prompt preprocessing |
 | **Spark** | `ref_audio` kwarg | Yes | SparkTTS voice cloning |

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -18,7 +18,7 @@ Generate natural-sounding speech from text. Multiple models with multilingual su
 | **KittenTTS** | Compact KittenTTS 0.8 models for edge-friendly TTS | EN | [nano](https://huggingface.co/mlx-community/kitten-tts-nano-0.8) / [micro](https://huggingface.co/mlx-community/kitten-tts-micro-0.8) / [mini](https://huggingface.co/mlx-community/kitten-tts-mini-0.8) |
 | **Qwen3-TTS** | Alibaba's multilingual TTS with voice design | ZH, EN, JA, KO, + more | [mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16) |
 | **Voxtral TTS** | Mistral's 4B multilingual TTS (20 voices, 9 languages) | EN, FR, ES, DE, IT, PT, NL, AR, HI | [mlx-community/Voxtral-4B-TTS-2603-mlx-bf16](https://huggingface.co/mlx-community/Voxtral-4B-TTS-2603-mlx-bf16) |
-| **CSM** | Conversational Speech Model with voice cloning | EN | [mlx-community/csm-1b](https://huggingface.co/mlx-community/csm-1b) |
+| **CSM / MisoTTS** | Sesame-style conversational speech models with voice cloning | EN | [mlx-community/csm-1b](https://huggingface.co/mlx-community/csm-1b), [MisoTTS bf16](https://huggingface.co/mlx-community/MisoLabs-MisoTTS-bf16), [MisoTTS 8bit](https://huggingface.co/mlx-community/MisoLabs-MisoTTS-8bit) |
 | **Dia** | Dialogue-focused TTS | EN | [mlx-community/Dia-1.6B-fp16](https://huggingface.co/mlx-community/Dia-1.6B-fp16) |
 | **Chatterbox** | Expressive multilingual TTS | EN, ES, FR, DE, IT, PT, + more | [mlx-community/chatterbox-fp16](https://huggingface.co/mlx-community/chatterbox-fp16) |
 | **KugelAudio** | 7B multilingual TTS for 24 European languages | 24 European languages | [kugelaudio/kugelaudio-0-open](https://huggingface.co/kugelaudio/kugelaudio-0-open) |

--- a/docs/models/tts/csm.md
+++ b/docs/models/tts/csm.md
@@ -1,12 +1,14 @@
-# CSM (Conversational Speech Model)
+# CSM / MisoTTS
 
-CSM is Sesame's 1B parameter conversational speech model with voice cloning support. It generates natural-sounding speech and supports multi-turn conversational context, making it well-suited for dialogue applications.
+CSM-family models use the Sesame conversational speech architecture with voice cloning support. They generate natural-sounding speech and support multi-turn conversational context, making them well-suited for dialogue applications.
 
 ## Model Variants
 
 | Model | Format | HuggingFace |
 |-------|--------|-------------|
 | `mlx-community/csm-1b` | -- | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/csm-1b) |
+| `mlx-community/MisoLabs-MisoTTS-bf16` | BF16 safetensors | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/MisoLabs-MisoTTS-bf16) |
+| `mlx-community/MisoLabs-MisoTTS-8bit` | 8-bit MLX quantized | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/MisoLabs-MisoTTS-8bit) |
 
 ## Usage
 
@@ -21,6 +23,12 @@ CSM is Sesame's 1B parameter conversational speech model with voice cloning supp
         --voice conversational_a
     ```
 
+    ```bash
+    mlx_audio.tts.generate \
+        --model mlx-community/MisoLabs-MisoTTS-bf16 \
+        --text "Hello from Miso."
+    ```
+
 === "Python"
 
     ```python
@@ -33,6 +41,15 @@ CSM is Sesame's 1B parameter conversational speech model with voice cloning supp
         voice="conversational_a",
     ):
         audio = result.audio  # mx.array waveform
+    ```
+
+    ```python
+    from mlx_audio.tts.utils import load_model
+
+    model = load_model("mlx-community/MisoLabs-MisoTTS-bf16")
+
+    for result in model.generate(text="Hello from Miso."):
+        audio = result.audio
     ```
 
 ### Voice Cloning

--- a/docs/models/tts/index.md
+++ b/docs/models/tts/index.md
@@ -13,7 +13,7 @@ MLX-Audio supports a wide range of TTS models optimized for Apple Silicon. Each 
 | [**OmniVoice**](omnivoice.md) | 0.6B backbone + HiggsAudio tokenizer | 646+ languages | Yes | -- | Zero-shot multilingual cloning, nonverbal tags, CMU + pinyin controls |
 | [**Voxtral TTS**](voxtral-tts.md) | 4B | EN, FR, ES, DE, IT, PT, NL, AR, HI | -- | Yes | 20 voice presets, 9 languages, chunked streaming output |
 | [**Svara TTS**](svara.md) | 3B | 19 Indian langs (HI, BN, TA, TE, KN, ML, MR, GU, PA, OR, AS, BH, MAG, MAI, HNE, BRX, DOI, NE, SA, EN-IN) | -- | Yes | Orpheus-family, SNAC 24 kHz, 38 voices, 4-bit/8-bit MLX quants |
-| [**CSM**](csm.md) | 1B | EN | Yes | Yes | Conversational speech, voice cloning, multi-turn context |
+| [**CSM / MisoTTS**](csm.md) | 1B / 8B | EN | Yes | Yes | Sesame-style conversational speech, voice cloning, multi-turn context |
 | [**Dia**](dia.md) | 1.6B | EN | -- | -- | Dialogue with `[S1]`/`[S2]` speaker tags |
 | [**Chatterbox**](chatterbox.md) | -- | EN + 15 languages | Yes | -- | Expressive, emotion exaggeration control |
 | [KugelAudio](kugelaudio.md) | 7B | 24 European languages | -- | -- | VibeVoice-based multilingual TTS with diffusion decoding |

--- a/mlx_audio/tts/models/sesame/sesame.py
+++ b/mlx_audio/tts/models/sesame/sesame.py
@@ -4,11 +4,10 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
-import numpy as np
 from huggingface_hub import hf_hub_download
 from mlx_lm.models.cache import make_prompt_cache
 from mlx_lm.models.llama import LlamaModel
@@ -28,7 +27,9 @@ from .attention import Attention
 try:
     from .watermarking import CSM_1B_GH_WATERMARK, load_watermarker, watermark
 except ImportError:
-    pass
+    CSM_1B_GH_WATERMARK = None
+    load_watermarker = None
+    watermark = None
 
 MIMI_REPO = "kyutai/moshiko-pytorch-bf16"
 TOKENIZER_REPO = "unsloth/Llama-3.2-1B"
@@ -224,6 +225,29 @@ def create_llama_model_args(flavor: str) -> LlamaModelArgs:
                 "rope_type": "llama3",
             },
         )
+    elif flavor == "llama-8B":
+        return LlamaModelArgs(
+            model_type="llama",
+            num_hidden_layers=32,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            head_dim=128,
+            hidden_size=4096,
+            intermediate_size=14336,
+            rms_norm_eps=1e-5,
+            vocab_size=128_256,
+            max_position_embeddings=2048,
+            attention_bias=False,
+            mlp_bias=False,
+            rope_theta=500_000,
+            rope_scaling={
+                "factor": 32.0,
+                "low_freq_factor": 1.0,
+                "high_freq_factor": 4.0,
+                "original_max_position_embeddings": 8192,
+                "rope_type": "llama3",
+            },
+        )
     elif flavor == "llama-100M":
         return LlamaModelArgs(
             model_type="llama",
@@ -233,6 +257,29 @@ def create_llama_model_args(flavor: str) -> LlamaModelArgs:
             head_dim=128,
             hidden_size=1024,
             intermediate_size=8192,
+            rms_norm_eps=1e-5,
+            vocab_size=128_256,
+            max_position_embeddings=2048,
+            attention_bias=False,
+            mlp_bias=False,
+            rope_theta=500_000,
+            rope_scaling={
+                "factor": 32.0,
+                "low_freq_factor": 1.0,
+                "high_freq_factor": 4.0,
+                "original_max_position_embeddings": 8192,
+                "rope_type": "llama3",
+            },
+        )
+    elif flavor == "llama-300M":
+        return LlamaModelArgs(
+            model_type="llama",
+            num_hidden_layers=8,
+            num_attention_heads=24,
+            num_key_value_heads=6,
+            head_dim=64,
+            hidden_size=1536,
+            intermediate_size=6912,
             rms_norm_eps=1e-5,
             vocab_size=128_256,
             max_position_embeddings=2048,
@@ -297,11 +344,6 @@ class SesameModel(nn.Module):
         self.caches_enabled = False
 
     def setup_caches(self, max_batch_size: int):
-        try:
-            backbone_args = create_llama_model_args_for_backbone(self.args)
-        except Exception:
-            backbone_args = create_llama_model_args(self.args.backbone_flavor)
-
         self.backbone_cache = make_prompt_cache(self.backbone)
         self.decoder_cache = make_prompt_cache(self.decoder)
         self.caches_enabled = True
@@ -413,6 +455,15 @@ class Model(nn.Module):
         super().__init__()
         self.model = SesameModel(config)
         self.model.setup_caches(1)
+        self._frame_size = self.model.args.audio_num_codebooks + 1
+        self._speaker_prefix_space = bool(config.get("speaker_prefix_space", False))
+        self._watermark_key = config.get(
+            "watermark_key", globals().get("CSM_1B_GH_WATERMARK")
+        )
+        self._use_default_voice_prompt = bool(
+            config.get("use_default_voice_prompt", True)
+        )
+        self._default_voice_match = bool(config.get("voice_match", True))
 
         self.tokenizer_repo = config.get("text_tokenizer")
         if self.tokenizer_repo:
@@ -454,11 +505,17 @@ class Model(nn.Module):
         frame_tokens = []
         frame_masks = []
 
+        prompt_text = text.lstrip() if self._speaker_prefix_space else text
+        speaker_prefix = (
+            f"[{speaker}] " if self._speaker_prefix_space else f"[{speaker}]"
+        )
         text_tokens = self._text_tokenizer.encode(
-            f"[{speaker}]{text}", return_tensors="mlx"
+            f"{speaker_prefix}{prompt_text}", return_tensors="mlx"
         ).squeeze(0)
-        text_frame = mx.zeros((len(text_tokens), 33)).astype(mx.int32)
-        text_frame_mask = mx.zeros((len(text_tokens), 33)).astype(mx.bool_)
+        text_frame = mx.zeros((len(text_tokens), self._frame_size)).astype(mx.int32)
+        text_frame_mask = mx.zeros((len(text_tokens), self._frame_size)).astype(
+            mx.bool_
+        )
         text_frame[:, -1] = text_tokens
         text_frame_mask[:, -1] = True
 
@@ -475,14 +532,24 @@ class Model(nn.Module):
 
         # (K, T)
         audio_tokens = self._audio_tokenizer.encode(audio[None, None, ...])[0]
+        if audio_tokens.shape[0] != self.model.args.audio_num_codebooks:
+            raise ValueError(
+                "Audio tokenizer returned "
+                f"{audio_tokens.shape[0]} codebooks, expected "
+                f"{self.model.args.audio_num_codebooks}"
+            )
 
         # add EOS frame
         if add_eos:
-            eos_frame = mx.zeros((audio_tokens.shape[0], 1))
+            eos_frame = mx.zeros((audio_tokens.shape[0], 1)).astype(audio_tokens.dtype)
             audio_tokens = mx.concat([audio_tokens, eos_frame], axis=1)
 
-        audio_frame = mx.zeros((audio_tokens.shape[1], 33)).astype(mx.int32)
-        audio_frame_mask = mx.zeros((audio_tokens.shape[1], 33)).astype(mx.bool_)
+        audio_frame = mx.zeros((audio_tokens.shape[1], self._frame_size)).astype(
+            mx.int32
+        )
+        audio_frame_mask = mx.zeros((audio_tokens.shape[1], self._frame_size)).astype(
+            mx.bool_
+        )
         audio_frame[:, :-1] = audio_tokens.swapaxes(0, 1)
         audio_frame_mask[:, :-1] = True
 
@@ -514,7 +581,7 @@ class Model(nn.Module):
             if not k.startswith("model."):
                 k = "model." + k
 
-            if "attn" in k and not "self_attn" in k:
+            if "attn" in k and "self_attn" not in k:
                 k = k.replace("attn", "self_attn")
                 k = k.replace("output_proj", "o_proj")
 
@@ -606,12 +673,12 @@ class Model(nn.Module):
         # Watermarking ensures transparency, dissuades misuse, and enables traceability.
         # Please be a responsible AI citizen and keep the watermarking in place.
         # If using CSM 1B in another application, use your own private key and keep it secret.
-        if self._watermarker is not None:
+        if self._watermarker is not None and self._watermark_key is not None:
             audio = watermark(
                 self._watermarker,
                 audio,
                 self._sample_rate,
-                CSM_1B_GH_WATERMARK,
+                self._watermark_key,
             )
             audio = mx.array(audio, dtype=mx.float32)
 
@@ -673,9 +740,12 @@ class Model(nn.Module):
         ref_text: str = None,
         stream: bool = False,
         streaming_interval: float = 0.5,
-        voice_match: bool = True,
+        voice_match: Optional[bool] = None,
         **kwargs,
     ):
+        if voice_match is None:
+            voice_match = self._default_voice_match
+
         # Load reference audio if provided (handles file paths and mx.array)
         if ref_audio is not None:
             ref_audio = load_audio(ref_audio, sample_rate=self.sample_rate)
@@ -683,7 +753,7 @@ class Model(nn.Module):
         # if reference audio is provided, use it as the first segment
         if len(context) == 0 and ref_audio is not None and ref_text is not None:
             context = [Segment(speaker=speaker, text=ref_text, audio=ref_audio)]
-        elif ref_audio is None:
+        elif ref_audio is None and len(context) == 0 and self._use_default_voice_prompt:
             # otherwise, use the provided or default voice
             if voice is None:
                 voice = "conversational_a"
@@ -702,7 +772,8 @@ class Model(nn.Module):
             text = re.split(split_pattern, text.strip()) if split_pattern else [text]
 
         for prompt in text:
-            if voice_match:
+            current_context = list(context)
+            if voice_match and current_context:
                 generation_text = (context[0].text + " " + prompt).strip()
                 current_context = [
                     Segment(
@@ -724,7 +795,7 @@ class Model(nn.Module):
                 tokens.append(segment_tokens)
                 tokens_mask.append(segment_tokens_mask)
 
-            if not voice_match:
+            if not voice_match or not current_context:
                 gen_segment_tokens, gen_segment_tokens_mask = (
                     self._tokenize_text_segment(prompt, speaker)
                 )

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -5227,6 +5227,114 @@ class TestMossTTSRegistration(unittest.TestCase):
             self.assertIs(arch.Model, SharedModel)
 
 
+class TestMisoTTSRegistration(unittest.TestCase):
+    def test_model_type_registered(self):
+        from mlx_audio.tts.utils import MODEL_REMAPPING
+        from mlx_audio.utils import get_model_category, get_model_name_parts
+
+        model_name = get_model_name_parts("MisoLabs/MisoTTS")
+
+        self.assertEqual(MODEL_REMAPPING["misotts"], "sesame")
+        self.assertEqual(get_model_category(None, model_name), "tts")
+
+    def test_miso_llama_flavors(self):
+        from mlx_audio.tts.models.sesame.sesame import create_llama_model_args
+
+        backbone = create_llama_model_args("llama-8B")
+        decoder = create_llama_model_args("llama-300M")
+
+        self.assertEqual(backbone.num_hidden_layers, 32)
+        self.assertEqual(backbone.hidden_size, 4096)
+        self.assertEqual(backbone.intermediate_size, 14336)
+        self.assertEqual(backbone.num_attention_heads, 32)
+        self.assertEqual(backbone.num_key_value_heads, 8)
+        self.assertEqual(decoder.num_hidden_layers, 8)
+        self.assertEqual(decoder.hidden_size, 1536)
+        self.assertEqual(decoder.intermediate_size, 6912)
+        self.assertEqual(decoder.num_attention_heads, 24)
+        self.assertEqual(decoder.num_key_value_heads, 6)
+
+    def test_sesame_uses_configured_frame_size_and_prompt_spacing(self):
+        from mlx_audio.tts.models.sesame import sesame
+
+        encoded_text = []
+
+        class FakeTokenizer:
+            def encode(self, text, return_tensors=None):
+                encoded_text.append(text)
+                return mx.array([[7, 8]])
+
+        class FakeSesameModel:
+            def __init__(self, config):
+                self.args = SimpleNamespace(
+                    audio_num_codebooks=config["audio_num_codebooks"]
+                )
+
+            def setup_caches(self, max_batch_size):
+                self.max_batch_size = max_batch_size
+
+            def reset_caches(self):
+                pass
+
+            def generate_frame(self, tokens, tokens_mask, input_pos, sampler):
+                return mx.zeros((1, self.args.audio_num_codebooks), dtype=mx.int32)
+
+        class FakeMimi:
+            cfg = SimpleNamespace(sample_rate=24000)
+
+            def eval(self):
+                return None
+
+            def encode(self, audio):
+                return mx.array([[[1, 2], [3, 4], [5, 6]]])
+
+        with (
+            patch("mlx_audio.tts.models.sesame.sesame.SesameModel", FakeSesameModel),
+            patch(
+                "mlx_audio.tts.models.sesame.sesame.load_llama3_tokenizer",
+                return_value=FakeTokenizer(),
+            ),
+            patch(
+                "mlx_audio.tts.models.sesame.sesame.Mimi.from_pretrained",
+                return_value=FakeMimi(),
+            ),
+            patch(
+                "mlx_audio.tts.models.sesame.sesame.MimiStreamingDecoder",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "mlx_audio.tts.models.sesame.sesame.load_watermarker",
+                side_effect=RuntimeError,
+                create=True,
+            ),
+        ):
+            model = sesame.Model(
+                {
+                    "audio_num_codebooks": 3,
+                    "speaker_prefix_space": True,
+                    "use_default_voice_prompt": False,
+                    "voice_match": False,
+                }
+            )
+
+        text_tokens, text_mask = model._tokenize_text_segment("  Hello", speaker=2)
+        audio_tokens, audio_mask = model._tokenize_audio(mx.zeros((16,)))
+
+        self.assertFalse(model._use_default_voice_prompt)
+        self.assertFalse(model._default_voice_match)
+        self.assertEqual(encoded_text[-1], "[2] Hello")
+        self.assertEqual(text_tokens.shape, (2, 4))
+        self.assertEqual(text_mask.shape, (2, 4))
+        self.assertEqual(audio_tokens.shape, (3, 4))
+        self.assertEqual(audio_mask.shape, (3, 4))
+
+        model.default_speaker_prompt = MagicMock(
+            side_effect=AssertionError("default prompt should not load")
+        )
+        list(model.generate("Direct text", max_audio_length_ms=80))
+        self.assertEqual(encoded_text[-1], "[0] Direct text")
+
+
 class TestOmniVoiceBackbone(unittest.TestCase):
     def _make_backbone(self):
         from mlx_audio.tts.models.omnivoice.backbone import (

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -5228,14 +5228,6 @@ class TestMossTTSRegistration(unittest.TestCase):
 
 
 class TestMisoTTSRegistration(unittest.TestCase):
-    def test_model_type_registered(self):
-        from mlx_audio.tts.utils import MODEL_REMAPPING
-        from mlx_audio.utils import get_model_category, get_model_name_parts
-
-        model_name = get_model_name_parts("MisoLabs/MisoTTS")
-
-        self.assertEqual(MODEL_REMAPPING["misotts"], "sesame")
-        self.assertEqual(get_model_category(None, model_name), "tts")
 
     def test_miso_llama_flavors(self):
         from mlx_audio.tts.models.sesame.sesame import create_llama_model_args


### PR DESCRIPTION
This is just a Sesame-arch model, so no major changes needed other than adopting their tokenization style and backbone/decoder flavors. The official repo doesn't ship a config file (!) and has fp32 weights, so I uploaded bf16 and 8-bit quants to `mlx-community`.