### PR TITLE
feat(stt): add --max-line-length to split long srt/vtt cues

### DIFF
--- a/mlx_audio/stt/generate.py
+++ b/mlx_audio/stt/generate.py
@@ -38,6 +38,13 @@ def parse_args(argv: Optional[List[str]] = None):
         choices=["txt", "srt", "vtt", "json"],
         help="Output format (txt, srt, vtt, or json)",
     )
+    parser.add_argument(
+        "--max-line-length",
+        type=int,
+        default=None,
+        help="Split srt/vtt cues at punctuation so each stays within roughly "
+        "this many characters (default: no splitting)",
+    )
     parser.add_argument("--verbose", action="store_true", help="Verbose output")
     parser.add_argument(
         "--max-tokens",
@@ -125,21 +132,59 @@ def format_vtt_timestamp(seconds: float) -> str:
     return format_timestamp(seconds).replace(",", ".")
 
 
-def _get_cues(segments):
+def _split_cue(cue, max_line_length):
+    """Split a long cue into shorter ones at sentence/clause boundaries.
+
+    Models that only return segment-level timestamps (e.g. Qwen3-ASR) can emit
+    one cue per 30s chunk, which renders as a multi-line subtitle covering half
+    the screen. We break it at punctuation and spread the cue's time span across
+    the pieces proportionally to their length, so each cue fits on one line.
+    """
+    text = cue["text"]
+    pieces, buf = [], ""
+    for ch in text:
+        buf += ch
+        if ch in "。！？.!?；;\n" or (len(buf) >= max_line_length and ch in "，、,"):
+            pieces.append(buf.strip())
+            buf = ""
+    if buf.strip():
+        pieces.append(buf.strip())
+    pieces = [p for p in pieces if p]
+    if len(pieces) <= 1:
+        return [cue]
+
+    total = sum(len(p) for p in pieces)
+    span = cue["end"] - cue["start"]
+    out, start = [], cue["start"]
+    for p in pieces:
+        end = start + span * len(p) / total
+        out.append({"start": start, "end": end, "text": p})
+        start = end
+    out[-1]["end"] = cue["end"]
+    return out
+
+
+def _get_cues(segments, max_line_length=None):
     """Extract unified cues from any model's output (Parakeet or Whisper).
 
     Uses word-level cues when available, otherwise falls back to segment-level.
     """
     if hasattr(segments, "sentences"):
-        return [
+        cues = [
             {"start": s.start, "end": s.end, "text": s.text} for s in segments.sentences
         ]
-    cues = []
-    for s in segments.segments:
-        cues.append({"start": s["start"], "end": s["end"], "text": s["text"]})
-        if "words" in s and s["words"]:
-            for w in s["words"]:
-                cues.append({"start": w["start"], "end": w["end"], "text": w["word"]})
+    else:
+        cues = []
+        for s in segments.segments:
+            cues.append({"start": s["start"], "end": s["end"], "text": s["text"]})
+            if "words" in s and s["words"]:
+                for w in s["words"]:
+                    cues.append(
+                        {"start": w["start"], "end": w["end"], "text": w["word"]}
+                    )
+
+    if max_line_length:
+        cues = [c for cue in cues for c in _split_cue(cue, max_line_length)]
     return cues
 
 
@@ -152,13 +197,13 @@ def save_as_txt(segments, output_path: str):
         f.write(segments.text)
 
 
-def save_as_srt(segments, output_path: str):
+def save_as_srt(segments, output_path: str, max_line_length=None):
     with (
         open(f"{output_path}.srt", "w", encoding="utf-8")
         if output_path != "-"
         else contextlib.nullcontext(sys.stdout)
     ) as f:
-        for i, cue in enumerate(_get_cues(segments), 1):
+        for i, cue in enumerate(_get_cues(segments, max_line_length), 1):
             f.write(f"{i}\n")
             f.write(
                 f"{format_timestamp(cue['start'])} --> {format_timestamp(cue['end'])}\n"
@@ -166,14 +211,14 @@ def save_as_srt(segments, output_path: str):
             f.write(f"{cue['text']}\n\n")
 
 
-def save_as_vtt(segments, output_path: str):
+def save_as_vtt(segments, output_path: str, max_line_length=None):
     with (
         open(f"{output_path}.vtt", "w", encoding="utf-8")
         if output_path != "-"
         else contextlib.nullcontext(sys.stdout)
     ) as f:
         f.write("WEBVTT\n\n")
-        for i, cue in enumerate(_get_cues(segments), 1):
+        for i, cue in enumerate(_get_cues(segments, max_line_length), 1):
             f.write(f"{i}\n")
             f.write(
                 f"{format_vtt_timestamp(cue['start'])} --> {format_vtt_timestamp(cue['end'])}\n"
@@ -287,6 +332,7 @@ def generate_transcription(
     format: str = "txt",
     verbose: bool = False,
     text: str = "",
+    max_line_length: Optional[int] = None,
     **kwargs,
 ):
     """Generate transcriptions from audio files.
@@ -415,9 +461,9 @@ def generate_transcription(
             print("[WARNING] No segments found, saving as plain text.")
         save_as_txt(segments, output_path)
     elif format == "srt":
-        save_as_srt(segments, output_path)
+        save_as_srt(segments, output_path, max_line_length)
     elif format == "vtt":
-        save_as_vtt(segments, output_path)
+        save_as_vtt(segments, output_path, max_line_length)
     elif format == "json":
         save_as_json(segments, output_path)
 

--- a/mlx_audio/stt/tests/test_subtitle_segmentation.py
+++ b/mlx_audio/stt/tests/test_subtitle_segmentation.py
@@ -1,0 +1,31 @@
+import types
+import unittest
+
+from mlx_audio.stt.generate import _get_cues, _split_cue
+
+
+class TestSubtitleSegmentation(unittest.TestCase):
+    def test_short_cue_is_not_split(self):
+        cue = {"start": 0.0, "end": 2.0, "text": "Hello world."}
+        self.assertEqual(_split_cue(cue, 40), [cue])
+
+    def test_long_cue_split_preserves_span_and_order(self):
+        cue = {"start": 10.0, "end": 30.0, "text": "一二三。四五六。七八九。"}
+        out = _split_cue(cue, 2)
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out[0]["start"], 10.0)
+        self.assertEqual(out[-1]["end"], 30.0)
+        for a, b in zip(out, out[1:]):
+            self.assertEqual(a["end"], b["start"])
+        self.assertEqual("".join(c["text"] for c in out), cue["text"])
+
+    def test_get_cues_default_keeps_single_segment(self):
+        seg = types.SimpleNamespace(
+            segments=[{"start": 0.0, "end": 1.0, "text": "a。b。"}]
+        )
+        self.assertEqual(len(_get_cues(seg)), 1)
+        self.assertEqual(len(_get_cues(seg, max_line_length=1)), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Context

Segment-only STT models (e.g. Qwen3-ASR) emit **one cue per audio chunk**, so with the default `--chunk-duration 30` each `.srt`/`.vtt` cue spans ~30s and holds 50+ characters. Over a video this fills half the screen and isn't usable as a subtitle. Lowering `--chunk-duration` is a blunt workaround — it shrinks the ASR window (hurting accuracy/speed) and still won't break at sentence boundaries.

Closes #780.

## Description

Add an opt-in `--max-line-length N`. When set, each srt/vtt cue is split at sentence/clause punctuation (`。！？.!?；;` and, past the limit, `，、,`), and the cue's `[start, end]` span is distributed across the pieces proportionally to their character length. This is presentation-only — no extra model and no word-level alignment required (forced alignment remains the path to exact word timing).

Before / after (`--max-line-length 18`):

```
1
00:00:00,000 --> 00:00:33,782
Hello，大家好，我是美咋了。这课我们继续学习现代基础的四点三线相关、线无关与线表示。这课可以说是向量与方组这个章节呢比较重要的，也颇有难度的一个小节，所以大家要多花点心思。
```
```
1
00:00:00,000 --> 00:00:06,142
Hello，大家好，我是美咋了。
2
00:00:06,142 --> 00:00:13,820
这课我们继续学习现代基础的四点三线相关、
...
```

## Changes in the codebase

- `_get_cues()` takes an optional `max_line_length`; a new `_split_cue()` helper does the punctuation split + proportional retiming. Both `save_as_srt`/`save_as_vtt` route through it, so SRT and VTT share one code path.
- `--max-line-length` CLI flag (default `None` → behavior unchanged).
- `test_subtitle_segmentation.py` covering no-split, span/order preservation, and the default-unchanged path.

## Changes outside the codebase

None.

## Additional information

Default unset means this is fully backward compatible. The split is a soft cap (it breaks at the first clause boundary after reaching the limit) rather than a hard character truncation, to avoid cutting words mid-token.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [x] Issue referenced (Closes #780)