### PR TITLE
Fix Kokoro SineGen broadcast crash on certain inputs

### DIFF
--- a/mlx_audio/tts/models/kokoro/istftnet.py
+++ b/mlx_audio/tts/models/kokoro/istftnet.py
@@ -615,6 +615,15 @@ class SineGen:
         # Generate UV signal
         uv = self._f02uv(f0)
 
+        # Length-match guard: _f02sine's internal phase upsampling can yield a
+        # time dimension one hop longer than uv for certain f0 lengths, which
+        # makes the noise broadcast below fail with a [broadcast_shapes] error
+        # on a significant fraction of real inputs. Truncate both to the common
+        # length (a <=1-hop trim of the excitation signal, inaudible).
+        seq_len = min(sine_waves.shape[1], uv.shape[1])
+        sine_waves = sine_waves[:, :seq_len, :]
+        uv = uv[:, :seq_len, :]
+
         # Generate noise
         noise_amp = uv * self.noise_std + (1 - uv) * self.sine_amp / 3
         noise = noise_amp * mx.random.normal(sine_waves.shape)


### PR DESCRIPTION
While running Kokoro-82M (bf16 and 8-bit) via mlx-audio, generation crashes on a significant fraction of ordinary sentences with:

```
ValueError: [broadcast_shapes] Shapes (1, N, 1) and (1, N+hop, 9) cannot be broadcast.
```

### Root cause
In `SineGen.__call__` (`mlx_audio/tts/models/kokoro/istftnet.py`), `_f02sine`'s internal phase upsampling can produce a time dimension **one hop longer** than the `uv` signal returned by `_f02uv(f0)` for certain `f0` lengths. The next line then broadcasts `noise_amp` (shape `(1, N, 1)`) against `mx.random.normal(sine_waves.shape)` (shape `(1, N+hop, 9)`) and fails.

The mismatch is **deterministic per input** (the same sentences fail across bf16/8-bit and across runs), so retrying does not help.

### Fix
Truncate `sine_waves` and `uv` to their common length before combining — a `<=1`-hop trim of the excitation signal.

### Verification
- A 10-sentence smoke test goes from **6/10 → 10/10** passing.
- The trim is inaudible: previously-failing sentences (incl. `"Hello there."`) round-trip cleanly through Whisper (`whisperkit-cli`) — transcripts match the input text.
- Tested on Apple Silicon (M2 Max), Python 3.12, mlx-audio `main`, both `mlx-community/Kokoro-82M-bf16` and `-8bit`.
