### PR TITLE
Fix SineGen length alignment

### DIFF
--- a/mlx_audio/tts/models/kitten_tts/istftnet.py
+++ b/mlx_audio/tts/models/kitten_tts/istftnet.py
@@ -615,6 +615,16 @@ class SineGen:
             sines = mx.cos(i_phase * 2 * mx.pi)
         return sines
 
+    def _match_f0_length(self, sine_waves: mx.array, f0: mx.array) -> mx.array:
+        target_len = f0.shape[1]
+        if sine_waves.shape[1] == target_len:
+            return sine_waves
+        if sine_waves.shape[1] > target_len:
+            return sine_waves[:, :target_len, :]
+        return mx.pad(
+            sine_waves, ((0, 0), (0, target_len - sine_waves.shape[1]), (0, 0))
+        )
+
     def __call__(self, f0: mx.array) -> Tuple[mx.array, mx.array, mx.array]:
         f0_buf = mx.zeros((f0.shape[0], f0.shape[1], self.dim))
 
@@ -623,6 +633,7 @@ class SineGen:
 
         # Generate sine waveforms
         sine_waves = self._f02sine(fn) * self.sine_amp
+        sine_waves = self._match_f0_length(sine_waves, f0)
 
         # Generate UV signal
         uv = self._f02uv(f0)

--- a/mlx_audio/tts/models/kokoro/istftnet.py
+++ b/mlx_audio/tts/models/kokoro/istftnet.py
@@ -603,6 +603,16 @@ class SineGen:
             sines = mx.cos(i_phase * 2 * mx.pi)
         return sines
 
+    def _match_f0_length(self, sine_waves: mx.array, f0: mx.array) -> mx.array:
+        target_len = f0.shape[1]
+        if sine_waves.shape[1] == target_len:
+            return sine_waves
+        if sine_waves.shape[1] > target_len:
+            return sine_waves[:, :target_len, :]
+        return mx.pad(
+            sine_waves, ((0, 0), (0, target_len - sine_waves.shape[1]), (0, 0))
+        )
+
     def __call__(self, f0: mx.array) -> Tuple[mx.array, mx.array, mx.array]:
         f0_buf = mx.zeros((f0.shape[0], f0.shape[1], self.dim))
 
@@ -611,6 +621,7 @@ class SineGen:
 
         # Generate sine waveforms
         sine_waves = self._f02sine(fn) * self.sine_amp
+        sine_waves = self._match_f0_length(sine_waves, f0)
 
         # Generate UV signal
         uv = self._f02uv(f0)

--- a/mlx_audio/tts/tests/test_sinegen_length_alignment.py
+++ b/mlx_audio/tts/tests/test_sinegen_length_alignment.py
@@ -1,0 +1,17 @@
+import mlx.core as mx
+import pytest
+
+from mlx_audio.tts.models.kitten_tts.istftnet import SineGen as KittenSineGen
+from mlx_audio.tts.models.kokoro.istftnet import SineGen as KokoroSineGen
+
+
+@pytest.mark.parametrize("sine_gen_cls", [KokoroSineGen, KittenSineGen])
+def test_sinegen_matches_f0_length_after_interpolation(sine_gen_cls):
+    sine_gen = sine_gen_cls(24000, upsample_scale=300, harmonic_num=8)
+    f0 = mx.ones((1, 2, 1)) * 120
+
+    sine_waves, uv, noise = sine_gen(f0)
+
+    assert sine_waves.shape == (1, 2, 9)
+    assert uv.shape == (1, 2, 1)
+    assert noise.shape == (1, 2, 9)


### PR DESCRIPTION
## Summary
- align Kokoro and Kitten TTS generated sine wave lengths to the input F0 length before applying UV/noise tensors
- avoid MLX broadcast shape errors when interpolation round-trips to a neighboring frame count
- add a small synthetic regression test covering both SineGen implementations

## Reproduction
A Kokoro speech request can fail during generation with:

```
ValueError: [broadcast_shapes] Shapes (1,147600,1) and (1,147900,9) cannot be broadcast.
```

The same mismatch can be reproduced without model weights by calling Kokoro or Kitten `SineGen` with a short F0 tensor and `upsample_scale=300`.

## Tests
- `python -m pytest mlx_audio/tts/tests/test_sinegen_length_alignment.py -q`
- `python -m pytest mlx_audio/tts/tests/test_interpolate.py -q`