### PR TITLE
Add nemotron_asr: MLX port of nvidia/nemotron-3.5-asr-streaming-0.6b (offline + cache-aware streaming)

### DIFF
--- a/mlx_audio/stt/models/nemotron_asr/__init__.py
+++ b/mlx_audio/stt/models/nemotron_asr/__init__.py
@@ -1,0 +1,4 @@
+from mlx_audio.stt.models.nemotron_asr.config import ModelConfig
+from mlx_audio.stt.models.nemotron_asr.model import Model, STTOutput
+
+__all__ = ["Model", "ModelConfig", "STTOutput"]

--- a/mlx_audio/stt/models/nemotron_asr/attention.py
+++ b/mlx_audio/stt/models/nemotron_asr/attention.py
@@ -1,0 +1,96 @@
+"""Relative-positional multi-head attention for Nemotron FastConformer.
+
+Same rel_pos math as NeMo/Parakeet (pos_bias_u/v, linear_pos, untied per layer),
+but: no bias on q/k/v/out, and an additive float mask (0 / -inf) of shape
+(Tq, Tk) for the chunked_limited context restriction.
+"""
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+class RelPositionMultiHeadAttention(nn.Module):
+    def __init__(self, n_head: int, n_feat: int):
+        super().__init__()
+        self.n_head = n_head
+        self.n_feat = n_feat
+        self.head_dim = n_feat // n_head
+        self.scale = self.head_dim**-0.5
+
+        self.linear_q = nn.Linear(n_feat, n_feat, bias=False)
+        self.linear_k = nn.Linear(n_feat, n_feat, bias=False)
+        self.linear_v = nn.Linear(n_feat, n_feat, bias=False)
+        self.linear_out = nn.Linear(n_feat, n_feat, bias=False)
+        self.linear_pos = nn.Linear(n_feat, n_feat, bias=False)
+
+        self.pos_bias_u = mx.zeros((n_head, self.head_dim))
+        self.pos_bias_v = mx.zeros((n_head, self.head_dim))
+
+    def rel_shift(self, x: mx.array) -> mx.array:
+        B, H, Tq, pos_len = x.shape
+        x = mx.pad(x, [(0, 0)] * (x.ndim - 1) + [(1, 0)])
+        x = x.reshape(B, H, pos_len + 1, Tq)
+        x = x[:, :, 1:, :].reshape(B, H, Tq, pos_len)
+        return x
+
+    def __call__(
+        self,
+        x: mx.array,
+        pos_emb: mx.array,
+        mask: mx.array | None = None,
+    ) -> mx.array:
+        q, k, v = self.linear_q(x), self.linear_k(x), self.linear_v(x)
+        p = self.linear_pos(pos_emb)
+
+        B, T, _ = q.shape
+        _, pos_len, _ = p.shape
+
+        q = q.reshape(B, T, self.n_head, self.head_dim)
+        q_u = (q + self.pos_bias_u).transpose(0, 2, 1, 3)
+        q_v = (q + self.pos_bias_v).transpose(0, 2, 1, 3)
+        k = k.reshape(B, T, self.n_head, self.head_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(B, T, self.n_head, self.head_dim).transpose(0, 2, 1, 3)
+        p = p.reshape(1, pos_len, self.n_head, self.head_dim).transpose(0, 2, 1, 3)
+
+        matrix_bd = mx.matmul(q_v, p.swapaxes(-2, -1))
+        matrix_bd = self.rel_shift(matrix_bd)[:, :, :, : k.shape[-2]] * self.scale
+
+        if mask is not None:
+            matrix_bd = matrix_bd + mask  # additive (0 / -inf), shape (1,1,Tq,Tk)
+
+        o = mx.fast.scaled_dot_product_attention(
+            q_u, k, v, scale=self.scale, mask=matrix_bd
+        )
+        o = o.transpose(0, 2, 1, 3).reshape(B, T, -1)
+        return self.linear_out(o)
+
+
+class RelPositionalEncoding(nn.Module):
+    def __init__(self, d_model: int, max_len: int = 5000):
+        super().__init__()
+        self.d_model = d_model
+        self.max_len = max_len
+        self._build(max_len)
+
+    def _build(self, max_len: int):
+        positions = mx.arange(max_len - 1, -max_len, -1, dtype=mx.int32)
+        positions = mx.expand_dims(positions, axis=1).astype(mx.float32)
+        div_term = mx.exp(
+            mx.arange(0, self.d_model, 2, dtype=mx.float32)
+            * -(math.log(10000.0) / self.d_model)
+        )
+        pe = mx.zeros((2 * max_len - 1, self.d_model), dtype=mx.float32)
+        pe[:, 0::2] = mx.sin(positions * div_term)
+        pe[:, 1::2] = mx.cos(positions * div_term)
+        self._pe = mx.expand_dims(pe, axis=0)
+        self.max_len = max_len
+
+    def __call__(self, x: mx.array) -> mx.array:
+        T = x.shape[1]
+        if T > self.max_len:
+            self._build(T + 1)
+        center = self._pe.shape[1] // 2
+        pos_emb = self._pe[:, center - (T - 1) : center + T].astype(x.dtype)
+        return pos_emb

--- a/mlx_audio/stt/models/nemotron_asr/attention.py
+++ b/mlx_audio/stt/models/nemotron_asr/attention.py
@@ -66,6 +66,29 @@ class RelPositionMultiHeadAttention(nn.Module):
         o = o.transpose(0, 2, 1, 3).reshape(B, T, -1)
         return self.linear_out(o)
 
+    def stream(self, q_in: mx.array, kv_in: mx.array, pos_emb: mx.array) -> mx.array:
+        """Cache-aware step: q_in (B,c,d) attends to kv_in (B,L,d), no mask
+        (the L-window IS the allowed context). pos_emb is for length L (2L-1)."""
+        q = self.linear_q(q_in)
+        k = self.linear_k(kv_in)
+        v = self.linear_v(kv_in)
+        p = self.linear_pos(pos_emb)
+        B, c, _ = q.shape
+        L = kv_in.shape[1]
+        pos_len = p.shape[1]
+        q = q.reshape(B, c, self.n_head, self.head_dim)
+        q_u = (q + self.pos_bias_u).transpose(0, 2, 1, 3)
+        q_v = (q + self.pos_bias_v).transpose(0, 2, 1, 3)
+        k = k.reshape(B, L, self.n_head, self.head_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(B, L, self.n_head, self.head_dim).transpose(0, 2, 1, 3)
+        p = p.reshape(1, pos_len, self.n_head, self.head_dim).transpose(0, 2, 1, 3)
+        matrix_bd = mx.matmul(q_v, p.swapaxes(-2, -1))
+        matrix_bd = self.rel_shift(matrix_bd)[:, :, :, :L] * self.scale
+        o = mx.fast.scaled_dot_product_attention(
+            q_u, k, v, scale=self.scale, mask=matrix_bd
+        )
+        return self.linear_out(o.transpose(0, 2, 1, 3).reshape(B, c, -1))
+
 
 class RelPositionalEncoding(nn.Module):
     def __init__(self, d_model: int, max_len: int = 5000):
@@ -88,9 +111,11 @@ class RelPositionalEncoding(nn.Module):
         self.max_len = max_len
 
     def __call__(self, x: mx.array) -> mx.array:
-        T = x.shape[1]
-        if T > self.max_len:
-            self._build(T + 1)
+        return self.pos_emb_for(x.shape[1], x.dtype)
+
+    def pos_emb_for(self, length: int, dtype=mx.float32) -> mx.array:
+        """Positional embedding for a window of `length` frames (2*length-1)."""
+        if length > self.max_len:
+            self._build(length + 1)
         center = self._pe.shape[1] // 2
-        pos_emb = self._pe[:, center - (T - 1) : center + T].astype(x.dtype)
-        return pos_emb
+        return self._pe[:, center - (length - 1) : center + length].astype(dtype)

--- a/mlx_audio/stt/models/nemotron_asr/audio.py
+++ b/mlx_audio/stt/models/nemotron_asr/audio.py
@@ -1,0 +1,72 @@
+"""Log-mel preprocessing for Nemotron 3.5 ASR.
+
+Matches NeMo's AudioToMelSpectrogramPreprocessor for this model:
+  - 16 kHz, n_fft=512, win 400 (Hann), hop 160, 128 mel bins
+  - preemphasis 0.97, power spectrum (|stft|^2), log(x + 2^-24)
+  - normalize="NA"  -> NO normalization (unlike Parakeet's per_feature/global)
+
+The mel filterbank (`fb`) and `window` are taken VERBATIM from the .nemo
+(`preprocessor.featurizer.{fb,window}`) so the filters are bit-identical to the
+reference; only the STFT/log math is re-implemented here.
+"""
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+
+from mlx_audio.dsp import stft
+
+
+@dataclass
+class PreprocessArgs:
+    sample_rate: int = 16000
+    n_fft: int = 512
+    win_length: int = 400
+    hop_length: int = 160
+    features: int = 128
+    preemph: float = 0.97
+    log_zero_guard_value: float = 2.0**-24
+
+
+def log_mel_spectrogram(
+    audio: mx.array,
+    fb: mx.array,
+    window: mx.array,
+    args: PreprocessArgs,
+) -> mx.array:
+    """audio: (n_samples,) -> mel: (1, n_frames, features)."""
+    orig_dtype = audio.dtype
+    x = audio.astype(mx.float32)
+
+    # preemphasis high-pass: y[n] = x[n] - 0.97*x[n-1]
+    if args.preemph and args.preemph > 0:
+        x = mx.concatenate([x[:1], x[1:] - args.preemph * x[:-1]], axis=0)
+
+    # center-pad the win_length window to n_fft (matches torch.stft centering)
+    w = window.astype(mx.float32)
+    if w.shape[0] < args.n_fft:
+        left = (args.n_fft - w.shape[0]) // 2
+        right = args.n_fft - w.shape[0] - left
+        w = mx.concatenate([mx.zeros((left,)), w, mx.zeros((right,))], axis=0)
+
+    spec = stft(
+        x,
+        n_fft=args.n_fft,
+        hop_length=args.hop_length,
+        win_length=args.n_fft,
+        window=w,
+        center=True,
+        pad_mode="constant",  # NeMo FilterbankFeatures uses zero (constant) padding
+    )  # (n_frames, n_fft//2+1)
+    power = mx.square(mx.abs(spec))  # power spectrum
+
+    # mel: fb (128, 257) @ power.T (257, n_frames) -> (128, n_frames)
+    fb2 = fb.astype(mx.float32)
+    if fb2.ndim == 3:
+        fb2 = fb2[0]
+    mel = fb2 @ power.T
+    mel = mx.log(mel + args.log_zero_guard_value)
+
+    # normalize="NA": no normalization
+    mel = mx.expand_dims(mel.T, axis=0)  # (1, n_frames, features)
+    return mel.astype(orig_dtype)

--- a/mlx_audio/stt/models/nemotron_asr/config.py
+++ b/mlx_audio/stt/models/nemotron_asr/config.py
@@ -1,0 +1,52 @@
+"""Config parsing for Nemotron 3.5 ASR (NeMo model_config -> typed args)."""
+
+from mlx_audio.stt.models.nemotron_asr.audio import PreprocessArgs
+from mlx_audio.stt.models.nemotron_asr.encoder import EncoderArgs
+
+
+class ModelConfig:
+    """Thin wrapper over the NeMo config dict (matches Parakeet convention)."""
+
+    def __init__(self, config: dict):
+        self._config = config
+
+    @classmethod
+    def from_dict(cls, config: dict) -> "ModelConfig":
+        if "model_type" not in config:
+            config = {**config, "model_type": "nemotron_asr"}
+        return cls(config)
+
+
+def _first_att_context(enc: dict) -> tuple:
+    acs = enc.get("att_context_size", [[56, 3]])
+    first = acs[0] if acs and isinstance(acs[0], (list, tuple)) else acs
+    return (int(first[0]), int(first[1]))
+
+
+def parse_preprocess(config: dict) -> PreprocessArgs:
+    p = config.get("preprocessor", {})
+    sr = int(p.get("sample_rate", 16000))
+    return PreprocessArgs(
+        sample_rate=sr,
+        n_fft=int(p.get("n_fft", 512)),
+        win_length=int(p.get("window_size", 0.025) * sr),
+        hop_length=int(p.get("window_stride", 0.01) * sr),
+        features=int(p.get("features", 128)),
+        preemph=float(p.get("preemph", 0.97) or 0.0),
+    )
+
+
+def parse_encoder(config: dict) -> EncoderArgs:
+    e = config.get("encoder", {})
+    return EncoderArgs(
+        feat_in=int(e.get("feat_in", 128)),
+        n_layers=int(e.get("n_layers", 24)),
+        d_model=int(e.get("d_model", 1024)),
+        n_heads=int(e.get("n_heads", 8)),
+        ff_expansion_factor=int(e.get("ff_expansion_factor", 4)),
+        subsampling_factor=int(e.get("subsampling_factor", 8)),
+        subsampling_conv_channels=int(e.get("subsampling_conv_channels", 256)),
+        conv_kernel_size=int(e.get("conv_kernel_size", 9)),
+        pos_emb_max_len=int(e.get("pos_emb_max_len", 5000)),
+        att_context_size=_first_att_context(e),
+    )

--- a/mlx_audio/stt/models/nemotron_asr/decoder.py
+++ b/mlx_audio/stt/models/nemotron_asr/decoder.py
@@ -1,0 +1,24 @@
+"""RNN-T prediction + joint networks for Nemotron 3.5 ASR.
+
+Identical in structure to Parakeet's RNN-T (2-layer LSTM prednet + joint with
+separate enc/pred projections), so we reuse those implementations directly.
+Weight keys match: decoder.prediction.{embed,dec_rnn.lstm.N.*}, joint.{enc,pred,joint_net.2}.
+"""
+
+from mlx_audio.stt.models.parakeet.rnnt import (  # noqa: F401
+    JointArgs,
+    JointNetwork,
+    JointNetworkArgs,
+    PredictArgs,
+    PredictNetwork,
+    PredictNetworkArgs,
+)
+
+__all__ = [
+    "PredictNetwork",
+    "JointNetwork",
+    "PredictArgs",
+    "JointArgs",
+    "PredictNetworkArgs",
+    "JointNetworkArgs",
+]

--- a/mlx_audio/stt/models/nemotron_asr/encoder.py
+++ b/mlx_audio/stt/models/nemotron_asr/encoder.py
@@ -1,0 +1,176 @@
+"""Cache-aware FastConformer encoder for Nemotron 3.5 ASR (offline path).
+
+Differences from Parakeet's Conformer (all required for parity):
+  - causal dw_striding subsampling (CausalConv2D: pad (k-1, s-1) both dims)
+  - causal depthwise conv + LayerNorm (not symmetric + BatchNorm)
+  - no bias on FFN / attention / conv1d
+  - chunked_limited attention mask (block-causal, block size att_ctx[1]+1)
+"""
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_audio.stt.models.nemotron_asr.attention import (
+    RelPositionalEncoding,
+    RelPositionMultiHeadAttention,
+)
+
+
+@dataclass
+class EncoderArgs:
+    feat_in: int = 128
+    n_layers: int = 24
+    d_model: int = 1024
+    n_heads: int = 8
+    ff_expansion_factor: int = 4
+    subsampling_factor: int = 8
+    subsampling_conv_channels: int = 256
+    conv_kernel_size: int = 9
+    pos_emb_max_len: int = 5000
+    att_context_size: tuple = (56, 3)
+
+
+def _silu(x):
+    return x * mx.sigmoid(x)
+
+
+class CausalDwStridingSubsampling(nn.Module):
+    """8x dw_striding subsampling with causal padding (matches NeMo CausalConv2D)."""
+
+    def __init__(self, args: EncoderArgs):
+        super().__init__()
+        c = args.subsampling_conv_channels
+        self.k = 3
+        self.stride = 2
+        self.left = self.k - 1  # 2
+        self.right = self.stride - 1  # 1
+        self.n_stages = 3  # 8x = 2^3
+        # indices 0,2,5 are stride-2 (causal); 3,6 pointwise k1; 1,4,7 ReLU
+        self.conv = [
+            nn.Conv2d(1, c, 3, stride=2, padding=0, bias=True),  # 0
+            nn.ReLU(),  # 1
+            nn.Conv2d(c, c, 3, stride=2, padding=0, groups=c, bias=True),  # 2 dw
+            nn.Conv2d(c, c, 1, stride=1, padding=0, bias=True),  # 3 pw
+            nn.ReLU(),  # 4
+            nn.Conv2d(c, c, 3, stride=2, padding=0, groups=c, bias=True),  # 5 dw
+            nn.Conv2d(c, c, 1, stride=1, padding=0, bias=True),  # 6 pw
+            nn.ReLU(),  # 7
+        ]
+        self._stride_idx = {0, 2, 5}
+        # final freq dim after 3 causal stride-2 stages on feat_in
+        f = args.feat_in
+        for _ in range(self.n_stages):
+            f = (f + self.left + self.right - self.k) // self.stride + 1
+        self.out = nn.Linear(c * f, args.d_model)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # x: (B, T, F) -> NHWC (B, T, F, 1)
+        x = mx.expand_dims(x, axis=-1)
+        for i, layer in enumerate(self.conv):
+            if i in self._stride_idx:
+                # causal pad on time (H) and freq (W): (left, right) each
+                x = mx.pad(
+                    x,
+                    [(0, 0), (self.left, self.right), (self.left, self.right), (0, 0)],
+                )
+            x = layer(x)
+        # x: (B, T', F', C) -> flatten C-major: (B, T', C, F') -> (B, T', C*F')
+        B, T, F, C = x.shape
+        x = x.transpose(0, 1, 3, 2).reshape(B, T, C * F)
+        return self.out(x)
+
+
+class FeedForward(nn.Module):
+    def __init__(self, d_model: int, d_ff: int):
+        super().__init__()
+        self.linear1 = nn.Linear(d_model, d_ff, bias=False)
+        self.linear2 = nn.Linear(d_ff, d_model, bias=False)
+
+    def __call__(self, x):
+        return self.linear2(_silu(self.linear1(x)))
+
+
+class Convolution(nn.Module):
+    """Causal depthwise conv module with LayerNorm (conv_norm_type=layer_norm)."""
+
+    def __init__(self, args: EncoderArgs):
+        super().__init__()
+        d = args.d_model
+        k = args.conv_kernel_size
+        self.left = k - 1  # causal: pad left k-1, right 0
+        self.pointwise_conv1 = nn.Conv1d(d, d * 2, 1, bias=False)
+        self.depthwise_conv = nn.Conv1d(d, d, k, padding=0, groups=d, bias=False)
+        self.batch_norm = nn.LayerNorm(d)  # legacy attr name; actually LayerNorm
+        self.pointwise_conv2 = nn.Conv1d(d, d, 1, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # x: (B, T, C)
+        x = self.pointwise_conv1(x)  # (B, T, 2C)
+        x = nn.glu(x, axis=-1)  # (B, T, C)
+        x = mx.pad(x, [(0, 0), (self.left, 0), (0, 0)])  # causal time pad
+        x = self.depthwise_conv(x)  # (B, T, C)
+        x = self.batch_norm(x)  # LayerNorm over C
+        x = _silu(x)
+        return self.pointwise_conv2(x)
+
+
+class ConformerBlock(nn.Module):
+    def __init__(self, args: EncoderArgs):
+        super().__init__()
+        d = args.d_model
+        ff = d * args.ff_expansion_factor
+        self.norm_feed_forward1 = nn.LayerNorm(d)
+        self.feed_forward1 = FeedForward(d, ff)
+        self.norm_self_att = nn.LayerNorm(d)
+        self.self_attn = RelPositionMultiHeadAttention(args.n_heads, d)
+        self.norm_conv = nn.LayerNorm(d)
+        self.conv = Convolution(args)
+        self.norm_feed_forward2 = nn.LayerNorm(d)
+        self.feed_forward2 = FeedForward(d, ff)
+        self.norm_out = nn.LayerNorm(d)
+
+    def __call__(self, x, pos_emb, mask=None):
+        x = x + 0.5 * self.feed_forward1(self.norm_feed_forward1(x))
+        x = x + self.self_attn(self.norm_self_att(x), pos_emb=pos_emb, mask=mask)
+        x = x + self.conv(self.norm_conv(x))
+        x = x + 0.5 * self.feed_forward2(self.norm_feed_forward2(x))
+        return self.norm_out(x)
+
+
+def chunked_limited_mask(T: int, att_context_size, dtype) -> mx.array:
+    """Block-causal additive mask (0 / -inf), shape (1,1,T,T).
+
+    chunk_size = right+1; frame i (chunk ci=i//cs) attends to j (cj) iff
+    cj <= ci and ci - cj <= left//cs.
+    """
+    left, right = int(att_context_size[0]), int(att_context_size[1])
+    cs = right + 1
+    left_chunks = (left // cs) if left >= 0 else 10**9
+    idx = mx.arange(T)
+    ci = (idx // cs).reshape(T, 1)
+    cj = (idx // cs).reshape(1, T)
+    diff = ci - cj
+    allowed = (diff >= 0) & (diff <= left_chunks)
+    neg = mx.array(-1e9, dtype=dtype)
+    mask = mx.where(allowed, mx.array(0.0, dtype=dtype), neg)
+    return mask.reshape(1, 1, T, T)
+
+
+class Conformer(nn.Module):
+    def __init__(self, args: EncoderArgs):
+        super().__init__()
+        self.args = args
+        self.pre_encode = CausalDwStridingSubsampling(args)
+        self.pos_enc = RelPositionalEncoding(args.d_model, args.pos_emb_max_len)
+        self.layers = [ConformerBlock(args) for _ in range(args.n_layers)]
+
+    def __call__(self, mel: mx.array) -> mx.array:
+        # mel: (B, T, F) -> (B, T', d_model)
+        x = self.pre_encode(mel)
+        pos_emb = self.pos_enc(x)
+        mask = chunked_limited_mask(x.shape[1], self.args.att_context_size, x.dtype)
+        for layer in self.layers:
+            x = layer(x, pos_emb=pos_emb, mask=mask)
+        return x

--- a/mlx_audio/stt/models/nemotron_asr/model.py
+++ b/mlx_audio/stt/models/nemotron_asr/model.py
@@ -55,6 +55,17 @@ class STTOutput:
         return f"STTOutput(text={self.text!r}, language={self.language!r})"
 
 
+class StreamingResult:
+    def __init__(self, text, new_text, tokens, is_final):
+        self.text = text
+        self.new_text = new_text
+        self.tokens = tokens
+        self.is_final = is_final
+
+    def __repr__(self):
+        return f"StreamingResult(new={self.new_text!r}, final={self.is_final})"
+
+
 class Model(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -206,3 +217,50 @@ class Model(nn.Module):
         if strip_lang_tags:
             text, lang = strip_lang_tag(text)
         return STTOutput(text=text, language=lang or target_lang, tokens=ids)
+
+    def stream_generate(
+        self,
+        audio: Union[str, Path, mx.array],
+        *,
+        target_lang: str = "en-US",
+        chunk_frames: Optional[int] = None,
+        strip_lang_tags: bool = True,
+        dtype: mx.Dtype = mx.float32,
+        **kwargs,
+    ):
+        """Cache-aware streaming transcription. Yields StreamingResult per chunk
+        (token-identical to generate() at the native chunk size)."""
+        from mlx_audio.stt.models.nemotron_asr.streaming import stream_transcribe
+
+        if isinstance(audio, (str, Path)):
+            audio = load_audio(audio, self.preprocess_args.sample_rate, dtype=dtype)
+        else:
+            audio = audio.astype(dtype)
+        mel = log_mel_spectrogram(
+            audio,
+            self.preprocessor.featurizer.fb,
+            self.preprocessor.featurizer.window,
+            self.preprocess_args,
+        ).astype(dtype)
+        prompt_id = self._resolve_prompt_id(target_lang)
+
+        def _result(item, is_final):
+            new, all_ids = item
+            text = self.tokenizer.decode(all_ids)
+            if strip_lang_tags:
+                text, _ = strip_lang_tag(text)
+            return StreamingResult(
+                text=text,
+                new_text=self.tokenizer.decode(new) if new else "",
+                tokens=list(all_ids),
+                is_final=is_final,
+            )
+
+        # lazy: one-item lookahead so the last chunk is flagged is_final
+        prev = None
+        for item in stream_transcribe(self, mel, prompt_id, chunk_frames):
+            if prev is not None:
+                yield _result(prev, False)
+            prev = item
+        if prev is not None:
+            yield _result(prev, True)

--- a/mlx_audio/stt/models/nemotron_asr/model.py
+++ b/mlx_audio/stt/models/nemotron_asr/model.py
@@ -123,6 +123,9 @@ class Model(nn.Module):
     def sanitize(self, weights: dict) -> dict:
         # converter already matches MLX layout/keys; nothing to remap.
         return weights
+        # NOTE: no model_quant_predicate — quantize the full model. The encoder is
+        # ~90% of params, so protecting it saves ~2%; q8 over the full model is
+        # the effective sweet spot (-41% size, content-lossless). See parity_test.
 
     # ---- prompt fusion ----
     def _fuse(self, encoded: mx.array, prompt_id: int) -> mx.array:

--- a/mlx_audio/stt/models/nemotron_asr/model.py
+++ b/mlx_audio/stt/models/nemotron_asr/model.py
@@ -1,0 +1,205 @@
+"""Nemotron 3.5 ASR (FastConformer prompted RNN-T) — MLX, offline path.
+
+Pipeline: log-mel -> FastConformer encoder -> language-prompt fusion -> RNN-T
+greedy. Streaming (cache-aware) is added in a later phase.
+"""
+
+from pathlib import Path
+from typing import Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_audio.stt.models.nemotron_asr.audio import PreprocessArgs, log_mel_spectrogram
+from mlx_audio.stt.models.nemotron_asr.config import (
+    ModelConfig,
+    parse_encoder,
+    parse_preprocess,
+)
+from mlx_audio.stt.models.nemotron_asr.decoder import (
+    JointArgs,
+    JointNetwork,
+    JointNetworkArgs,
+    PredictArgs,
+    PredictNetwork,
+    PredictNetworkArgs,
+)
+from mlx_audio.stt.models.nemotron_asr.encoder import Conformer, EncoderArgs
+from mlx_audio.stt.models.nemotron_asr.tokenizer import VocabTokenizer, strip_lang_tag
+from mlx_audio.stt.utils import load_audio
+
+
+class _Featurizer(nn.Module):
+    """Holds the .nemo mel filterbank + window so they load as weights
+    (keys preprocessor.featurizer.{fb,window}) and stay bit-identical."""
+
+    def __init__(self, n_mels: int, n_fft: int, win_length: int):
+        super().__init__()
+        self.fb = mx.zeros((1, n_mels, n_fft // 2 + 1))
+        self.window = mx.zeros((win_length,))
+
+
+class _Preprocessor(nn.Module):
+    def __init__(self, n_mels: int, n_fft: int, win_length: int):
+        super().__init__()
+        self.featurizer = _Featurizer(n_mels, n_fft, win_length)
+
+
+class STTOutput:
+    def __init__(self, text: str, language: Optional[str] = None, tokens=None):
+        self.text = text
+        self.language = language
+        self.tokens = tokens or []
+
+    def __repr__(self):
+        return f"STTOutput(text={self.text!r}, language={self.language!r})"
+
+
+class Model(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        if isinstance(config, ModelConfig):
+            config = config._config
+
+        enc = config.get("encoder", {})
+        joint = config.get("joint", {})
+        vocab = config.get("vocabulary") or []
+        vocab_size = int(joint.get("num_classes", len(vocab) or 13087))
+        md = config.get("model_defaults", {})
+        decoding = config.get("decoding", {}) or {}
+        greedy = decoding.get("greedy", {}) if isinstance(decoding, dict) else {}
+        pred_hidden = int(
+            config.get("decoder", {}).get("prednet", {}).get("pred_hidden", 640)
+        )
+        joint_hidden = int(joint.get("jointnet", {}).get("joint_hidden", 640))
+
+        self.preprocess_args = parse_preprocess(config)
+        self.encoder_args = parse_encoder(config)
+        d = self.encoder_args.d_model
+        self.vocab_size = vocab_size
+        self.blank_id = vocab_size  # blank index (joint output dim = vocab+1)
+        self.num_prompts = int(md.get("num_prompts", config.get("num_prompts", 128)))
+        self.prompt_dictionary = dict(md.get("prompt_dictionary", {}) or {})
+        self.max_symbols = int(greedy.get("max_symbols", 10)) if greedy else 10
+        self.tokenizer = VocabTokenizer(vocab)
+
+        self.preprocessor = _Preprocessor(
+            self.preprocess_args.features,
+            self.preprocess_args.n_fft,
+            self.preprocess_args.win_length,
+        )
+        self.encoder = Conformer(self.encoder_args)
+        # prompt_kernel list -> weight keys prompt_kernel.{0,2}.*
+        self.prompt_kernel = [
+            nn.Linear(d + self.num_prompts, 2 * d),
+            nn.ReLU(),
+            nn.Linear(2 * d, d),
+        ]
+        self.decoder = PredictNetwork(
+            PredictArgs(
+                blank_as_pad=True,
+                vocab_size=vocab_size,
+                prednet=PredictNetworkArgs(pred_hidden=pred_hidden, pred_rnn_layers=2),
+            )
+        )
+        self.joint = JointNetwork(
+            JointArgs(
+                num_classes=vocab_size,
+                vocabulary=vocab,
+                jointnet=JointNetworkArgs(
+                    joint_hidden=joint_hidden,
+                    activation="relu",
+                    encoder_hidden=d,
+                    pred_hidden=pred_hidden,
+                ),
+            )
+        )
+        self.train(False)  # eval mode
+
+    @classmethod
+    def from_config(cls, config) -> "Model":
+        return cls(config)
+
+    def sanitize(self, weights: dict) -> dict:
+        # converter already matches MLX layout/keys; nothing to remap.
+        return weights
+
+    # ---- prompt fusion ----
+    def _fuse(self, encoded: mx.array, prompt_id: int) -> mx.array:
+        B, T, _ = encoded.shape
+        onehot = mx.zeros((B, T, self.num_prompts), dtype=encoded.dtype)
+        onehot[:, :, prompt_id] = 1.0
+        x = mx.concatenate([encoded, onehot], axis=-1)
+        for layer in self.prompt_kernel:
+            x = layer(x)
+        return x
+
+    def _resolve_prompt_id(self, target_lang: str) -> int:
+        if target_lang in self.prompt_dictionary:
+            return int(self.prompt_dictionary[target_lang])
+        return int(self.prompt_dictionary.get("auto", 0))
+
+    # ---- greedy RNN-T ----
+    def _greedy(self, enc_post: mx.array) -> list[int]:
+        T = enc_post.shape[1]
+        last_token = self.blank_id
+        hidden = None
+        hyp: list[int] = []
+        t = 0
+        new_sym = 0
+        while t < T:
+            feat = enc_post[:, t : t + 1]
+            cur = (
+                mx.array([[last_token]], dtype=mx.int32)
+                if last_token != self.blank_id
+                else None
+            )
+            dec_out, (h, c) = self.decoder(cur, hidden)
+            dec_out = dec_out.astype(feat.dtype)
+            logits = self.joint(feat, dec_out)
+            pred = int(mx.argmax(logits))
+            if pred != self.blank_id:
+                last_token = pred
+                hidden = (h.astype(feat.dtype), c.astype(feat.dtype))
+                hyp.append(pred)
+                new_sym += 1
+                if self.max_symbols is not None and new_sym >= self.max_symbols:
+                    t += 1
+                    new_sym = 0
+            else:
+                t += 1
+                new_sym = 0
+        return hyp
+
+    # ---- public API ----
+    def encode(self, mel: mx.array, target_lang: str = "en-US") -> mx.array:
+        enc = self.encoder(mel)
+        return self._fuse(enc, self._resolve_prompt_id(target_lang))
+
+    def generate(
+        self,
+        audio: Union[str, Path, mx.array],
+        *,
+        target_lang: str = "en-US",
+        strip_lang_tags: bool = True,
+        dtype: mx.Dtype = mx.float32,
+        **kwargs,
+    ) -> STTOutput:
+        if isinstance(audio, (str, Path)):
+            audio = load_audio(audio, self.preprocess_args.sample_rate, dtype=dtype)
+        else:
+            audio = audio.astype(dtype)
+
+        mel = log_mel_spectrogram(
+            audio,
+            self.preprocessor.featurizer.fb,
+            self.preprocessor.featurizer.window,
+            self.preprocess_args,
+        ).astype(dtype)
+        enc_post = self.encode(mel, target_lang)
+        ids = self._greedy(enc_post)
+        text = self.tokenizer.decode(ids)
+        lang = None
+        if strip_lang_tags:
+            text, lang = strip_lang_tag(text)
+        return STTOutput(text=text, language=lang or target_lang, tokens=ids)

--- a/mlx_audio/stt/models/nemotron_asr/streaming.py
+++ b/mlx_audio/stt/models/nemotron_asr/streaming.py
@@ -1,0 +1,116 @@
+"""Cache-aware streaming for the Nemotron FastConformer encoder.
+
+Each conformer layer keeps two caches (matching NeMo cache_last_channel /
+cache_last_time):
+  - attn cache: last `left_cache` frames of the attention input (norm_self_att out)
+  - conv cache: last `conv_kernel-1` frames of the depthwise-conv input (GLU out)
+
+Per chunk: Q = new frames, K/V = [attn_cache + new]; depthwise conv prepends the
+conv_cache instead of zero-padding. With the window sized to the allowed left
+context, no attention mask is needed — so streaming output is frame-identical to
+the offline (chunked_limited) encoder. Subsampling is done up-front on the
+provided mel; incremental subsampling can wrap this later.
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _stream_block(layer, x, pos_enc, attn_cache, conv_cache, left_cache, conv_left):
+    # half-step FFN 1
+    residual = x + 0.5 * layer.feed_forward1(layer.norm_feed_forward1(x))
+
+    # cache-aware self-attention
+    xn = layer.norm_self_att(residual)
+    kv = xn if attn_cache is None else mx.concatenate([attn_cache, xn], axis=1)
+    pos_emb = pos_enc.pos_emb_for(kv.shape[1], x.dtype)
+    residual = residual + layer.self_attn.stream(xn, kv, pos_emb)
+    attn_cache_next = kv[:, -left_cache:]
+
+    # cache-aware causal conv
+    xc = layer.norm_conv(residual)
+    g = nn.glu(layer.conv.pointwise_conv1(xc), axis=-1)  # (B, c, d)
+    if conv_cache is None:
+        conv_cache = mx.zeros((g.shape[0], conv_left, g.shape[2]), dtype=g.dtype)
+    din = mx.concatenate([conv_cache, g], axis=1)
+    dw = layer.conv.depthwise_conv(din)  # valid conv -> (B, c, d)
+    conv_cache_next = din[:, -conv_left:]
+    cc = layer.conv.batch_norm(dw)
+    cc = cc * mx.sigmoid(cc)  # SiLU
+    residual = residual + layer.conv.pointwise_conv2(cc)
+
+    # half-step FFN 2 + final norm
+    residual = residual + 0.5 * layer.feed_forward2(layer.norm_feed_forward2(residual))
+    return layer.norm_out(residual), attn_cache_next, conv_cache_next
+
+
+def native_chunk_frames(conformer) -> int:
+    """Block size that makes streaming frame-identical to offline:
+    chunk = right_context + 1 (the chunked_limited block granularity)."""
+    return int(conformer.args.att_context_size[1]) + 1
+
+
+def _iter_chunks(conformer, mel, chunk_frames):
+    """Yield (encoder_frames_for_chunk) streaming over the conformer."""
+    left_cache = int(conformer.args.att_context_size[0])
+    conv_left = conformer.args.conv_kernel_size - 1
+    feats = conformer.pre_encode(mel)  # (1, T', d) — subsample up-front
+    T = feats.shape[1]
+    n = len(conformer.layers)
+    attn_cache = [None] * n
+    conv_cache = [None] * n
+    for s in range(0, T, chunk_frames):
+        x = feats[:, s : s + chunk_frames]
+        for li, layer in enumerate(conformer.layers):
+            x, attn_cache[li], conv_cache[li] = _stream_block(
+                layer,
+                x,
+                conformer.pos_enc,
+                attn_cache[li],
+                conv_cache[li],
+                left_cache,
+                conv_left,
+            )
+        yield x
+
+
+def stream_conformer(conformer, mel, chunk_frames=None):
+    """Cache-aware streamed conformer over `mel`; returns (1, T', d).
+    Frame-identical to offline when chunk_frames == native_chunk_frames."""
+    cf = chunk_frames or native_chunk_frames(conformer)
+    return mx.concatenate(list(_iter_chunks(conformer, mel, cf)), axis=1)
+
+
+def stream_transcribe(model, mel, prompt_id, chunk_frames=None):
+    """Cache-aware streaming RNN-T decode. Yields (new_token_ids, all_token_ids)
+    per chunk; persists LSTM/last-token state across chunks. Token sequence
+    equals the offline greedy result at the native chunk size."""
+    cf = chunk_frames or native_chunk_frames(model.encoder)
+    last_token = model.blank_id
+    hidden = None
+    all_ids: list[int] = []
+    for enc in _iter_chunks(model.encoder, mel, cf):
+        post = model._fuse(enc, prompt_id)  # (1, c, d) language-conditioned
+        new: list[int] = []
+        for t in range(post.shape[1]):
+            feat = post[:, t : t + 1]
+            sym = 0
+            while True:
+                cur = (
+                    mx.array([[last_token]], dtype=mx.int32)
+                    if last_token != model.blank_id
+                    else None
+                )
+                dec_out, (h, c) = model.decoder(cur, hidden)
+                logits = model.joint(feat, dec_out.astype(feat.dtype))
+                pred = int(mx.argmax(logits))
+                if pred == model.blank_id:
+                    break
+                last_token = pred
+                hidden = (h.astype(feat.dtype), c.astype(feat.dtype))
+                new.append(pred)
+                sym += 1
+                if model.max_symbols is not None and sym >= model.max_symbols:
+                    break
+        all_ids.extend(new)
+        yield new, all_ids

--- a/mlx_audio/stt/models/nemotron_asr/streaming.py
+++ b/mlx_audio/stt/models/nemotron_asr/streaming.py
@@ -8,8 +8,10 @@ cache_last_time):
 Per chunk: Q = new frames, K/V = [attn_cache + new]; depthwise conv prepends the
 conv_cache instead of zero-padding. With the window sized to the allowed left
 context, no attention mask is needed — so streaming output is frame-identical to
-the offline (chunked_limited) encoder. Subsampling is done up-front on the
-provided mel; incremental subsampling can wrap this later.
+the offline (chunked_limited) encoder. Subsampling is also incremental: each mel
+chunk is subsampled with a 16-frame mel cache, emitting only newly-stable frames
+(causal dw-striding has no real future dependency; the per-chunk boundary frame
+is recomputed next chunk).
 """
 
 import mlx.core as mx
@@ -50,17 +52,42 @@ def native_chunk_frames(conformer) -> int:
     return int(conformer.args.att_context_size[1]) + 1
 
 
+_PRE_ENCODE_MEL_CACHE = 16  # mel frames of left context for incremental subsampling
+# (>= causal receptive field of the 8x dw-striding stack)
+
+
 def _iter_chunks(conformer, mel, chunk_frames):
-    """Yield (encoder_frames_for_chunk) streaming over the conformer."""
+    """Yield encoder frames per chunk — fully incremental: chunk-wise causal
+    subsampling (16-frame mel cache) feeding the cache-aware conformer. Output is
+    frame-identical to offline at chunk_frames == native_chunk_frames."""
     left_cache = int(conformer.args.att_context_size[0])
     conv_left = conformer.args.conv_kernel_size - 1
-    feats = conformer.pre_encode(mel)  # (1, T', d) — subsample up-front
-    T = feats.shape[1]
+    sf = conformer.args.subsampling_factor
+    M = chunk_frames * sf  # mel frames consumed per chunk
+    N = mel.shape[1]
     n = len(conformer.layers)
     attn_cache = [None] * n
     conv_cache = [None] * n
-    for s in range(0, T, chunk_frames):
-        x = feats[:, s : s + chunk_frames]
+    mel_cache = None
+    emitted = 0  # encoder frames emitted so far
+    consumed = 0  # mel frames consumed so far
+    while consumed < N:
+        m = mel[:, consumed : consumed + M]
+        cache_len = 0 if mel_cache is None else mel_cache.shape[1]
+        win = m if mel_cache is None else mx.concatenate([mel_cache, m], axis=1)
+        sub = conformer.pre_encode(win)  # incremental subsample of this window
+        L = consumed + m.shape[1]
+        is_final = L >= N
+        base = (consumed - cache_len) // sf  # global index of window frame 0
+        lo = emitted - base
+        hi = sub.shape[1] if is_final else (L // sf - base)  # stable frames only
+        feats = sub[:, lo:hi]
+        emitted = base + hi
+        consumed = L
+        mel_cache = win[:, -_PRE_ENCODE_MEL_CACHE:]
+        if feats.shape[1] == 0:
+            continue
+        x = feats
         for li, layer in enumerate(conformer.layers):
             x, attn_cache[li], conv_cache[li] = _stream_block(
                 layer,

--- a/mlx_audio/stt/models/nemotron_asr/tokenizer.py
+++ b/mlx_audio/stt/models/nemotron_asr/tokenizer.py
@@ -1,0 +1,29 @@
+"""Detokenizer for Nemotron 3.5 ASR (SentencePiece BPE pieces).
+
+The .nemo's tokenizer is SentencePiece BPE (13087 pieces). The converter dumps
+the piece list into config `vocabulary`, so detok is dependency-free:
+join pieces and turn the SP space marker into spaces. The model emits a trailing
+language tag piece (e.g. `<en-US>`); `strip_lang_tag` removes it.
+"""
+
+import re
+
+_SP_SPACE = "▁"  # ▁
+_LANG_TAG = re.compile(r"\s*<[a-z]{2}(?:-[A-Za-z]{2,3})?>\s*$")
+
+
+class VocabTokenizer:
+    def __init__(self, vocabulary: list[str]):
+        self.vocabulary = vocabulary
+
+    def decode(self, ids: list[int]) -> str:
+        pieces = [self.vocabulary[i] for i in ids if 0 <= i < len(self.vocabulary)]
+        return "".join(pieces).replace(_SP_SPACE, " ").strip()
+
+
+def strip_lang_tag(text: str) -> tuple[str, str | None]:
+    """Return (clean_text, lang_tag) where lang_tag is e.g. 'en-US' or None."""
+    m = _LANG_TAG.search(text)
+    if not m:
+        return text, None
+    return _LANG_TAG.sub("", text), m.group(0).strip().strip("<>")

--- a/mlx_audio/stt/utils.py
+++ b/mlx_audio/stt/utils.py
@@ -25,6 +25,7 @@ MODEL_REMAPPING = {
     "granite_speech_nar": "granite_speech_nar",
     "qwen2_audio": "qwen2_audio",
     "mega_asr": "mega_asr",
+    "nemotron_asr": "nemotron_asr",
 }
 
 


### PR DESCRIPTION
## Summary

Adds **`nemotron_asr`** — an MLX port of [`nvidia/nemotron-3.5-asr-streaming-0.6b`](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b),
a multilingual **cache-aware streaming** FastConformer + RNN-T model with
language-ID prompt conditioning (40 language-locales).

Both **offline** and **cache-aware streaming** are validated **token-identical** to
the NeMo reference, and WER on FLEURS matches NeMo at the noise floor.

## What's included

`mlx_audio/stt/models/nemotron_asr/`:
- `audio.py` — NeMo-exact log-mel (preemph 0.97, log-guard 2⁻²⁴, `pad_mode=constant`; uses the `.nemo` filterbank/window verbatim)
- `encoder.py` — FastConformer: causal dw-striding subsampling, causal depthwise conv + LayerNorm, no-bias, block-causal `chunked_limited` attention mask
- `attention.py` — relative-positional MHA (+ cache-aware `stream` step)
- `decoder.py` — RNN-T prednet + joint (reuses the Parakeet implementation)
- `prompt fusion` — one-hot language ⊕ encoder → MLP, replacing the encoder output before the joint
- `streaming.py` — fully incremental: per-layer attention(left-context)+conv caches and incremental causal subsampling (16-frame mel cache), O(n), no recompute
- `model.py` — `Model.generate` (offline) and `Model.stream_generate` (incremental partials)
- registered `nemotron_asr` in `mlx_audio/stt/utils.py::MODEL_REMAPPING`

## Parity & quantization

FLEURS en-US (200 utt, 16 kHz), word-level WER with shared normalization.
Reference = NeMo on CUDA (RTX 4090); MLX measured on an M1 Mac mini (16 GB):

| Model | Backend | WER | Δ vs NeMo | Size | RTF |
|------|---------|-----|-----------|------|-----|
| NeMo bf16 (reference) | CUDA · RTX 4090 | 10.35% | — | — | 0.0040 |
| MLX bf16 | Metal · M1 Mac mini | 10.37% | **+0.02%** (1 word / 4261) | 1.28 GB | 0.099 |
| MLX 8-bit | Metal · M1 Mac mini | 10.42% | **+0.07%** (3 words) | 0.72 GB (−43%) | 0.062 |

> RTF is on different hardware (RTX 4090 vs M1 Mac mini) — shown for reference, not a
> like-for-like speed comparison. Parity is the WER match: MLX bf16 differs from the
> CUDA reference by **1 word in 4261**.

- Offline & streaming encoder output are **frame-identical** to offline/NeMo on 16 kHz input.
- 8-bit quantization of the full model is effective; protecting the encoder is not worthwhile (it is ~90% of params).

## Usage

```python
from mlx_audio.stt import load

model = load("mlx-community/nemotron-3.5-asr-streaming-0.6b-bf16")
print(model.generate("audio.wav", target_lang="en-US").text)

for r in model.stream_generate("audio.wav", target_lang="en-US"):
    print(("[final] " if r.is_final else "[part]  ") + r.text)
```

`target_lang`: a locale (`en-US`, `es-ES`, …) or `"auto"`.

## Weights

- [`mlx-community/nemotron-3.5-asr-streaming-0.6b-bf16`](https://huggingface.co/mlx-community/nemotron-3.5-asr-streaming-0.6b-bf16) ✅
- `mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit` (upload pending)

## Known limitation

Exact parity requires **16 kHz** input. For other sample rates, `mlx_audio`'s
resampler leaves slightly more near-Nyquist energy than librosa, which can perturb
the top mel bins (tracked separately). Feed 16 kHz audio, or resample with a
band-limiting resampler.
