### PR TITLE
Fix interpolate scale factor drift

### DIFF
--- a/mlx_audio/tts/models/interpolate.py
+++ b/mlx_audio/tts/models/interpolate.py
@@ -4,6 +4,13 @@ from typing import List, Optional, Tuple, Union
 import mlx.core as mx
 
 
+def _ceil_with_float_tolerance(value: float) -> int:
+    nearest_int = round(value)
+    if abs(value - nearest_int) < 1e-9:
+        value = nearest_int
+    return int(math.ceil(value))
+
+
 def interpolate(
     input: mx.array,
     size: Optional[Union[int, Tuple[int, ...], List[int]]] = None,
@@ -43,9 +50,10 @@ def interpolate(
         size = []
         for i in range(spatial_dims):
             # Use ceiling instead of floor to match PyTorch behavior
+            scaled_size = float(input.shape[i + 2]) * float(scale_factor[i])
             curr_size = max(
                 1,
-                int(math.ceil(float(input.shape[i + 2]) * float(scale_factor[i]))),
+                _ceil_with_float_tolerance(scaled_size),
             )
             size.append(curr_size)
 

--- a/mlx_audio/tts/tests/test_interpolate.py
+++ b/mlx_audio/tts/tests/test_interpolate.py
@@ -37,6 +37,11 @@ class TestInterpolate(unittest.TestCase):
         result = interpolate(x, scale_factor=2)
         self.assertEqual(result.shape, (2, 3, 8))
 
+        # Avoid expanding exact integer output sizes because of float64 drift.
+        x = mx.array(np.zeros((1, 1, 296400)))
+        result = interpolate(x, scale_factor=1 / 300)
+        self.assertEqual(result.shape, (1, 1, 988))
+
     def test_interpolate1d_nearest(self):
         """Test 1D nearest neighbor interpolation."""
         # Create a simple test array


### PR DESCRIPTION
Fixes #786.

## Summary
- Add a tiny tolerance around integer output sizes when computing scaled interpolation dimensions.
- Add a regression case for the Kokoro scale factor drift that should produce 988 frames, not 989.

## Verification
- `pytest mlx_audio/tts/tests/test_interpolate.py`
- `black --check mlx_audio/tts/models/interpolate.py mlx_audio/tts/tests/test_interpolate.py`
