### PR TITLE
fix(utils): sharpen resampler anti-aliasing filter

### DIFF
--- a/mlx_audio/tests/test_dsp.py
+++ b/mlx_audio/tests/test_dsp.py
@@ -160,6 +160,57 @@ def test_normalize_peak_matches_reference_values():
     )
 
 
+def test_resample_rejects_energy_above_target_nyquist():
+    """A tone just above the new Nyquist must be band-limited away, not aliased
+    back into the signal. The previous Kaiser(5.0) default left a large residual
+    in the top bins here (#24)."""
+    from mlx_audio.utils import resample_audio
+
+    orig, target = 24000, 16000
+    t = np.arange(2 * orig) / orig
+    tone = np.sin(2 * np.pi * 8200.0 * t).astype(np.float32)  # 200 Hz above Nyquist
+    out = np.asarray(resample_audio(tone, orig, target))
+    rms = float(np.sqrt(np.mean(out[400:-400] ** 2)))
+    assert rms < 0.01  # sharp filter -> ~0; the old default left ~0.26
+
+
+def test_resample_preserves_passband():
+    """In-band tones pass with ~unit gain, including near the Nyquist edge where
+    the old filter drooped (full-scale sine RMS == 1/sqrt(2) ~= 0.7071)."""
+    from mlx_audio.utils import resample_audio
+
+    orig, target = 24000, 16000
+    t = np.arange(2 * orig) / orig
+    for freq in (1000.0, 7000.0):
+        tone = np.sin(2 * np.pi * freq * t).astype(np.float32)
+        out = np.asarray(resample_audio(tone, orig, target))
+        rms = float(np.sqrt(np.mean(out[400:-400] ** 2)))
+        assert 0.70 < rms < 0.72
+
+
+def test_resample_length_and_type():
+    """Output length tracks the rate ratio and the return type matches input."""
+    import mlx.core as mx
+
+    from mlx_audio.utils import resample_audio
+
+    x = np.zeros(24000, dtype=np.float32)
+    out = resample_audio(x, 24000, 16000)
+    assert isinstance(out, np.ndarray)
+    assert abs(len(out) - 16000) <= 1
+
+    out_mx = resample_audio(mx.array(x), 24000, 16000)
+    assert isinstance(out_mx, mx.array)
+
+
+def test_resample_noop_when_rates_equal():
+    from mlx_audio.utils import resample_audio
+
+    x = np.linspace(-1.0, 1.0, 100, dtype=np.float32)
+    out = resample_audio(x, 16000, 16000)
+    np.testing.assert_array_equal(np.asarray(out), x)
+
+
 def test_integrated_loudness_validation_matches_previous_behavior():
     """Verify the public helper keeps the old validation semantics."""
     from mlx_audio.dsp import integrated_loudness

--- a/mlx_audio/utils.py
+++ b/mlx_audio/utils.py
@@ -546,6 +546,13 @@ def resample_audio(
 ):
     """Resample audio with polyphase filtering.
 
+    Uses a Kaiser-windowed sinc anti-aliasing filter equivalent to ``librosa``'s
+    ``kaiser_best`` (resampy parameters) instead of ``resample_poly``'s default
+    Kaiser(5.0). The default filter has a wide transition band that leaves
+    significant energy near the new Nyquist; the sharper filter band-limits
+    cleanly so resampled audio matches the librosa-equivalent featurizers that
+    ASR reference pipelines (e.g. NeMo) assume. See issue #24.
+
     Args:
         audio: Audio array as numpy or MLX.
         orig_sample_rate: Original sample rate.
@@ -567,11 +574,23 @@ def resample_audio(
     gcd = math.gcd(int(orig_sample_rate), int(sample_rate))
     up = sample_rate // gcd
     down = orig_sample_rate // gcd
+
+    # kaiser_best-equivalent anti-aliasing FIR (resampy defaults): a long,
+    # high-attenuation Kaiser sinc designed at the upsampled rate. Cutoff is at
+    # ``rolloff / max(up, down)`` of the upsampled Nyquist.
+    max_rate = max(up, down)
+    num_zeros, rolloff, beta = 64, 0.9475937167399596, 14.769656459379492
+    fir = signal.firwin(
+        2 * num_zeros * max_rate + 1,
+        rolloff / max_rate,
+        window=("kaiser", beta),
+    )
     resampled = signal.resample_poly(
         audio_np,
         up,
         down,
         axis=axis,
+        window=fir,
         padtype="edge",
     ).astype(np.float32, copy=False)
 


### PR DESCRIPTION
## Problem

`mlx_audio.utils.resample_audio` (used by `stt.utils.load_audio` and others) relies on `scipy.signal.resample_poly`'s **default Kaiser(5.0)** FIR. Its wide transition band leaves significant energy near the new Nyquist when downsampling (e.g. 24 kHz → 16 kHz), diverging from the `librosa`-equivalent featurizers that ASR reference pipelines (e.g. NeMo) assume. On borderline inputs this flips tokens.

Found while porting `nvidia/nemotron-3.5-asr-streaming-0.6b`: 16 kHz-native input is token-exact vs NeMo, but a 24 kHz file resampled internally produced `Hello world` instead of the reference `Hello World`.

## Fix

Use a **`kaiser_best`-equivalent** anti-aliasing FIR (resampy parameters: `num_zeros=64`, `rolloff=0.9476`, `beta=14.77`) designed at the upsampled rate and passed to `resample_poly`. **scipy-only — no new dependency.** Polyphase `upfirdn` keeps it fast (44.1 kHz → 16 kHz of 10 s audio in ~70 ms).

## Validation

Power-spectrum relative error vs a `librosa` `soxr_hq` reference (`audio_000.wav`, 24 kHz → 16 kHz):

| STFT bins | before | after |
|---|---|---|
| all (0–256) | 0.0026 | 0.0004 |
| 200–256 | 0.299 | 0.083 |
| 250–256 (near Nyquist) | **~1001** | **~1.1** |

After matches `librosa`'s own `kaiser_best` (~1.0). End-to-end, the `nemotron_asr` transcript of the 24 kHz fixture goes from `Hello world` → `Hello World` (the NeMo reference).

## Tests

Adds anti-aliasing (8.2 kHz tone above Nyquist rejected), passband-preservation (incl. near-Nyquist edge), output-length, and dtype regression tests in `test_dsp.py`.

Fixes beshkenadze/mlx-audio#24.