### PR TITLE
Add Confucius4-TTS: multilingual zero-shot voice-cloning TTS (MLX)

### DIFF
--- a/mlx_audio/tts/models/confucius4/README.md
+++ b/mlx_audio/tts/models/confucius4/README.md
@@ -1,0 +1,65 @@
+# Confucius4-TTS
+
+Multilingual, cross-lingual, zero-shot voice-cloning TTS, ported to MLX from
+[netease-youdao/Confucius4-TTS](https://huggingface.co/netease-youdao/Confucius4-TTS)
+(Apache-2.0).
+
+Pipeline: w2v-bert semantic features + CAMPPlus speaker embedding → T2S (GPT-2)
+→ S2A conditional flow-matching (DiT + WaveNet) → BigVGAN v2 vocoder.
+
+## Voice Cloning
+
+Clone any voice from a short reference clip. Pass the text, the reference wav,
+and the target language code:
+
+```python
+from mlx_audio.tts.utils import load_model
+
+model = load_model("mlx-community/Confucius4-TTS-mlx")
+results = list(model.generate(
+    text="Xin chào, đây là giọng nói được nhân bản.",
+    ref_audio="reference.wav",   # any sample rate; decoded + resampled to 16 kHz
+    lang="vi",
+))
+
+audio = results[0].audio              # mx.array
+sample_rate = results[0].sample_rate  # 22050
+```
+
+Save the result with the bundled audio I/O helper:
+
+```python
+import numpy as np
+from mlx_audio.audio_io import write
+
+write("output.wav", np.array(results[0].audio), results[0].sample_rate)
+```
+
+## Languages
+
+`lang` accepts: `zh`, `en`, `vi`, `ja`, `ko`, `th`.
+
+## Available Models
+
+| Model | Precision | Description |
+|-------|-----------|-------------|
+| `mlx-community/Confucius4-TTS-mlx`      | fp32 | Full-quality weights |
+| `mlx-community/Confucius4-TTS-mlx-int8` | int8 | ~60% smaller, faster on Apple Silicon |
+
+## Converting Weights
+
+Convert the original PyTorch checkpoint to MLX:
+
+```bash
+python -m mlx_audio.tts.models.confucius4.convert --out ./confucius4-model
+```
+
+Add `--quantize int8` (or `int4`) to quantize the T2S body matmuls.
+
+## Notes
+
+- No `torch`/`transformers` in the inference path; `torch` is used only in
+  `convert.py` for weight conversion.
+- Reference audio is decoded and resampled to 16 kHz mono internally via the
+  repo's audio I/O and resampling utilities.
+```

--- a/mlx_audio/tts/models/confucius4/__init__.py
+++ b/mlx_audio/tts/models/confucius4/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
+# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
+# Licensed under the Apache License, Version 2.0.
+from .confucius4 import Model, ModelConfig
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_audio/tts/models/confucius4/__init__.py
+++ b/mlx_audio/tts/models/confucius4/__init__.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
-# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
-# Licensed under the Apache License, Version 2.0.
+# Copyright © 2023-2024 Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 from .confucius4 import Model, ModelConfig
 
 __all__ = ["Model", "ModelConfig"]

--- a/mlx_audio/tts/models/confucius4/confucius4.py
+++ b/mlx_audio/tts/models/confucius4/confucius4.py
@@ -64,7 +64,11 @@ class Model(nn.Module):
         self.config = config
         self.sample_rate = config.sample_rate
         d = Path(config.model_path)
-        self.w2v = W2VBertMLX(str(d / "w2vbert_mlx.safetensors"))
+        self.w2v = W2VBertMLX(
+            str(d / "w2vbert_mlx.safetensors"),
+            group_size=config.quant_group_size,
+            bits=config.quant_bits,
+        )
         self.prefix = T2SPrefixMLX(str(d / "t2s_model.safetensors"))
         self.t2s = T2SMLX(
             str(d / "t2s_model.safetensors"),

--- a/mlx_audio/tts/models/confucius4/confucius4.py
+++ b/mlx_audio/tts/models/confucius4/confucius4.py
@@ -123,6 +123,13 @@ class Model(nn.Module):
         audio = audio.astype(np.float32)
         if audio.ndim > 1:
             audio = audio.mean(1)
+        if sr != 16000:
+            # fbank_160, CAMPPlus and _ref_mel all assume a 16 kHz stream;
+            # without this a 44.1/48 kHz ref is misread as 16 kHz and the
+            # downstream mel is off by sr/16000, producing garbled audio.
+            import librosa
+
+            audio = librosa.resample(audio, orig_sr=sr, target_sr=16000)
 
         feats = self._fbank(audio, self._mel, self._win)
         h17 = np.array(self.w2v.hidden17(mx.array(feats)))

--- a/mlx_audio/tts/models/confucius4/confucius4.py
+++ b/mlx_audio/tts/models/confucius4/confucius4.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
+# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
+# Licensed under the Apache License, Version 2.0.
+"""Confucius4-TTS: multilingual, cross-lingual, zero-shot voice-cloning TTS in MLX.
+
+Pipeline: w2v-bert semantic features + CAMPPlus speaker emb -> T2S (GPT-2) ->
+S2A flow-matching (DiT+WaveNet) -> BigVGAN vocoder. All MLX; frontend DSP numpy.
+"""
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from mlx_audio.tts.models.base import BaseModelArgs, GenerationResult
+from mlx_audio.tts.models.chatterbox.s3gen.xvector import CAMPPlus
+
+from .t2s import T2SMLX
+from .s2a import S2AEstimator
+from .vocoder import BigVGANMLX
+from .w2vbert import W2VBertMLX
+from .prefix import T2SPrefixMLX
+
+LANGUAGE_TOKEN = {  # subset; matches Confucius LANGUAGE_TOKEN_MAP
+    "zh": "请用中文朗读接下来的文字", "en": "请用英文朗读接下来的文字",
+    "vi": "请用越南语朗读接下来的文字", "ja": "请用日语朗读接下来的文字",
+    "ko": "请用韩语朗读接下来的文字", "th": "请用泰语朗读接下来的文字",
+}
+
+
+@dataclass
+class ModelConfig(BaseModelArgs):
+    model_path: str = ""
+    sample_rate: int = 22050
+    model_type: str = "confucius4"
+
+
+def _ref_mel(audio16k):
+    import librosa
+    SR, NFFT, HOP, WIN = 22050, 1024, 256, 1024
+    a = librosa.resample(audio16k, orig_sr=16000, target_sr=SR)
+    mb = librosa.filters.mel(sr=SR, n_fft=NFFT, n_mels=80, fmin=0, fmax=None)
+    hann = np.hanning(WIN + 1)[:-1].astype(np.float32)
+    pad = (NFFT - HOP) // 2
+    y = np.pad(a, (pad, pad), mode="reflect")
+    nfr = 1 + (len(y) - NFFT) // HOP
+    fr = np.stack([y[i * HOP:i * HOP + NFFT] * hann for i in range(nfr)], 0)
+    spec = np.sqrt(np.abs(np.fft.rfft(fr, NFFT, axis=1)).T ** 2 + 1e-9)
+    return np.log(np.clip(mb @ spec, 1e-5, None)).T[None].astype(np.float32)
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.sample_rate = config.sample_rate
+        d = Path(config.model_path)
+        self.w2v = W2VBertMLX(str(d / "w2vbert_mlx.safetensors"))
+        self.prefix = T2SPrefixMLX(str(d / "t2s_model.safetensors"))
+        self.t2s = T2SMLX(str(d / "t2s_model.safetensors"))
+        self.s2a = S2AEstimator(str(d / "s2a_mlx.safetensors"))
+        self.voc = BigVGANMLX(str(d / "bigvgan_mlx.safetensors"))
+        self.stats = np.load(str(d / "w2v_stats.npz"))
+        from mlx.utils import tree_unflatten
+        self.camp = CAMPPlus(feat_dim=80, embedding_size=192)
+        self.camp.update(tree_unflatten(list(mx.load(str(d / "campplus.safetensors")).items())))
+        mx.eval(self.camp.parameters()); self.camp.eval()
+        # torch-free preprocessing: numpy fbank + `tokenizers` (Rust) tokenizer
+        from tokenizers import Tokenizer
+        from .features import fbank_160
+        self._fbank = fbank_160
+        ff = np.load(str(d / "fbank_filters.npz"))
+        self._mel, self._win = ff["mel"], ff["window"]
+        self._tok = Tokenizer.from_file(str(d / "checkpoints" / "tokenizer.json"))
+
+    def sanitize(self, weights):
+        return {}  # sub-weights are loaded from the model dir in __init__
+
+    def load_weights(self, *args, **kwargs):
+        # Components self-load from the model dir in __init__; the standard
+        # tree loader is bypassed. No-op keeps mlx_audio.tts.utils.load() happy.
+        return self
+
+    def generate(self, text: str, ref_audio: str, lang: str = "vi",
+                 temperature: float = 0.8, top_k: int = 30, top_p: float = 0.8,
+                 repetition_penalty: float = 10.0, seed: int = 0, **kwargs):
+        import soundfile as sf
+        t0 = time.time()
+        audio, sr = sf.read(ref_audio)
+        audio = audio.astype(np.float32)
+        if audio.ndim > 1:
+            audio = audio.mean(1)
+
+        feats = self._fbank(audio, self._mel, self._win)
+        h17 = np.array(self.w2v.hidden17(mx.array(feats)))
+        cond_vec = mx.array((h17 - self.stats["mean"]) / self.stats["std"])
+        style = mx.array(np.array(self.camp.inference(mx.array(audio))).reshape(1, 192))
+        ref_mel = mx.array(_ref_mel(audio))
+
+        lt = LANGUAGE_TOKEN.get(lang, LANGUAGE_TOKEN["en"])
+        ids = self._tok.encode(f"You are a helpful assistant. {lt}:{text}").ids
+        cond_emb = self.prefix.cond_emb(cond_vec)
+        text_emb = self.prefix.text_emb(mx.array([ids]))
+        codes, latent = self.t2s.generate(cond_emb, text_emb, temperature=temperature,
+                                          top_k=top_k, top_p=top_p, rep_pen=repetition_penalty, seed=seed)
+
+        T_ref = ref_mel.shape[1]
+        mu = self.s2a.build_mu(mx.array(codes[None]), mx.array(latent), T_ref)
+        mx.random.seed(seed)
+        z = mx.random.normal((1, 80, mu.shape[1]))
+        mel = self.s2a.solve_euler(z, mx.transpose(ref_mel, (0, 2, 1)), mu, style,
+                                   mx.linspace(0, 1, 26), cfg=0.7)[:, :, T_ref:]
+        wav = self.voc(mel)
+        mx.eval(wav)
+        wav = mx.array(np.array(wav).reshape(-1))
+
+        samples = wav.shape[0]
+        dt = time.time() - t0
+        dur = samples / self.sample_rate
+        yield GenerationResult(
+            audio=wav, samples=samples, sample_rate=self.sample_rate, segment_idx=0,
+            token_count=len(codes), audio_duration=f"{dur:.2f}s",
+            real_time_factor=round(dt / dur, 2) if dur else 0.0,
+            prompt={"tokens": len(codes)}, audio_samples={"samples": samples},
+            processing_time_seconds=round(dt, 2), peak_memory_usage=0.0,
+            is_final_chunk=True,
+        )

--- a/mlx_audio/tts/models/confucius4/confucius4.py
+++ b/mlx_audio/tts/models/confucius4/confucius4.py
@@ -18,16 +18,19 @@ import numpy as np
 from mlx_audio.tts.models.base import BaseModelArgs, GenerationResult
 from mlx_audio.tts.models.chatterbox.s3gen.xvector import CAMPPlus
 
-from .t2s import T2SMLX
+from .prefix import T2SPrefixMLX
 from .s2a import S2AEstimator
+from .t2s import T2SMLX
 from .vocoder import BigVGANMLX
 from .w2vbert import W2VBertMLX
-from .prefix import T2SPrefixMLX
 
 LANGUAGE_TOKEN = {  # subset; matches Confucius LANGUAGE_TOKEN_MAP
-    "zh": "请用中文朗读接下来的文字", "en": "请用英文朗读接下来的文字",
-    "vi": "请用越南语朗读接下来的文字", "ja": "请用日语朗读接下来的文字",
-    "ko": "请用韩语朗读接下来的文字", "th": "请用泰语朗读接下来的文字",
+    "zh": "请用中文朗读接下来的文字",
+    "en": "请用英文朗读接下来的文字",
+    "vi": "请用越南语朗读接下来的文字",
+    "ja": "请用日语朗读接下来的文字",
+    "ko": "请用韩语朗读接下来的文字",
+    "th": "请用泰语朗读接下来的文字",
 }
 
 
@@ -40,6 +43,7 @@ class ModelConfig(BaseModelArgs):
 
 def _ref_mel(audio16k):
     import librosa
+
     SR, NFFT, HOP, WIN = 22050, 1024, 256, 1024
     a = librosa.resample(audio16k, orig_sr=16000, target_sr=SR)
     mb = librosa.filters.mel(sr=SR, n_fft=NFFT, n_mels=80, fmin=0, fmax=None)
@@ -47,7 +51,7 @@ def _ref_mel(audio16k):
     pad = (NFFT - HOP) // 2
     y = np.pad(a, (pad, pad), mode="reflect")
     nfr = 1 + (len(y) - NFFT) // HOP
-    fr = np.stack([y[i * HOP:i * HOP + NFFT] * hann for i in range(nfr)], 0)
+    fr = np.stack([y[i * HOP : i * HOP + NFFT] * hann for i in range(nfr)], 0)
     spec = np.sqrt(np.abs(np.fft.rfft(fr, NFFT, axis=1)).T ** 2 + 1e-9)
     return np.log(np.clip(mb @ spec, 1e-5, None)).T[None].astype(np.float32)
 
@@ -65,12 +69,18 @@ class Model(nn.Module):
         self.voc = BigVGANMLX(str(d / "bigvgan_mlx.safetensors"))
         self.stats = np.load(str(d / "w2v_stats.npz"))
         from mlx.utils import tree_unflatten
+
         self.camp = CAMPPlus(feat_dim=80, embedding_size=192)
-        self.camp.update(tree_unflatten(list(mx.load(str(d / "campplus.safetensors")).items())))
-        mx.eval(self.camp.parameters()); self.camp.eval()
+        self.camp.update(
+            tree_unflatten(list(mx.load(str(d / "campplus.safetensors")).items()))
+        )
+        mx.eval(self.camp.parameters())
+        self.camp.eval()
         # torch-free preprocessing: numpy fbank + `tokenizers` (Rust) tokenizer
         from tokenizers import Tokenizer
+
         from .features import fbank_160
+
         self._fbank = fbank_160
         ff = np.load(str(d / "fbank_filters.npz"))
         self._mel, self._win = ff["mel"], ff["window"]
@@ -84,10 +94,20 @@ class Model(nn.Module):
         # tree loader is bypassed. No-op keeps mlx_audio.tts.utils.load() happy.
         return self
 
-    def generate(self, text: str, ref_audio: str, lang: str = "vi",
-                 temperature: float = 0.8, top_k: int = 30, top_p: float = 0.8,
-                 repetition_penalty: float = 10.0, seed: int = 0, **kwargs):
+    def generate(
+        self,
+        text: str,
+        ref_audio: str,
+        lang: str = "vi",
+        temperature: float = 0.8,
+        top_k: int = 30,
+        top_p: float = 0.8,
+        repetition_penalty: float = 10.0,
+        seed: int = 0,
+        **kwargs,
+    ):
         import soundfile as sf
+
         t0 = time.time()
         audio, sr = sf.read(ref_audio)
         audio = audio.astype(np.float32)
@@ -104,15 +124,28 @@ class Model(nn.Module):
         ids = self._tok.encode(f"You are a helpful assistant. {lt}:{text}").ids
         cond_emb = self.prefix.cond_emb(cond_vec)
         text_emb = self.prefix.text_emb(mx.array([ids]))
-        codes, latent = self.t2s.generate(cond_emb, text_emb, temperature=temperature,
-                                          top_k=top_k, top_p=top_p, rep_pen=repetition_penalty, seed=seed)
+        codes, latent = self.t2s.generate(
+            cond_emb,
+            text_emb,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            rep_pen=repetition_penalty,
+            seed=seed,
+        )
 
         T_ref = ref_mel.shape[1]
         mu = self.s2a.build_mu(mx.array(codes[None]), mx.array(latent), T_ref)
         mx.random.seed(seed)
         z = mx.random.normal((1, 80, mu.shape[1]))
-        mel = self.s2a.solve_euler(z, mx.transpose(ref_mel, (0, 2, 1)), mu, style,
-                                   mx.linspace(0, 1, 26), cfg=0.7)[:, :, T_ref:]
+        mel = self.s2a.solve_euler(
+            z,
+            mx.transpose(ref_mel, (0, 2, 1)),
+            mu,
+            style,
+            mx.linspace(0, 1, 26),
+            cfg=0.7,
+        )[:, :, T_ref:]
         wav = self.voc(mel)
         mx.eval(wav)
         wav = mx.array(np.array(wav).reshape(-1))
@@ -121,10 +154,16 @@ class Model(nn.Module):
         dt = time.time() - t0
         dur = samples / self.sample_rate
         yield GenerationResult(
-            audio=wav, samples=samples, sample_rate=self.sample_rate, segment_idx=0,
-            token_count=len(codes), audio_duration=f"{dur:.2f}s",
+            audio=wav,
+            samples=samples,
+            sample_rate=self.sample_rate,
+            segment_idx=0,
+            token_count=len(codes),
+            audio_duration=f"{dur:.2f}s",
             real_time_factor=round(dt / dur, 2) if dur else 0.0,
-            prompt={"tokens": len(codes)}, audio_samples={"samples": samples},
-            processing_time_seconds=round(dt, 2), peak_memory_usage=0.0,
+            prompt={"tokens": len(codes)},
+            audio_samples={"samples": samples},
+            processing_time_seconds=round(dt, 2),
+            peak_memory_usage=0.0,
             is_final_chunk=True,
         )

--- a/mlx_audio/tts/models/confucius4/confucius4.py
+++ b/mlx_audio/tts/models/confucius4/confucius4.py
@@ -1,10 +1,8 @@
-# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
-# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
-# Licensed under the Apache License, Version 2.0.
+# Copyright © 2023-2024 Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 """Confucius4-TTS: multilingual, cross-lingual, zero-shot voice-cloning TTS in MLX.
 
 Pipeline: w2v-bert semantic features + CAMPPlus speaker emb -> T2S (GPT-2) ->
-S2A flow-matching (DiT+WaveNet) -> BigVGAN vocoder. All MLX; frontend DSP numpy.
+S2A flow-matching (DiT+WaveNet) -> BigVGAN vocoder. All MLX; ref-mel DSP numpy.
 """
 import time
 from dataclasses import dataclass
@@ -43,19 +41,55 @@ class ModelConfig(BaseModelArgs):
     quant_group_size: int = 64
 
 
+def _slaney_mel(sr, n_fft, n_mels):
+    """librosa.filters.mel(htk=False, norm="slaney") reimplemented in numpy."""
+    n_freqs = n_fft // 2 + 1
+    fftfreqs = np.linspace(0, sr / 2, n_freqs)
+    f_sp, min_log_hz = 200.0 / 3, 1000.0
+    min_log_mel = min_log_hz / f_sp
+    logstep = np.log(6.4) / 27.0
+
+    def hz_to_mel(f):
+        f = np.asarray(f, dtype=float)
+        mel = f / f_sp
+        log = f >= min_log_hz
+        mel[log] = min_log_mel + np.log(f[log] / min_log_hz) / logstep
+        return mel
+
+    def mel_to_hz(m):
+        f = f_sp * m
+        log = m >= min_log_mel
+        f[log] = min_log_hz * np.exp(logstep * (m[log] - min_log_mel))
+        return f
+
+    mpts = np.linspace(0.0, hz_to_mel([sr / 2])[0], n_mels + 2)
+    fpts = mel_to_hz(mpts)
+    fdiff = np.diff(fpts)
+    ramps = fpts[:, None] - fftfreqs[None, :]
+    w = np.zeros((n_mels, n_freqs))
+    for i in range(n_mels):
+        lower = -ramps[i] / fdiff[i]
+        upper = ramps[i + 2] / fdiff[i + 1]
+        w[i] = np.maximum(0, np.minimum(lower, upper))
+    w *= (2.0 / (fpts[2 : n_mels + 2] - fpts[:n_mels]))[:, None]  # slaney norm
+    return w.astype(np.float32)
+
+
+_REF_MEL_FB = _slaney_mel(22050, 1024, 80)
+
+
 def _ref_mel(audio16k):
-    import librosa
+    from mlx_audio.utils import resample_audio
 
     SR, NFFT, HOP, WIN = 22050, 1024, 256, 1024
-    a = librosa.resample(audio16k, orig_sr=16000, target_sr=SR)
-    mb = librosa.filters.mel(sr=SR, n_fft=NFFT, n_mels=80, fmin=0, fmax=None)
+    a = np.asarray(resample_audio(audio16k, 16000, SR))
     hann = np.hanning(WIN + 1)[:-1].astype(np.float32)
     pad = (NFFT - HOP) // 2
     y = np.pad(a, (pad, pad), mode="reflect")
     nfr = 1 + (len(y) - NFFT) // HOP
     fr = np.stack([y[i * HOP : i * HOP + NFFT] * hann for i in range(nfr)], 0)
     spec = np.sqrt(np.abs(np.fft.rfft(fr, NFFT, axis=1)).T ** 2 + 1e-9)
-    return np.log(np.clip(mb @ spec, 1e-5, None)).T[None].astype(np.float32)
+    return np.log(np.clip(_REF_MEL_FB @ spec, 1e-5, None)).T[None].astype(np.float32)
 
 
 class Model(nn.Module):
@@ -93,7 +127,7 @@ class Model(nn.Module):
 
         self._fbank = fbank_160
         ff = np.load(str(d / "fbank_filters.npz"))
-        self._mel, self._win = ff["mel"], ff["window"]
+        self._mel, self._win = mx.array(ff["mel"]), mx.array(ff["window"])
         self._tok = Tokenizer.from_file(str(d / "checkpoints" / "tokenizer.json"))
 
     def sanitize(self, weights):
@@ -116,23 +150,17 @@ class Model(nn.Module):
         seed: int = 0,
         **kwargs,
     ):
-        import soundfile as sf
+        from mlx_audio.utils import load_audio
 
         t0 = time.time()
-        audio, sr = sf.read(ref_audio)
-        audio = audio.astype(np.float32)
-        if audio.ndim > 1:
-            audio = audio.mean(1)
-        if sr != 16000:
-            # fbank_160, CAMPPlus and _ref_mel all assume a 16 kHz stream;
-            # without this a 44.1/48 kHz ref is misread as 16 kHz and the
-            # downstream mel is off by sr/16000, producing garbled audio.
-            import librosa
+        # load_audio decodes via audio_io and resamples to 16 kHz mono with the
+        # repo resampler; fbank_160, CAMPPlus and _ref_mel all assume 16 kHz.
+        # Without the resample a 44.1/48 kHz ref is misread as 16 kHz and the
+        # downstream mel is off by sr/16000, producing garbled audio.
+        audio = np.asarray(load_audio(ref_audio, sample_rate=16000))
 
-            audio = librosa.resample(audio, orig_sr=sr, target_sr=16000)
-
-        feats = self._fbank(audio, self._mel, self._win)
-        h17 = np.array(self.w2v.hidden17(mx.array(feats)))
+        feats = self._fbank(mx.array(audio), self._mel, self._win)
+        h17 = np.array(self.w2v.hidden17(feats))
         cond_vec = mx.array((h17 - self.stats["mean"]) / self.stats["std"])
         style = mx.array(np.array(self.camp.inference(mx.array(audio))).reshape(1, 192))
         ref_mel = mx.array(_ref_mel(audio))

--- a/mlx_audio/tts/models/confucius4/confucius4.py
+++ b/mlx_audio/tts/models/confucius4/confucius4.py
@@ -39,6 +39,8 @@ class ModelConfig(BaseModelArgs):
     model_path: str = ""
     sample_rate: int = 22050
     model_type: str = "confucius4"
+    quant_bits: int = 8  # bits used if T2S weights are quantized (int8/int4)
+    quant_group_size: int = 64
 
 
 def _ref_mel(audio16k):
@@ -64,7 +66,11 @@ class Model(nn.Module):
         d = Path(config.model_path)
         self.w2v = W2VBertMLX(str(d / "w2vbert_mlx.safetensors"))
         self.prefix = T2SPrefixMLX(str(d / "t2s_model.safetensors"))
-        self.t2s = T2SMLX(str(d / "t2s_model.safetensors"))
+        self.t2s = T2SMLX(
+            str(d / "t2s_model.safetensors"),
+            group_size=config.quant_group_size,
+            bits=config.quant_bits,
+        )
         self.s2a = S2AEstimator(str(d / "s2a_mlx.safetensors"))
         self.voc = BigVGANMLX(str(d / "bigvgan_mlx.safetensors"))
         self.stats = np.load(str(d / "w2v_stats.npz"))

--- a/mlx_audio/tts/models/confucius4/convert.py
+++ b/mlx_audio/tts/models/confucius4/convert.py
@@ -8,7 +8,6 @@ torch is used ONLY here (conversion), never at inference.
 """
 import argparse
 import glob
-import re
 from pathlib import Path
 
 import numpy as np
@@ -37,6 +36,12 @@ def main():
 
     ap = argparse.ArgumentParser()
     ap.add_argument("--out", default="./confucius4-model")
+    ap.add_argument(
+        "--quantize",
+        choices=["none", "int8"],
+        default="none",
+        help="int8: 8-bit (group 64) the T2S body matmuls; semantic_head kept fp32",
+    )
     a = ap.parse_args()
     out = Path(a.out)
     out.mkdir(parents=True, exist_ok=True)
@@ -51,11 +56,32 @@ def main():
         )
         print("saved", name, len(d))
 
-    # T2S (F32 safetensors, mx-loadable as-is) -> copy
+    # T2S GPT-2 weights. With --quantize int8, 8-bit (group 64) the body
+    # matmuls (attn/mlp); keep semantic_head + norms + embeddings fp32 — this
+    # preserves token-selection fidelity (8-bit head audibly degrades it).
     t2s_pt = hf_hub_download(
         "netease-youdao/Confucius4-TTS", filename="t2s_model.safetensors"
     )
-    save("t2s_model.safetensors", safetensors.torch.load_file(t2s_pt))
+    if a.quantize == "int8":
+        Wt = mx.load(t2s_pt)
+        body = {
+            f"transformer.h.{i}.{n}.weight"
+            for i in range(24)
+            for n in ("attn.c_attn", "attn.c_proj", "mlp.c_fc", "mlp.c_proj")
+        }
+        qd = {}
+        for k, v in Wt.items():
+            if k in body:  # GPT-2 Conv1D [in,out] -> [out,in] for quantized_matmul
+                wq, sc, bs = mx.quantize(mx.transpose(v), group_size=64, bits=8)
+                qd[k] = wq
+                qd[k[:-7] + ".scales"] = sc
+                qd[k[:-7] + ".biases"] = bs
+            else:
+                qd[k] = v
+        mx.save_safetensors(str(out / "t2s_model.safetensors"), qd)
+        print(f"saved t2s_model.safetensors (int8 body: {len(body)} matmuls)")
+    else:
+        save("t2s_model.safetensors", safetensors.torch.load_file(t2s_pt))
 
     # S2A (.pt, fold weight_norm)
     s2a_pt = hf_hub_download("netease-youdao/Confucius4-TTS", filename="s2a_model.pt")
@@ -110,7 +136,7 @@ def main():
     print("saved w2v_stats.npz")
 
     # CAMPPlus: sanitize via mlx-audio's CAMPPlus then save (no torch at inference)
-    from mlx.utils import tree_flatten, tree_unflatten
+    from mlx.utils import tree_unflatten
 
     from mlx_audio.tts.models.chatterbox.s3gen.xvector import CAMPPlus
 
@@ -146,6 +172,17 @@ def main():
         window=win.astype(np.float32),
     )
     print("saved fbank_filters.npz")
+
+    # tokenizer (loaded torch-free at runtime via tokenizers.Tokenizer.from_file)
+    import shutil
+
+    ck = out / "checkpoints"
+    ck.mkdir(exist_ok=True)
+    tok_json = hf_hub_download(
+        "netease-youdao/Confucius4-TTS", filename="tokenizer.json"
+    )
+    shutil.copy(tok_json, ck / "tokenizer.json")
+    print("saved checkpoints/tokenizer.json")
     print("DONE ->", out)
 
 

--- a/mlx_audio/tts/models/confucius4/convert.py
+++ b/mlx_audio/tts/models/confucius4/convert.py
@@ -112,7 +112,37 @@ def main():
         if k.startswith("feature_projection.")
         or (k.startswith("encoder.layers.") and int(k.split(".")[2]) <= 16)
     }
-    save("w2vbert_mlx.safetensors", keep)
+    if a.quantize != "none":
+        # quantize per-layer ffn + attn linears (feature_projection kept fp32:
+        # in=160 not divisible by group 64, and it is tiny anyway)
+        wlin = {
+            f"encoder.layers.{i}.{n}.weight"
+            for i in range(17)
+            for n in (
+                "ffn1.intermediate_dense",
+                "ffn1.output_dense",
+                "ffn2.intermediate_dense",
+                "ffn2.output_dense",
+                "self_attn.linear_q",
+                "self_attn.linear_k",
+                "self_attn.linear_v",
+                "self_attn.linear_out",
+            )
+        }
+        qd = {}
+        for k, v in keep.items():
+            arr = mx.array(v.detach().cpu().numpy().astype(np.float32))
+            if k in wlin:
+                wq, sc, bs = mx.quantize(arr, group_size=64, bits=qbits)
+                qd[k] = wq
+                qd[k[:-7] + ".scales"] = sc
+                qd[k[:-7] + ".biases"] = bs
+            else:
+                qd[k] = arr
+        mx.save_safetensors(str(out / "w2vbert_mlx.safetensors"), qd)
+        print(f"saved w2vbert_mlx.safetensors ({a.quantize} linears: {len(wlin)})")
+    else:
+        save("w2vbert_mlx.safetensors", keep)
 
     # w2v stats
     st = torch.load(

--- a/mlx_audio/tts/models/confucius4/convert.py
+++ b/mlx_audio/tts/models/confucius4/convert.py
@@ -30,70 +30,121 @@ def _fold_weight_norm(sd):
 
 
 def main():
-    import torch
     import mlx.core as mx
     import safetensors.torch
+    import torch
     from huggingface_hub import hf_hub_download
 
     ap = argparse.ArgumentParser()
     ap.add_argument("--out", default="./confucius4-model")
     a = ap.parse_args()
-    out = Path(a.out); out.mkdir(parents=True, exist_ok=True)
+    out = Path(a.out)
+    out.mkdir(parents=True, exist_ok=True)
 
     def save(name, d):
-        mx.save_safetensors(str(out / name),
-                            {k: mx.array(v.detach().cpu().numpy().astype(np.float32)) for k, v in d.items()})
+        mx.save_safetensors(
+            str(out / name),
+            {
+                k: mx.array(v.detach().cpu().numpy().astype(np.float32))
+                for k, v in d.items()
+            },
+        )
         print("saved", name, len(d))
 
     # T2S (F32 safetensors, mx-loadable as-is) -> copy
-    t2s_pt = hf_hub_download("netease-youdao/Confucius4-TTS", filename="t2s_model.safetensors")
+    t2s_pt = hf_hub_download(
+        "netease-youdao/Confucius4-TTS", filename="t2s_model.safetensors"
+    )
     save("t2s_model.safetensors", safetensors.torch.load_file(t2s_pt))
 
     # S2A (.pt, fold weight_norm)
     s2a_pt = hf_hub_download("netease-youdao/Confucius4-TTS", filename="s2a_model.pt")
     sd = torch.load(s2a_pt, map_location="cpu", weights_only=False)
-    save("s2a_mlx.safetensors", _fold_weight_norm(sd.state_dict() if hasattr(sd, "state_dict") else sd))
+    save(
+        "s2a_mlx.safetensors",
+        _fold_weight_norm(sd.state_dict() if hasattr(sd, "state_dict") else sd),
+    )
 
     # BigVGAN (fold weight_norm)
-    bv = torch.load(hf_hub_download("nvidia/bigvgan_v2_22khz_80band_256x", filename="bigvgan_generator.pt"),
-                    map_location="cpu", weights_only=False)
+    bv = torch.load(
+        hf_hub_download(
+            "nvidia/bigvgan_v2_22khz_80band_256x", filename="bigvgan_generator.pt"
+        ),
+        map_location="cpu",
+        weights_only=False,
+    )
     save("bigvgan_mlx.safetensors", _fold_weight_norm(bv.get("generator", bv)))
 
     # w2v-bert: feature_projection + layers 0..16 only
     from transformers import Wav2Vec2BertModel
+
     wsd = Wav2Vec2BertModel.from_pretrained("facebook/w2v-bert-2.0").eval().state_dict()
-    keep = {k: v for k, v in wsd.items()
-            if k.startswith("feature_projection.") or
-            (k.startswith("encoder.layers.") and int(k.split(".")[2]) <= 16)}
+    keep = {
+        k: v
+        for k, v in wsd.items()
+        if k.startswith("feature_projection.")
+        or (k.startswith("encoder.layers.") and int(k.split(".")[2]) <= 16)
+    }
     save("w2vbert_mlx.safetensors", keep)
 
     # w2v stats
-    st = torch.load(hf_hub_download("facebook/w2v-bert-2.0", filename="wav2vec2bert_stats.pt")
-                    if False else glob.glob(str(Path(t2s_pt).parent / "wav2vec2bert_stats.pt"))[0]
-                    if glob.glob(str(Path(t2s_pt).parent / "wav2vec2bert_stats.pt")) else
-                    hf_hub_download("netease-youdao/Confucius4-TTS", filename="wav2vec2bert_stats.pt"),
-                    map_location="cpu")
-    np.savez(str(out / "w2v_stats.npz"),
-             mean=st["mean"].numpy().astype(np.float32), std=torch.sqrt(st["var"]).numpy().astype(np.float32))
+    st = torch.load(
+        (
+            hf_hub_download("facebook/w2v-bert-2.0", filename="wav2vec2bert_stats.pt")
+            if False
+            else (
+                glob.glob(str(Path(t2s_pt).parent / "wav2vec2bert_stats.pt"))[0]
+                if glob.glob(str(Path(t2s_pt).parent / "wav2vec2bert_stats.pt"))
+                else hf_hub_download(
+                    "netease-youdao/Confucius4-TTS", filename="wav2vec2bert_stats.pt"
+                )
+            )
+        ),
+        map_location="cpu",
+    )
+    np.savez(
+        str(out / "w2v_stats.npz"),
+        mean=st["mean"].numpy().astype(np.float32),
+        std=torch.sqrt(st["var"]).numpy().astype(np.float32),
+    )
     print("saved w2v_stats.npz")
 
     # CAMPPlus: sanitize via mlx-audio's CAMPPlus then save (no torch at inference)
-    from mlx.utils import tree_unflatten, tree_flatten
+    from mlx.utils import tree_flatten, tree_unflatten
+
     from mlx_audio.tts.models.chatterbox.s3gen.xvector import CAMPPlus
+
     cm = CAMPPlus(feat_dim=80, embedding_size=192)
-    csd = torch.load(hf_hub_download("funasr/campplus", filename="campplus_cn_common.bin"), map_location="cpu")
+    csd = torch.load(
+        hf_hub_download("funasr/campplus", filename="campplus_cn_common.bin"),
+        map_location="cpu",
+    )
     csd = csd.get("state_dict", csd)
-    san = cm.sanitize({k: mx.array(v.float().numpy()) for k, v in csd.items() if torch.is_tensor(v)})
+    san = cm.sanitize(
+        {k: mx.array(v.float().numpy()) for k, v in csd.items() if torch.is_tensor(v)}
+    )
     mx.save_safetensors(str(out / "campplus.safetensors"), dict(san))
     print("saved campplus.safetensors", len(san))
 
     # precompute SeamlessM4T fbank mel matrix + povey window (torch-free at runtime)
     from transformers.audio_utils import mel_filter_bank, window_function
-    mel = mel_filter_bank(num_frequency_bins=257, num_mel_filters=80, min_frequency=20,
-                          max_frequency=8000, sampling_rate=16000, norm=None,
-                          mel_scale="kaldi", triangularize_in_mel_space=True)
+
+    mel = mel_filter_bank(
+        num_frequency_bins=257,
+        num_mel_filters=80,
+        min_frequency=20,
+        max_frequency=8000,
+        sampling_rate=16000,
+        norm=None,
+        mel_scale="kaldi",
+        triangularize_in_mel_space=True,
+    )
     win = window_function(400, "povey", periodic=False)
-    np.savez(str(out / "fbank_filters.npz"), mel=mel.astype(np.float32), window=win.astype(np.float32))
+    np.savez(
+        str(out / "fbank_filters.npz"),
+        mel=mel.astype(np.float32),
+        window=win.astype(np.float32),
+    )
     print("saved fbank_filters.npz")
     print("DONE ->", out)
 

--- a/mlx_audio/tts/models/confucius4/convert.py
+++ b/mlx_audio/tts/models/confucius4/convert.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
-# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
-# Licensed under the Apache License, Version 2.0.
+# Copyright © 2023-2024 Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 """Convert original Confucius4-TTS (+ deps) torch weights into an MLX model dir.
 torch is used ONLY here (conversion), never at inference.
 

--- a/mlx_audio/tts/models/confucius4/convert.py
+++ b/mlx_audio/tts/models/confucius4/convert.py
@@ -38,9 +38,9 @@ def main():
     ap.add_argument("--out", default="./confucius4-model")
     ap.add_argument(
         "--quantize",
-        choices=["none", "int8"],
+        choices=["none", "int8", "int4"],
         default="none",
-        help="int8: 8-bit (group 64) the T2S body matmuls; semantic_head kept fp32",
+        help="int8/int4: quantize (group 64) the T2S body matmuls; semantic_head kept fp32",
     )
     a = ap.parse_args()
     out = Path(a.out)
@@ -62,7 +62,8 @@ def main():
     t2s_pt = hf_hub_download(
         "netease-youdao/Confucius4-TTS", filename="t2s_model.safetensors"
     )
-    if a.quantize == "int8":
+    qbits = {"int8": 8, "int4": 4}.get(a.quantize, 8)
+    if a.quantize != "none":
         Wt = mx.load(t2s_pt)
         body = {
             f"transformer.h.{i}.{n}.weight"
@@ -72,14 +73,14 @@ def main():
         qd = {}
         for k, v in Wt.items():
             if k in body:  # GPT-2 Conv1D [in,out] -> [out,in] for quantized_matmul
-                wq, sc, bs = mx.quantize(mx.transpose(v), group_size=64, bits=8)
+                wq, sc, bs = mx.quantize(mx.transpose(v), group_size=64, bits=qbits)
                 qd[k] = wq
                 qd[k[:-7] + ".scales"] = sc
                 qd[k[:-7] + ".biases"] = bs
             else:
                 qd[k] = v
         mx.save_safetensors(str(out / "t2s_model.safetensors"), qd)
-        print(f"saved t2s_model.safetensors (int8 body: {len(body)} matmuls)")
+        print(f"saved t2s_model.safetensors ({a.quantize} body: {len(body)} matmuls)")
     else:
         save("t2s_model.safetensors", safetensors.torch.load_file(t2s_pt))
 
@@ -183,6 +184,21 @@ def main():
     )
     shutil.copy(tok_json, ck / "tokenizer.json")
     print("saved checkpoints/tokenizer.json")
+
+    import json
+
+    (out / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "confucius4",
+                "sample_rate": 22050,
+                "quant_bits": qbits,
+                "quant_group_size": 64,
+            },
+            indent=2,
+        )
+    )
+    print("saved config.json")
     print("DONE ->", out)
 
 

--- a/mlx_audio/tts/models/confucius4/convert.py
+++ b/mlx_audio/tts/models/confucius4/convert.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
+# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
+# Licensed under the Apache License, Version 2.0.
+"""Convert original Confucius4-TTS (+ deps) torch weights into an MLX model dir.
+torch is used ONLY here (conversion), never at inference.
+
+    python -m mlx_audio.tts.models.confucius4.convert --out ./confucius4-model
+"""
+import argparse
+import glob
+import re
+from pathlib import Path
+
+import numpy as np
+
+
+def _fold_weight_norm(sd):
+    folded, vg = {}, {}
+    for k, v in sd.items():
+        if k.endswith(".weight_v"):
+            vg.setdefault(k[:-9], {})["v"] = v
+        elif k.endswith(".weight_g"):
+            vg.setdefault(k[:-9], {})["g"] = v
+        else:
+            folded[k] = v
+    for base, d in vg.items():
+        g, v = d["g"].float(), d["v"].float()
+        folded[base + ".weight"] = g * v / v.flatten(1).norm(dim=1).view(-1, 1, 1)
+    return folded
+
+
+def main():
+    import torch
+    import mlx.core as mx
+    import safetensors.torch
+    from huggingface_hub import hf_hub_download
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="./confucius4-model")
+    a = ap.parse_args()
+    out = Path(a.out); out.mkdir(parents=True, exist_ok=True)
+
+    def save(name, d):
+        mx.save_safetensors(str(out / name),
+                            {k: mx.array(v.detach().cpu().numpy().astype(np.float32)) for k, v in d.items()})
+        print("saved", name, len(d))
+
+    # T2S (F32 safetensors, mx-loadable as-is) -> copy
+    t2s_pt = hf_hub_download("netease-youdao/Confucius4-TTS", filename="t2s_model.safetensors")
+    save("t2s_model.safetensors", safetensors.torch.load_file(t2s_pt))
+
+    # S2A (.pt, fold weight_norm)
+    s2a_pt = hf_hub_download("netease-youdao/Confucius4-TTS", filename="s2a_model.pt")
+    sd = torch.load(s2a_pt, map_location="cpu", weights_only=False)
+    save("s2a_mlx.safetensors", _fold_weight_norm(sd.state_dict() if hasattr(sd, "state_dict") else sd))
+
+    # BigVGAN (fold weight_norm)
+    bv = torch.load(hf_hub_download("nvidia/bigvgan_v2_22khz_80band_256x", filename="bigvgan_generator.pt"),
+                    map_location="cpu", weights_only=False)
+    save("bigvgan_mlx.safetensors", _fold_weight_norm(bv.get("generator", bv)))
+
+    # w2v-bert: feature_projection + layers 0..16 only
+    from transformers import Wav2Vec2BertModel
+    wsd = Wav2Vec2BertModel.from_pretrained("facebook/w2v-bert-2.0").eval().state_dict()
+    keep = {k: v for k, v in wsd.items()
+            if k.startswith("feature_projection.") or
+            (k.startswith("encoder.layers.") and int(k.split(".")[2]) <= 16)}
+    save("w2vbert_mlx.safetensors", keep)
+
+    # w2v stats
+    st = torch.load(hf_hub_download("facebook/w2v-bert-2.0", filename="wav2vec2bert_stats.pt")
+                    if False else glob.glob(str(Path(t2s_pt).parent / "wav2vec2bert_stats.pt"))[0]
+                    if glob.glob(str(Path(t2s_pt).parent / "wav2vec2bert_stats.pt")) else
+                    hf_hub_download("netease-youdao/Confucius4-TTS", filename="wav2vec2bert_stats.pt"),
+                    map_location="cpu")
+    np.savez(str(out / "w2v_stats.npz"),
+             mean=st["mean"].numpy().astype(np.float32), std=torch.sqrt(st["var"]).numpy().astype(np.float32))
+    print("saved w2v_stats.npz")
+
+    # CAMPPlus: sanitize via mlx-audio's CAMPPlus then save (no torch at inference)
+    from mlx.utils import tree_unflatten, tree_flatten
+    from mlx_audio.tts.models.chatterbox.s3gen.xvector import CAMPPlus
+    cm = CAMPPlus(feat_dim=80, embedding_size=192)
+    csd = torch.load(hf_hub_download("funasr/campplus", filename="campplus_cn_common.bin"), map_location="cpu")
+    csd = csd.get("state_dict", csd)
+    san = cm.sanitize({k: mx.array(v.float().numpy()) for k, v in csd.items() if torch.is_tensor(v)})
+    mx.save_safetensors(str(out / "campplus.safetensors"), dict(san))
+    print("saved campplus.safetensors", len(san))
+
+    # precompute SeamlessM4T fbank mel matrix + povey window (torch-free at runtime)
+    from transformers.audio_utils import mel_filter_bank, window_function
+    mel = mel_filter_bank(num_frequency_bins=257, num_mel_filters=80, min_frequency=20,
+                          max_frequency=8000, sampling_rate=16000, norm=None,
+                          mel_scale="kaldi", triangularize_in_mel_space=True)
+    win = window_function(400, "povey", periodic=False)
+    np.savez(str(out / "fbank_filters.npz"), mel=mel.astype(np.float32), window=win.astype(np.float32))
+    print("saved fbank_filters.npz")
+    print("DONE ->", out)
+
+
+if __name__ == "__main__":
+    main()

--- a/mlx_audio/tts/models/confucius4/features.py
+++ b/mlx_audio/tts/models/confucius4/features.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
+# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
+# Licensed under the Apache License, Version 2.0.
+"""Torch-free SeamlessM4T-style fbank (160-d) for the w2v-bert frontend.
+
+Reimplements transformers' SeamlessM4TFeatureExtractor in numpy: povey window,
+remove-dc + preemphasis 0.97 per frame, 80 kaldi-mel, log(mel_floor), per-mel-bin
+CMVN (ddof=1), stride-2 frame stacking. mel matrix + window are precomputed at
+convert time (fbank_filters.npz). Validated to ~1e-6 vs transformers.
+"""
+import numpy as np
+
+FRAME, HOP, NFFT, MEL_FLOOR = 400, 160, 512, 1.192092955078125e-07
+
+
+def fbank_160(audio: np.ndarray, mel_filters: np.ndarray, window: np.ndarray) -> np.ndarray:
+    """audio (T,) float 16kHz -> (1, num_frames//2, 160)."""
+    wav = audio.astype(np.float64) * (2 ** 15)
+    nfr = 1 + (len(wav) - FRAME) // HOP
+    melT = mel_filters.T
+    out = np.empty((nfr, 80), dtype=np.float64)
+    for i in range(nfr):
+        b = wav[i * HOP:i * HOP + FRAME].copy()
+        b = b - b.mean()                                   # remove_dc_offset
+        buf = np.zeros(NFFT)
+        buf[1:FRAME] = b[1:] - 0.97 * b[:-1]               # preemphasis
+        buf[0] = b[0] * 0.03
+        buf[:FRAME] *= window
+        spec = np.abs(np.fft.rfft(buf, NFFT)) ** 2
+        out[i] = np.log(np.maximum(MEL_FLOOR, melT @ spec))
+    out = (out - out.mean(0)) / np.sqrt(out.var(0, ddof=1) + 1e-7)   # per-bin CMVN
+    n = out.shape[0] - (out.shape[0] % 2)
+    return out[:n].reshape(n // 2, 160)[None].astype(np.float32)

--- a/mlx_audio/tts/models/confucius4/features.py
+++ b/mlx_audio/tts/models/confucius4/features.py
@@ -13,21 +13,23 @@ import numpy as np
 FRAME, HOP, NFFT, MEL_FLOOR = 400, 160, 512, 1.192092955078125e-07
 
 
-def fbank_160(audio: np.ndarray, mel_filters: np.ndarray, window: np.ndarray) -> np.ndarray:
+def fbank_160(
+    audio: np.ndarray, mel_filters: np.ndarray, window: np.ndarray
+) -> np.ndarray:
     """audio (T,) float 16kHz -> (1, num_frames//2, 160)."""
-    wav = audio.astype(np.float64) * (2 ** 15)
+    wav = audio.astype(np.float64) * (2**15)
     nfr = 1 + (len(wav) - FRAME) // HOP
     melT = mel_filters.T
     out = np.empty((nfr, 80), dtype=np.float64)
     for i in range(nfr):
-        b = wav[i * HOP:i * HOP + FRAME].copy()
-        b = b - b.mean()                                   # remove_dc_offset
+        b = wav[i * HOP : i * HOP + FRAME].copy()
+        b = b - b.mean()  # remove_dc_offset
         buf = np.zeros(NFFT)
-        buf[1:FRAME] = b[1:] - 0.97 * b[:-1]               # preemphasis
+        buf[1:FRAME] = b[1:] - 0.97 * b[:-1]  # preemphasis
         buf[0] = b[0] * 0.03
         buf[:FRAME] *= window
         spec = np.abs(np.fft.rfft(buf, NFFT)) ** 2
         out[i] = np.log(np.maximum(MEL_FLOOR, melT @ spec))
-    out = (out - out.mean(0)) / np.sqrt(out.var(0, ddof=1) + 1e-7)   # per-bin CMVN
+    out = (out - out.mean(0)) / np.sqrt(out.var(0, ddof=1) + 1e-7)  # per-bin CMVN
     n = out.shape[0] - (out.shape[0] % 2)
     return out[:n].reshape(n // 2, 160)[None].astype(np.float32)

--- a/mlx_audio/tts/models/confucius4/features.py
+++ b/mlx_audio/tts/models/confucius4/features.py
@@ -1,35 +1,41 @@
-# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
-# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
-# Licensed under the Apache License, Version 2.0.
-"""Torch-free SeamlessM4T-style fbank (160-d) for the w2v-bert frontend.
+# Copyright © 2023-2024 Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
+"""SeamlessM4T-style fbank (160-d) for the w2v-bert frontend, in MLX.
 
-Reimplements transformers' SeamlessM4TFeatureExtractor in numpy: povey window,
-remove-dc + preemphasis 0.97 per frame, 80 kaldi-mel, log(mel_floor), per-mel-bin
-CMVN (ddof=1), stride-2 frame stacking. mel matrix + window are precomputed at
-convert time (fbank_filters.npz). Validated to ~1e-6 vs transformers.
+Reimplements transformers' SeamlessM4TFeatureExtractor: povey window, remove-dc
++ preemphasis 0.97 per frame, 80 kaldi-mel, log(mel_floor), per-mel-bin CMVN
+(ddof=1), stride-2 frame stacking. The mel matrix + window are precomputed at
+convert time (fbank_filters.npz). Validated to ~1e-6 vs transformers; the MLX
+path matches that reference to float32 precision.
 """
-import numpy as np
+import mlx.core as mx
 
 FRAME, HOP, NFFT, MEL_FLOOR = 400, 160, 512, 1.192092955078125e-07
 
 
-def fbank_160(
-    audio: np.ndarray, mel_filters: np.ndarray, window: np.ndarray
-) -> np.ndarray:
-    """audio (T,) float 16kHz -> (1, num_frames//2, 160)."""
-    wav = audio.astype(np.float64) * (2**15)
-    nfr = 1 + (len(wav) - FRAME) // HOP
-    melT = mel_filters.T
-    out = np.empty((nfr, 80), dtype=np.float64)
-    for i in range(nfr):
-        b = wav[i * HOP : i * HOP + FRAME].copy()
-        b = b - b.mean()  # remove_dc_offset
-        buf = np.zeros(NFFT)
-        buf[1:FRAME] = b[1:] - 0.97 * b[:-1]  # preemphasis
-        buf[0] = b[0] * 0.03
-        buf[:FRAME] *= window
-        spec = np.abs(np.fft.rfft(buf, NFFT)) ** 2
-        out[i] = np.log(np.maximum(MEL_FLOOR, melT @ spec))
-    out = (out - out.mean(0)) / np.sqrt(out.var(0, ddof=1) + 1e-7)  # per-bin CMVN
-    n = out.shape[0] - (out.shape[0] % 2)
-    return out[:n].reshape(n // 2, 160)[None].astype(np.float32)
+def fbank_160(audio: mx.array, mel_filters: mx.array, window: mx.array) -> mx.array:
+    """audio (T,) 16 kHz -> (1, num_frames // 2, 160), all MLX."""
+    wav = audio.astype(mx.float32) * (2**15)
+    nfr = 1 + (wav.shape[0] - FRAME) // HOP
+
+    # frame the signal into (nfr, FRAME) via a strided gather
+    idx = mx.arange(nfr)[:, None] * HOP + mx.arange(FRAME)[None, :]
+    frames = mx.take(wav, idx, axis=0)
+    frames = frames - frames.mean(axis=1, keepdims=True)  # remove_dc_offset
+
+    # preemphasis: buf[0] = b[0] * 0.03 ; buf[1:] = b[1:] - 0.97 * b[:-1]
+    emph = mx.concatenate(
+        [frames[:, :1] * 0.03, frames[:, 1:] - 0.97 * frames[:, :-1]], axis=1
+    )
+    emph = emph * window  # povey window (FRAME,)
+    buf = mx.concatenate([emph, mx.zeros((nfr, NFFT - FRAME))], axis=1)
+
+    spec = mx.abs(mx.fft.rfft(buf, n=NFFT, axis=1)) ** 2  # (nfr, NFFT // 2 + 1)
+    out = mx.log(mx.maximum(MEL_FLOOR, spec @ mel_filters))  # (nfr, 80)
+
+    # per-mel-bin CMVN (unbiased variance, ddof=1)
+    mean = out.mean(axis=0, keepdims=True)
+    var = ((out - mean) ** 2).sum(axis=0, keepdims=True) / (nfr - 1)
+    out = (out - mean) / mx.sqrt(var + 1e-7)
+
+    n = nfr - (nfr % 2)
+    return out[:n].reshape(1, n // 2, 160)

--- a/mlx_audio/tts/models/confucius4/prefix.py
+++ b/mlx_audio/tts/models/confucius4/prefix.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
-# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
-# Licensed under the Apache License, Version 2.0.
+# Copyright © 2023-2024 Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 
 """T2S prefix encoders in MLX: text_projector + ECAPA-TDNN speaker_encoder.
 

--- a/mlx_audio/tts/models/confucius4/prefix.py
+++ b/mlx_audio/tts/models/confucius4/prefix.py
@@ -9,6 +9,7 @@ so the T2S decode no longer needs the torch prefix. Weights read from
 t2s_model.safetensors (text_projector.*, speaker_encoder.*, text_position_embedding.*).
 """
 import mlx.core as mx
+
 from .t2s import find_ckpt
 
 EPS = 1e-12
@@ -32,8 +33,8 @@ def reflect_pad(x, p):
     if p == 0:
         return x
     T = x.shape[1]
-    li = p - mx.arange(p)                      # [p, p-1, ..., 1]
-    ri = (T - 2) - mx.arange(p)                # [T-2, T-3, ..., T-1-p]
+    li = p - mx.arange(p)  # [p, p-1, ..., 1]
+    ri = (T - 2) - mx.arange(p)  # [T-2, T-3, ..., T-1-p]
     left = mx.take(x, li, axis=1)
     right = mx.take(x, ri, axis=1)
     return mx.concatenate([left, x, right], axis=1)
@@ -57,15 +58,32 @@ class T2SPrefixMLX:
 
     # ---------- text path ----------
     def text_emb(self, token_ids):
-        e = self.g("text_projector.embed.weight")[token_ids]              # (1,T,4096)
-        e = silu(lin(e, self.g("text_projector.text_projection_fc1.weight"), self.g("text_projector.text_projection_fc1.bias")))
-        e = lin(e, self.g("text_projector.text_projection_fc2.weight"), self.g("text_projector.text_projection_fc2.bias"))  # (1,T,1280)
+        e = self.g("text_projector.embed.weight")[token_ids]  # (1,T,4096)
+        e = silu(
+            lin(
+                e,
+                self.g("text_projector.text_projection_fc1.weight"),
+                self.g("text_projector.text_projection_fc1.bias"),
+            )
+        )
+        e = lin(
+            e,
+            self.g("text_projector.text_projection_fc2.weight"),
+            self.g("text_projector.text_projection_fc2.bias"),
+        )  # (1,T,1280)
         T = token_ids.shape[1]
         return e + self.g("text_position_embedding.embedding.weight")[:T][None]
 
     # ---------- ECAPA speaker encoder ----------
     def _tdnn(self, x, p, dilation=1):
-        return relu(conv_same(x, self.g(p + ".conv.weight"), self.g(p + ".conv.bias"), dilation=dilation))
+        return relu(
+            conv_same(
+                x,
+                self.g(p + ".conv.weight"),
+                self.g(p + ".conv.bias"),
+                dilation=dilation,
+            )
+        )
 
     def _res2net(self, x, p, dilation, scale=8):
         chunks = mx.split(x, scale, axis=2)
@@ -83,9 +101,11 @@ class T2SPrefixMLX:
         return mx.concatenate(outs, axis=2)
 
     def _se(self, x, p):
-        s = x.mean(axis=1, keepdims=True)                                 # (B,1,C)
+        s = x.mean(axis=1, keepdims=True)  # (B,1,C)
         s = relu(conv_same(s, self.g(p + ".conv1.weight"), self.g(p + ".conv1.bias")))
-        s = mx.sigmoid(conv_same(s, self.g(p + ".conv2.weight"), self.g(p + ".conv2.bias")))
+        s = mx.sigmoid(
+            conv_same(s, self.g(p + ".conv2.weight"), self.g(p + ".conv2.bias"))
+        )
         return x * s
 
     def _se_res2net(self, x, p, dilation):
@@ -97,7 +117,7 @@ class T2SPrefixMLX:
         return h + residual
 
     def _stats(self, x, w):
-        mean = (w * x).sum(axis=1)                                        # (B,C)
+        mean = (w * x).sum(axis=1)  # (B,C)
         std = mx.sqrt(mx.maximum((w * (x - mean[:, None]) ** 2).sum(axis=1), EPS))
         return mean, std
 
@@ -105,14 +125,24 @@ class T2SPrefixMLX:
         B, T, C = x.shape
         m = mx.full((B, T, 1), 1.0 / T)
         mean, std = self._stats(x, m)
-        att_in = mx.concatenate([x, mx.broadcast_to(mean[:, None], (B, T, C)),
-                                 mx.broadcast_to(std[:, None], (B, T, C))], axis=2)
+        att_in = mx.concatenate(
+            [
+                x,
+                mx.broadcast_to(mean[:, None], (B, T, C)),
+                mx.broadcast_to(std[:, None], (B, T, C)),
+            ],
+            axis=2,
+        )
         h = self._tdnn(att_in, "speaker_encoder.asp.tdnn")
         h = mx.tanh(h)
-        h = conv_same(h, self.g("speaker_encoder.asp.conv.weight"), self.g("speaker_encoder.asp.conv.bias"))
+        h = conv_same(
+            h,
+            self.g("speaker_encoder.asp.conv.weight"),
+            self.g("speaker_encoder.asp.conv.bias"),
+        )
         att = mx.softmax(h, axis=1)
         mean, std = self._stats(x, att)
-        return mx.concatenate([mean, std], axis=1)[:, None]               # (B,1,2C)
+        return mx.concatenate([mean, std], axis=1)[:, None]  # (B,1,2C)
 
     def cond_emb(self, cond_vec):
         """cond_vec (1,Tf,1024) -> (1,1,1280)."""
@@ -125,5 +155,7 @@ class T2SPrefixMLX:
         x = mx.concatenate(feats, axis=2)
         x = self._tdnn(x, "speaker_encoder.mfa")
         x = self._asp(x)
-        x = conv_same(x, self.g("speaker_encoder.fc.weight"), self.g("speaker_encoder.fc.bias"))
-        return x                                                          # (1,1,1280)
+        x = conv_same(
+            x, self.g("speaker_encoder.fc.weight"), self.g("speaker_encoder.fc.bias")
+        )
+        return x  # (1,1,1280)

--- a/mlx_audio/tts/models/confucius4/prefix.py
+++ b/mlx_audio/tts/models/confucius4/prefix.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
+# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
+# Licensed under the Apache License, Version 2.0.
+
+"""T2S prefix encoders in MLX: text_projector + ECAPA-TDNN speaker_encoder.
+
+Produces the [condition_emb | text_emb] prefix from (w2v condition_vector, token_ids),
+so the T2S decode no longer needs the torch prefix. Weights read from
+t2s_model.safetensors (text_projector.*, speaker_encoder.*, text_position_embedding.*).
+"""
+import mlx.core as mx
+from .t2s import find_ckpt
+
+EPS = 1e-12
+
+
+def lin(x, W, b=None):
+    y = x @ W.T
+    return y + b if b is not None else y
+
+
+def relu(x):
+    return mx.maximum(x, 0)
+
+
+def silu(x):
+    return x * mx.sigmoid(x)
+
+
+def reflect_pad(x, p):
+    """reflect pad along time axis=1 of (B,T,C), matching torch 'reflect'."""
+    if p == 0:
+        return x
+    T = x.shape[1]
+    li = p - mx.arange(p)                      # [p, p-1, ..., 1]
+    ri = (T - 2) - mx.arange(p)                # [T-2, T-3, ..., T-1-p]
+    left = mx.take(x, li, axis=1)
+    right = mx.take(x, ri, axis=1)
+    return mx.concatenate([left, x, right], axis=1)
+
+
+def conv_same(x, W, b, dilation=1, groups=1):
+    """conv1d 'same' padding (reflect). x (B,T,Cin); W torch (Cout,Cin,k)."""
+    k = W.shape[2]
+    p = dilation * (k - 1) // 2
+    xp = reflect_pad(x, p)
+    w = mx.transpose(W, (0, 2, 1))
+    return mx.conv1d(xp, w, stride=1, padding=0, dilation=dilation, groups=groups) + b
+
+
+class T2SPrefixMLX:
+    def __init__(self, ckpt=None):
+        self.W = mx.load(ckpt or find_ckpt())
+
+    def g(self, k):
+        return self.W[k]
+
+    # ---------- text path ----------
+    def text_emb(self, token_ids):
+        e = self.g("text_projector.embed.weight")[token_ids]              # (1,T,4096)
+        e = silu(lin(e, self.g("text_projector.text_projection_fc1.weight"), self.g("text_projector.text_projection_fc1.bias")))
+        e = lin(e, self.g("text_projector.text_projection_fc2.weight"), self.g("text_projector.text_projection_fc2.bias"))  # (1,T,1280)
+        T = token_ids.shape[1]
+        return e + self.g("text_position_embedding.embedding.weight")[:T][None]
+
+    # ---------- ECAPA speaker encoder ----------
+    def _tdnn(self, x, p, dilation=1):
+        return relu(conv_same(x, self.g(p + ".conv.weight"), self.g(p + ".conv.bias"), dilation=dilation))
+
+    def _res2net(self, x, p, dilation, scale=8):
+        chunks = mx.split(x, scale, axis=2)
+        outs = []
+        prev = None
+        for i in range(scale):
+            if i == 0:
+                o = chunks[0]
+            elif i == 1:
+                o = self._tdnn(chunks[1], f"{p}.blocks.0", dilation=dilation)
+            else:
+                o = self._tdnn(chunks[i] + prev, f"{p}.blocks.{i-1}", dilation=dilation)
+            outs.append(o)
+            prev = o
+        return mx.concatenate(outs, axis=2)
+
+    def _se(self, x, p):
+        s = x.mean(axis=1, keepdims=True)                                 # (B,1,C)
+        s = relu(conv_same(s, self.g(p + ".conv1.weight"), self.g(p + ".conv1.bias")))
+        s = mx.sigmoid(conv_same(s, self.g(p + ".conv2.weight"), self.g(p + ".conv2.bias")))
+        return x * s
+
+    def _se_res2net(self, x, p, dilation):
+        residual = x
+        h = self._tdnn(x, p + ".tdnn1")
+        h = self._res2net(h, p + ".res2net_block", dilation=dilation)
+        h = self._tdnn(h, p + ".tdnn2")
+        h = self._se(h, p + ".se_block")
+        return h + residual
+
+    def _stats(self, x, w):
+        mean = (w * x).sum(axis=1)                                        # (B,C)
+        std = mx.sqrt(mx.maximum((w * (x - mean[:, None]) ** 2).sum(axis=1), EPS))
+        return mean, std
+
+    def _asp(self, x):
+        B, T, C = x.shape
+        m = mx.full((B, T, 1), 1.0 / T)
+        mean, std = self._stats(x, m)
+        att_in = mx.concatenate([x, mx.broadcast_to(mean[:, None], (B, T, C)),
+                                 mx.broadcast_to(std[:, None], (B, T, C))], axis=2)
+        h = self._tdnn(att_in, "speaker_encoder.asp.tdnn")
+        h = mx.tanh(h)
+        h = conv_same(h, self.g("speaker_encoder.asp.conv.weight"), self.g("speaker_encoder.asp.conv.bias"))
+        att = mx.softmax(h, axis=1)
+        mean, std = self._stats(x, att)
+        return mx.concatenate([mean, std], axis=1)[:, None]               # (B,1,2C)
+
+    def cond_emb(self, cond_vec):
+        """cond_vec (1,Tf,1024) -> (1,1,1280)."""
+        x = cond_vec
+        x = self._tdnn(x, "speaker_encoder.blocks.0", dilation=1)
+        feats = []
+        for i in range(1, 4):
+            x = self._se_res2net(x, f"speaker_encoder.blocks.{i}", dilation=i + 1)
+            feats.append(x)
+        x = mx.concatenate(feats, axis=2)
+        x = self._tdnn(x, "speaker_encoder.mfa")
+        x = self._asp(x)
+        x = conv_same(x, self.g("speaker_encoder.fc.weight"), self.g("speaker_encoder.fc.bias"))
+        return x                                                          # (1,1,1280)

--- a/mlx_audio/tts/models/confucius4/s2a.py
+++ b/mlx_audio/tts/models/confucius4/s2a.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
+# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
+# Licensed under the Apache License, Version 2.0.
+
+"""S2A flow-matching estimator (DiT + WaveNet) ported to MLX.
+
+Validate-driven: phan DiT estimator truoc (RoPE interleaved fp32, adaLN/RMSNorm,
+SwiGLU, U-Net skip, WaveNet gated). Weights: b2/s2a_mlx.safetensors (weight_norm
+da fold, layout torch giu nguyen: Linear (out,in), Conv1d (out,in,k)).
+"""
+import math
+import os
+import mlx.core as mx
+
+HID, NH, HD, DEPTH = 512, 8, 64, 13
+ST = os.path.join(os.path.dirname(__file__), "..", "weights", "s2a_mlx.safetensors")
+
+
+def lin(x, W, b=None):
+    y = x @ W.T
+    return y + b if b is not None else y
+
+
+def conv1d(x_btc, W_oik, b=None, pad=0, dilation=1):
+    """x_btc (B,T,Cin); W_oik torch layout (Cout,Cin,k) -> (B,T,Cout)."""
+    w = mx.transpose(W_oik, (0, 2, 1))                 # (Cout,k,Cin) for mx
+    y = mx.conv1d(x_btc, w, stride=1, padding=pad, dilation=dilation)
+    return y + b if b is not None else y
+
+
+def rms_norm(x, w, eps=1e-5):
+    return x * mx.rsqrt((x * x).mean(-1, keepdims=True) + eps) * w
+
+
+def silu(x):
+    return x * mx.sigmoid(x)
+
+
+def mish(x):
+    return x * mx.tanh(mx.logaddexp(x, mx.zeros_like(x)))   # x*tanh(softplus(x))
+
+
+class S2AEstimator:
+    def __init__(self, st=ST):
+        self.W = mx.load(st)
+        self.freqs = self.W["decoder.estimator.freqs_cis"]   # (4096,32,2)
+
+    def g(self, name):
+        return self.W["decoder.estimator." + name]
+
+    # ---- timestep embedding ----
+    def _t_embed(self, t, prefix):
+        half = 128
+        emb = mx.exp(mx.arange(half) * (-math.log(10000) / half))
+        emb = 1000.0 * t[:, None] * emb[None]              # (B,256/2)
+        emb = mx.concatenate([mx.cos(emb), mx.sin(emb)], axis=-1)   # (B,256)
+        emb = silu(lin(emb, self.g(prefix + ".time_mlp.0.weight"), self.g(prefix + ".time_mlp.0.bias")))
+        return lin(emb, self.g(prefix + ".time_mlp.2.weight"), self.g(prefix + ".time_mlp.2.bias"))
+
+    def _rope(self, x):
+        # x (B,T,nh,hd) interleaved pairs
+        B, T, nh, hd = x.shape
+        xs = x.reshape(B, T, nh, hd // 2, 2)
+        c = self.freqs[:T, :, 0].reshape(1, T, 1, hd // 2)
+        s = self.freqs[:T, :, 1].reshape(1, T, 1, hd // 2)
+        xr, xi = xs[..., 0], xs[..., 1]
+        o0 = xr * c - xi * s
+        o1 = xi * c + xr * s
+        return mx.stack([o0, o1], axis=-1).reshape(B, T, nh, hd)
+
+    def _adaln(self, x, cond, prefix):
+        mod = lin(cond, self.g(prefix + ".modulation.weight"), self.g(prefix + ".modulation.bias"))
+        w, b = mx.split(mod, 2, axis=-1)
+        xn = rms_norm(x, self.g(prefix + ".norm.weight"))
+        return xn * w[:, None] + b[:, None]
+
+    def _attn(self, x, prefix):
+        B, T, _ = x.shape
+        qkv = lin(x, self.g(prefix + ".wqkv.weight"))
+        q, k, v = mx.split(qkv, 3, axis=-1)
+        q = self._rope(q.reshape(B, T, NH, HD))
+        k = self._rope(k.reshape(B, T, NH, HD))
+        v = v.reshape(B, T, NH, HD)
+        q = q.transpose(0, 2, 1, 3); k = k.transpose(0, 2, 1, 3); v = v.transpose(0, 2, 1, 3)
+        sc = (q @ k.transpose(0, 1, 3, 2)) * (1.0 / math.sqrt(HD))
+        a = mx.softmax(sc, axis=-1) @ v
+        a = a.transpose(0, 2, 1, 3).reshape(B, T, HID)
+        return lin(a, self.g(prefix + ".wo.weight"))
+
+    def _ff(self, x, prefix):
+        return lin(silu(lin(x, self.g(prefix + ".w1.weight"))) * lin(x, self.g(prefix + ".w3.weight")),
+                   self.g(prefix + ".w2.weight"))
+
+    def _block(self, h, cond, idx, skip_in):
+        p = f"transformer_blocks.{idx}."
+        if skip_in is not None:
+            h = lin(mx.concatenate([h, skip_in], axis=-1),
+                    self.g(p + "skip_in_linear.weight"), self.g(p + "skip_in_linear.bias"))
+        h = h + self._attn(self._adaln(h, cond, p + "attention_norm"), p + "attention")
+        h = h + self._ff(self._adaln(h, cond, p + "ffn_norm"), p + "feed_forward")
+        return h
+
+    def _wavenet(self, x_bct, g_b1):
+        # x_bct (B,512,T) torch layout; work in (B,T,512)
+        x = x_bct.transpose(0, 2, 1)                       # (B,T,512)
+        gp = self.g("wavenet.cond_layer.conv.weight")      # (8192,512,1)
+        gcond = conv1d(g_b1.transpose(0, 2, 1), gp, self.g("wavenet.cond_layer.conv.bias"))  # (B,1,8192)
+        out = mx.zeros_like(x)
+        n = 8
+        for i in range(n):
+            xin = conv1d(x, self.g(f"wavenet.in_layers.{i}.conv.weight"),
+                         self.g(f"wavenet.in_layers.{i}.conv.bias"), pad=2)   # k5 dil1 pad2 -> (B,T,1024)
+            gl = gcond[:, :, i * 1024:(i + 1) * 1024]                          # (B,1,1024)
+            ina = xin + gl
+            acts = mx.tanh(ina[..., :512]) * mx.sigmoid(ina[..., 512:])        # (B,T,512)
+            rs = conv1d(acts, self.g(f"wavenet.res_skip_layers.{i}.conv.weight"),
+                        self.g(f"wavenet.res_skip_layers.{i}.conv.bias"))      # k1
+            if i < n - 1:
+                x = x + rs[..., :512]
+                out = out + rs[..., 512:]
+            else:
+                out = out + rs
+        return out.transpose(0, 2, 1)                      # (B,512,T)
+
+    def _final_layer(self, x, c):
+        mod = lin(silu(c), self.g("final_layer.adaLN_modulation.1.weight"),
+                  self.g("final_layer.adaLN_modulation.1.bias"))
+        shift, scale = mx.split(mod, 2, axis=-1)
+        mu = x.mean(-1, keepdims=True)
+        var = ((x - mu) ** 2).mean(-1, keepdims=True)
+        xn = (x - mu) * mx.rsqrt(var + 1e-6)               # LayerNorm no affine
+        x = xn * (1.0 + scale[:, None]) + shift[:, None]
+        return lin(x, self.g("final_layer.linear.weight"), self.g("final_layer.linear.bias"))
+
+    # ---- preamble: semantic tokens + lm_latent -> mu (cat_condition) ----
+    def _group_norm1(self, x, w, b, eps=1e-5):
+        # GroupNorm(1, C) on (B,T,C): normalize over (T,C) per sample, affine per channel
+        mu = x.mean(axis=(1, 2), keepdims=True)
+        var = ((x - mu) ** 2).mean(axis=(1, 2), keepdims=True)
+        return (x - mu) * mx.rsqrt(var + eps) * w + b
+
+    def build_mu(self, codes, latent, T_ref):
+        """codes int (1,T), latent (1,T,1280), T_ref int -> mu (1,T_ref+target,512)."""
+        W = self.W
+        T = codes.shape[1]
+        emb = W["input_embedding.embedding.weight"][codes]                    # (1,T,8)
+        sem = conv1d(emb, W["input_embedding.out_project.weight"],
+                     W["input_embedding.out_project.bias"])                   # (1,T,1024)
+        text_cond = lin(mx.concatenate([latent, sem], axis=-1),
+                        W["encoder_proj.weight"], W["encoder_proj.bias"])      # (1,T,1024)
+        # length regulator
+        x = lin(text_cond, W["length_regulator.content_in_proj.weight"],
+                W["length_regulator.content_in_proj.bias"])                   # (1,T,512)
+        out_len = int(T * 1.72)
+        idx = mx.minimum((mx.arange(out_len) * (T / out_len)).astype(mx.int32), T - 1)
+        x = x[:, idx, :]                                                      # nearest interp (1,out_len,512)
+        for ci, gi in [(0, 1), (3, 4), (6, 7), (9, 10)]:
+            x = conv1d(x, W[f"length_regulator.model.{ci}.weight"],
+                       W[f"length_regulator.model.{ci}.bias"], pad=1)         # k3
+            x = self._group_norm1(x, W[f"length_regulator.model.{gi}.weight"],
+                                  W[f"length_regulator.model.{gi}.bias"])
+            x = mish(x)
+        cond_target = conv1d(x, W["length_regulator.model.12.weight"],
+                             W["length_regulator.model.12.bias"])             # k1 (1,out_len,512)
+        prompt_cond = mx.broadcast_to(W["prompt_cond"], (1, T_ref, 512))
+        return mx.concatenate([prompt_cond, cond_target], axis=1)            # (1,T_ref+out_len,512)
+
+    def solve_euler(self, z, prompt, mu, spks, t_span, cfg):
+        """z (1,80,Ttot), prompt (1,80,T_ref), mu (1,Ttot,512), spks (1,192).
+        Returns full mel (1,80,Ttot) via Euler ODE + CFG (mirrors torch)."""
+        Ttot = z.shape[-1]; T_ref = prompt.shape[-1]
+        zeros_tail = mx.zeros((1, 80, Ttot - T_ref))
+        prompt_x = mx.concatenate([prompt, zeros_tail], axis=-1)              # (1,80,Ttot)
+        x = mx.concatenate([mx.zeros((1, 80, T_ref)), z[..., T_ref:]], axis=-1)
+        z80 = mx.zeros_like(x); zmu = mx.zeros_like(mu); zspk = mx.zeros_like(spks)
+        t = float(t_span[0]); dt = float(t_span[1] - t_span[0])
+        for step in range(1, t_span.shape[0]):
+            x_in = mx.concatenate([x, x], axis=0)
+            px_in = mx.concatenate([prompt_x, z80], axis=0)
+            mu_in = mx.concatenate([mu, zmu], axis=0)
+            spk_in = mx.concatenate([spks, zspk], axis=0)
+            t_in = mx.array([t, t])
+            dphi = self.forward(x_in, mu_in, t_in, spk_in, px_in)             # (2,80,Ttot)
+            cond_d, uncond_d = dphi[:1], dphi[1:]
+            d = (1.0 + cfg) * cond_d - cfg * uncond_d
+            x = x + dt * d
+            t = t + dt
+            if step < t_span.shape[0] - 1:
+                dt = float(t_span[step + 1] - t)
+            # torch re-zeros prompt region of x every step (line 189)
+            x = mx.concatenate([mx.zeros((1, 80, T_ref)), x[..., T_ref:]], axis=-1)
+            mx.eval(x)
+        return x
+
+    def forward(self, x_bct, mu, t, spks, cond_bct):
+        """x,cond (B,80,T); mu (B,T,512); t (B,); spks (B,192) -> (B,80,T)."""
+        B = x_bct.shape[0]
+        x = x_bct.transpose(0, 2, 1)                       # (B,T,80)
+        cond = cond_bct.transpose(0, 2, 1)
+        T = x.shape[1]
+        t1 = self._t_embed(t, "t_embedder")
+        # input embed
+        mu_proj = lin(mu, self.g("input_embed.mu_projection.weight"), self.g("input_embed.mu_projection.bias"))
+        spks_seq = mx.broadcast_to(spks[:, None, :], (B, T, spks.shape[-1]))
+        xin = mx.concatenate([x, cond, mu_proj, spks_seq], axis=-1)            # (B,T,864)
+        h = lin(xin, self.g("input_embed.proj.weight"), self.g("input_embed.proj.bias"))
+        # transformer with U-Net skip
+        emit = set(range(DEPTH // 2)); recv = set(i for i in range(DEPTH) if i > DEPTH // 2)
+        stack = []
+        for idx in range(DEPTH):
+            skip_in = stack.pop() if (idx in recv and stack) else None
+            h = self._block(h, t1, idx, skip_in)
+            if idx in emit:
+                stack.append(h)
+        x_res = self._adaln(h, t1, "transformer_norm")
+        x_res = lin(mx.concatenate([x_res, x], axis=-1),
+                    self.g("skip_linear.weight"), self.g("skip_linear.bias"))
+        # wavenet final
+        x_out = lin(x_res, self.g("conv1.weight"), self.g("conv1.bias")).transpose(0, 2, 1)  # (B,512,T)
+        t2 = self._t_embed(t, "t_embedder2")
+        x_out = self._wavenet(x_out, t2[:, :, None])
+        x_out = x_out.transpose(0, 2, 1) + lin(x_res, self.g("res_projection.weight"), self.g("res_projection.bias"))
+        x_out = self._final_layer(x_out, t1).transpose(0, 2, 1)               # (B,512,T)
+        x_out = conv1d(x_out.transpose(0, 2, 1), self.g("conv2.weight"), self.g("conv2.bias")).transpose(0, 2, 1)
+        return x_out                                                          # (B,80,T)

--- a/mlx_audio/tts/models/confucius4/s2a.py
+++ b/mlx_audio/tts/models/confucius4/s2a.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
-# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
-# Licensed under the Apache License, Version 2.0.
+# Copyright © 2023-2024 Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 
 """S2A flow-matching estimator (DiT + WaveNet) ported to MLX.
 

--- a/mlx_audio/tts/models/confucius4/s2a.py
+++ b/mlx_audio/tts/models/confucius4/s2a.py
@@ -10,6 +10,7 @@ da fold, layout torch giu nguyen: Linear (out,in), Conv1d (out,in,k)).
 """
 import math
 import os
+
 import mlx.core as mx
 
 HID, NH, HD, DEPTH = 512, 8, 64, 13
@@ -23,7 +24,7 @@ def lin(x, W, b=None):
 
 def conv1d(x_btc, W_oik, b=None, pad=0, dilation=1):
     """x_btc (B,T,Cin); W_oik torch layout (Cout,Cin,k) -> (B,T,Cout)."""
-    w = mx.transpose(W_oik, (0, 2, 1))                 # (Cout,k,Cin) for mx
+    w = mx.transpose(W_oik, (0, 2, 1))  # (Cout,k,Cin) for mx
     y = mx.conv1d(x_btc, w, stride=1, padding=pad, dilation=dilation)
     return y + b if b is not None else y
 
@@ -37,13 +38,13 @@ def silu(x):
 
 
 def mish(x):
-    return x * mx.tanh(mx.logaddexp(x, mx.zeros_like(x)))   # x*tanh(softplus(x))
+    return x * mx.tanh(mx.logaddexp(x, mx.zeros_like(x)))  # x*tanh(softplus(x))
 
 
 class S2AEstimator:
     def __init__(self, st=ST):
         self.W = mx.load(st)
-        self.freqs = self.W["decoder.estimator.freqs_cis"]   # (4096,32,2)
+        self.freqs = self.W["decoder.estimator.freqs_cis"]  # (4096,32,2)
 
     def g(self, name):
         return self.W["decoder.estimator." + name]
@@ -52,10 +53,20 @@ class S2AEstimator:
     def _t_embed(self, t, prefix):
         half = 128
         emb = mx.exp(mx.arange(half) * (-math.log(10000) / half))
-        emb = 1000.0 * t[:, None] * emb[None]              # (B,256/2)
-        emb = mx.concatenate([mx.cos(emb), mx.sin(emb)], axis=-1)   # (B,256)
-        emb = silu(lin(emb, self.g(prefix + ".time_mlp.0.weight"), self.g(prefix + ".time_mlp.0.bias")))
-        return lin(emb, self.g(prefix + ".time_mlp.2.weight"), self.g(prefix + ".time_mlp.2.bias"))
+        emb = 1000.0 * t[:, None] * emb[None]  # (B,256/2)
+        emb = mx.concatenate([mx.cos(emb), mx.sin(emb)], axis=-1)  # (B,256)
+        emb = silu(
+            lin(
+                emb,
+                self.g(prefix + ".time_mlp.0.weight"),
+                self.g(prefix + ".time_mlp.0.bias"),
+            )
+        )
+        return lin(
+            emb,
+            self.g(prefix + ".time_mlp.2.weight"),
+            self.g(prefix + ".time_mlp.2.bias"),
+        )
 
     def _rope(self, x):
         # x (B,T,nh,hd) interleaved pairs
@@ -69,7 +80,11 @@ class S2AEstimator:
         return mx.stack([o0, o1], axis=-1).reshape(B, T, nh, hd)
 
     def _adaln(self, x, cond, prefix):
-        mod = lin(cond, self.g(prefix + ".modulation.weight"), self.g(prefix + ".modulation.bias"))
+        mod = lin(
+            cond,
+            self.g(prefix + ".modulation.weight"),
+            self.g(prefix + ".modulation.bias"),
+        )
         w, b = mx.split(mod, 2, axis=-1)
         xn = rms_norm(x, self.g(prefix + ".norm.weight"))
         return xn * w[:, None] + b[:, None]
@@ -81,56 +96,78 @@ class S2AEstimator:
         q = self._rope(q.reshape(B, T, NH, HD))
         k = self._rope(k.reshape(B, T, NH, HD))
         v = v.reshape(B, T, NH, HD)
-        q = q.transpose(0, 2, 1, 3); k = k.transpose(0, 2, 1, 3); v = v.transpose(0, 2, 1, 3)
+        q = q.transpose(0, 2, 1, 3)
+        k = k.transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
         sc = (q @ k.transpose(0, 1, 3, 2)) * (1.0 / math.sqrt(HD))
         a = mx.softmax(sc, axis=-1) @ v
         a = a.transpose(0, 2, 1, 3).reshape(B, T, HID)
         return lin(a, self.g(prefix + ".wo.weight"))
 
     def _ff(self, x, prefix):
-        return lin(silu(lin(x, self.g(prefix + ".w1.weight"))) * lin(x, self.g(prefix + ".w3.weight")),
-                   self.g(prefix + ".w2.weight"))
+        return lin(
+            silu(lin(x, self.g(prefix + ".w1.weight")))
+            * lin(x, self.g(prefix + ".w3.weight")),
+            self.g(prefix + ".w2.weight"),
+        )
 
     def _block(self, h, cond, idx, skip_in):
         p = f"transformer_blocks.{idx}."
         if skip_in is not None:
-            h = lin(mx.concatenate([h, skip_in], axis=-1),
-                    self.g(p + "skip_in_linear.weight"), self.g(p + "skip_in_linear.bias"))
+            h = lin(
+                mx.concatenate([h, skip_in], axis=-1),
+                self.g(p + "skip_in_linear.weight"),
+                self.g(p + "skip_in_linear.bias"),
+            )
         h = h + self._attn(self._adaln(h, cond, p + "attention_norm"), p + "attention")
         h = h + self._ff(self._adaln(h, cond, p + "ffn_norm"), p + "feed_forward")
         return h
 
     def _wavenet(self, x_bct, g_b1):
         # x_bct (B,512,T) torch layout; work in (B,T,512)
-        x = x_bct.transpose(0, 2, 1)                       # (B,T,512)
-        gp = self.g("wavenet.cond_layer.conv.weight")      # (8192,512,1)
-        gcond = conv1d(g_b1.transpose(0, 2, 1), gp, self.g("wavenet.cond_layer.conv.bias"))  # (B,1,8192)
+        x = x_bct.transpose(0, 2, 1)  # (B,T,512)
+        gp = self.g("wavenet.cond_layer.conv.weight")  # (8192,512,1)
+        gcond = conv1d(
+            g_b1.transpose(0, 2, 1), gp, self.g("wavenet.cond_layer.conv.bias")
+        )  # (B,1,8192)
         out = mx.zeros_like(x)
         n = 8
         for i in range(n):
-            xin = conv1d(x, self.g(f"wavenet.in_layers.{i}.conv.weight"),
-                         self.g(f"wavenet.in_layers.{i}.conv.bias"), pad=2)   # k5 dil1 pad2 -> (B,T,1024)
-            gl = gcond[:, :, i * 1024:(i + 1) * 1024]                          # (B,1,1024)
+            xin = conv1d(
+                x,
+                self.g(f"wavenet.in_layers.{i}.conv.weight"),
+                self.g(f"wavenet.in_layers.{i}.conv.bias"),
+                pad=2,
+            )  # k5 dil1 pad2 -> (B,T,1024)
+            gl = gcond[:, :, i * 1024 : (i + 1) * 1024]  # (B,1,1024)
             ina = xin + gl
-            acts = mx.tanh(ina[..., :512]) * mx.sigmoid(ina[..., 512:])        # (B,T,512)
-            rs = conv1d(acts, self.g(f"wavenet.res_skip_layers.{i}.conv.weight"),
-                        self.g(f"wavenet.res_skip_layers.{i}.conv.bias"))      # k1
+            acts = mx.tanh(ina[..., :512]) * mx.sigmoid(ina[..., 512:])  # (B,T,512)
+            rs = conv1d(
+                acts,
+                self.g(f"wavenet.res_skip_layers.{i}.conv.weight"),
+                self.g(f"wavenet.res_skip_layers.{i}.conv.bias"),
+            )  # k1
             if i < n - 1:
                 x = x + rs[..., :512]
                 out = out + rs[..., 512:]
             else:
                 out = out + rs
-        return out.transpose(0, 2, 1)                      # (B,512,T)
+        return out.transpose(0, 2, 1)  # (B,512,T)
 
     def _final_layer(self, x, c):
-        mod = lin(silu(c), self.g("final_layer.adaLN_modulation.1.weight"),
-                  self.g("final_layer.adaLN_modulation.1.bias"))
+        mod = lin(
+            silu(c),
+            self.g("final_layer.adaLN_modulation.1.weight"),
+            self.g("final_layer.adaLN_modulation.1.bias"),
+        )
         shift, scale = mx.split(mod, 2, axis=-1)
         mu = x.mean(-1, keepdims=True)
         var = ((x - mu) ** 2).mean(-1, keepdims=True)
-        xn = (x - mu) * mx.rsqrt(var + 1e-6)               # LayerNorm no affine
+        xn = (x - mu) * mx.rsqrt(var + 1e-6)  # LayerNorm no affine
         x = xn * (1.0 + scale[:, None]) + shift[:, None]
-        return lin(x, self.g("final_layer.linear.weight"), self.g("final_layer.linear.bias"))
+        return lin(
+            x, self.g("final_layer.linear.weight"), self.g("final_layer.linear.bias")
+        )
 
     # ---- preamble: semantic tokens + lm_latent -> mu (cat_condition) ----
     def _group_norm1(self, x, w, b, eps=1e-5):
@@ -143,44 +180,69 @@ class S2AEstimator:
         """codes int (1,T), latent (1,T,1280), T_ref int -> mu (1,T_ref+target,512)."""
         W = self.W
         T = codes.shape[1]
-        emb = W["input_embedding.embedding.weight"][codes]                    # (1,T,8)
-        sem = conv1d(emb, W["input_embedding.out_project.weight"],
-                     W["input_embedding.out_project.bias"])                   # (1,T,1024)
-        text_cond = lin(mx.concatenate([latent, sem], axis=-1),
-                        W["encoder_proj.weight"], W["encoder_proj.bias"])      # (1,T,1024)
+        emb = W["input_embedding.embedding.weight"][codes]  # (1,T,8)
+        sem = conv1d(
+            emb,
+            W["input_embedding.out_project.weight"],
+            W["input_embedding.out_project.bias"],
+        )  # (1,T,1024)
+        text_cond = lin(
+            mx.concatenate([latent, sem], axis=-1),
+            W["encoder_proj.weight"],
+            W["encoder_proj.bias"],
+        )  # (1,T,1024)
         # length regulator
-        x = lin(text_cond, W["length_regulator.content_in_proj.weight"],
-                W["length_regulator.content_in_proj.bias"])                   # (1,T,512)
+        x = lin(
+            text_cond,
+            W["length_regulator.content_in_proj.weight"],
+            W["length_regulator.content_in_proj.bias"],
+        )  # (1,T,512)
         out_len = int(T * 1.72)
         idx = mx.minimum((mx.arange(out_len) * (T / out_len)).astype(mx.int32), T - 1)
-        x = x[:, idx, :]                                                      # nearest interp (1,out_len,512)
+        x = x[:, idx, :]  # nearest interp (1,out_len,512)
         for ci, gi in [(0, 1), (3, 4), (6, 7), (9, 10)]:
-            x = conv1d(x, W[f"length_regulator.model.{ci}.weight"],
-                       W[f"length_regulator.model.{ci}.bias"], pad=1)         # k3
-            x = self._group_norm1(x, W[f"length_regulator.model.{gi}.weight"],
-                                  W[f"length_regulator.model.{gi}.bias"])
+            x = conv1d(
+                x,
+                W[f"length_regulator.model.{ci}.weight"],
+                W[f"length_regulator.model.{ci}.bias"],
+                pad=1,
+            )  # k3
+            x = self._group_norm1(
+                x,
+                W[f"length_regulator.model.{gi}.weight"],
+                W[f"length_regulator.model.{gi}.bias"],
+            )
             x = mish(x)
-        cond_target = conv1d(x, W["length_regulator.model.12.weight"],
-                             W["length_regulator.model.12.bias"])             # k1 (1,out_len,512)
+        cond_target = conv1d(
+            x,
+            W["length_regulator.model.12.weight"],
+            W["length_regulator.model.12.bias"],
+        )  # k1 (1,out_len,512)
         prompt_cond = mx.broadcast_to(W["prompt_cond"], (1, T_ref, 512))
-        return mx.concatenate([prompt_cond, cond_target], axis=1)            # (1,T_ref+out_len,512)
+        return mx.concatenate(
+            [prompt_cond, cond_target], axis=1
+        )  # (1,T_ref+out_len,512)
 
     def solve_euler(self, z, prompt, mu, spks, t_span, cfg):
         """z (1,80,Ttot), prompt (1,80,T_ref), mu (1,Ttot,512), spks (1,192).
         Returns full mel (1,80,Ttot) via Euler ODE + CFG (mirrors torch)."""
-        Ttot = z.shape[-1]; T_ref = prompt.shape[-1]
+        Ttot = z.shape[-1]
+        T_ref = prompt.shape[-1]
         zeros_tail = mx.zeros((1, 80, Ttot - T_ref))
-        prompt_x = mx.concatenate([prompt, zeros_tail], axis=-1)              # (1,80,Ttot)
+        prompt_x = mx.concatenate([prompt, zeros_tail], axis=-1)  # (1,80,Ttot)
         x = mx.concatenate([mx.zeros((1, 80, T_ref)), z[..., T_ref:]], axis=-1)
-        z80 = mx.zeros_like(x); zmu = mx.zeros_like(mu); zspk = mx.zeros_like(spks)
-        t = float(t_span[0]); dt = float(t_span[1] - t_span[0])
+        z80 = mx.zeros_like(x)
+        zmu = mx.zeros_like(mu)
+        zspk = mx.zeros_like(spks)
+        t = float(t_span[0])
+        dt = float(t_span[1] - t_span[0])
         for step in range(1, t_span.shape[0]):
             x_in = mx.concatenate([x, x], axis=0)
             px_in = mx.concatenate([prompt_x, z80], axis=0)
             mu_in = mx.concatenate([mu, zmu], axis=0)
             spk_in = mx.concatenate([spks, zspk], axis=0)
             t_in = mx.array([t, t])
-            dphi = self.forward(x_in, mu_in, t_in, spk_in, px_in)             # (2,80,Ttot)
+            dphi = self.forward(x_in, mu_in, t_in, spk_in, px_in)  # (2,80,Ttot)
             cond_d, uncond_d = dphi[:1], dphi[1:]
             d = (1.0 + cfg) * cond_d - cfg * uncond_d
             x = x + dt * d
@@ -195,17 +257,22 @@ class S2AEstimator:
     def forward(self, x_bct, mu, t, spks, cond_bct):
         """x,cond (B,80,T); mu (B,T,512); t (B,); spks (B,192) -> (B,80,T)."""
         B = x_bct.shape[0]
-        x = x_bct.transpose(0, 2, 1)                       # (B,T,80)
+        x = x_bct.transpose(0, 2, 1)  # (B,T,80)
         cond = cond_bct.transpose(0, 2, 1)
         T = x.shape[1]
         t1 = self._t_embed(t, "t_embedder")
         # input embed
-        mu_proj = lin(mu, self.g("input_embed.mu_projection.weight"), self.g("input_embed.mu_projection.bias"))
+        mu_proj = lin(
+            mu,
+            self.g("input_embed.mu_projection.weight"),
+            self.g("input_embed.mu_projection.bias"),
+        )
         spks_seq = mx.broadcast_to(spks[:, None, :], (B, T, spks.shape[-1]))
-        xin = mx.concatenate([x, cond, mu_proj, spks_seq], axis=-1)            # (B,T,864)
+        xin = mx.concatenate([x, cond, mu_proj, spks_seq], axis=-1)  # (B,T,864)
         h = lin(xin, self.g("input_embed.proj.weight"), self.g("input_embed.proj.bias"))
         # transformer with U-Net skip
-        emit = set(range(DEPTH // 2)); recv = set(i for i in range(DEPTH) if i > DEPTH // 2)
+        emit = set(range(DEPTH // 2))
+        recv = set(i for i in range(DEPTH) if i > DEPTH // 2)
         stack = []
         for idx in range(DEPTH):
             skip_in = stack.pop() if (idx in recv and stack) else None
@@ -213,13 +280,22 @@ class S2AEstimator:
             if idx in emit:
                 stack.append(h)
         x_res = self._adaln(h, t1, "transformer_norm")
-        x_res = lin(mx.concatenate([x_res, x], axis=-1),
-                    self.g("skip_linear.weight"), self.g("skip_linear.bias"))
+        x_res = lin(
+            mx.concatenate([x_res, x], axis=-1),
+            self.g("skip_linear.weight"),
+            self.g("skip_linear.bias"),
+        )
         # wavenet final
-        x_out = lin(x_res, self.g("conv1.weight"), self.g("conv1.bias")).transpose(0, 2, 1)  # (B,512,T)
+        x_out = lin(x_res, self.g("conv1.weight"), self.g("conv1.bias")).transpose(
+            0, 2, 1
+        )  # (B,512,T)
         t2 = self._t_embed(t, "t_embedder2")
         x_out = self._wavenet(x_out, t2[:, :, None])
-        x_out = x_out.transpose(0, 2, 1) + lin(x_res, self.g("res_projection.weight"), self.g("res_projection.bias"))
-        x_out = self._final_layer(x_out, t1).transpose(0, 2, 1)               # (B,512,T)
-        x_out = conv1d(x_out.transpose(0, 2, 1), self.g("conv2.weight"), self.g("conv2.bias")).transpose(0, 2, 1)
-        return x_out                                                          # (B,80,T)
+        x_out = x_out.transpose(0, 2, 1) + lin(
+            x_res, self.g("res_projection.weight"), self.g("res_projection.bias")
+        )
+        x_out = self._final_layer(x_out, t1).transpose(0, 2, 1)  # (B,512,T)
+        x_out = conv1d(
+            x_out.transpose(0, 2, 1), self.g("conv2.weight"), self.g("conv2.bias")
+        ).transpose(0, 2, 1)
+        return x_out  # (B,80,T)

--- a/mlx_audio/tts/models/confucius4/s2a.py
+++ b/mlx_audio/tts/models/confucius4/s2a.py
@@ -68,9 +68,26 @@ class S2AEstimator:
             self.g(prefix + ".time_mlp.2.bias"),
         )
 
+    def _extend_freqs(self, T):
+        # freqs_cis is precomputed only up to 4096 positions; a long ref mel
+        # (T_ref + target > 4096 frames) would slice short and crash _rope's
+        # reshape. RoPE angle is linear in position (angle(p)=p*theta), so we
+        # recover theta from row 1 and append the missing rows, leaving the
+        # original 4096 rows byte-identical.
+        import numpy as np
+
+        f = np.array(self.freqs)  # (P0, hd//2, 2)
+        P0 = f.shape[0]
+        theta = np.arctan2(f[1, :, 1], f[1, :, 0])
+        extra = np.arange(P0, T)[:, None] * theta[None, :]
+        tail = np.stack([np.cos(extra), np.sin(extra)], -1).astype(f.dtype)
+        self.freqs = mx.array(np.concatenate([f, tail], 0))
+
     def _rope(self, x):
         # x (B,T,nh,hd) interleaved pairs
         B, T, nh, hd = x.shape
+        if T > self.freqs.shape[0]:
+            self._extend_freqs(T)
         xs = x.reshape(B, T, nh, hd // 2, 2)
         c = self.freqs[:T, :, 0].reshape(1, T, 1, hd // 2)
         s = self.freqs[:T, :, 1].reshape(1, T, 1, hd // 2)

--- a/mlx_audio/tts/models/confucius4/t2s.py
+++ b/mlx_audio/tts/models/confucius4/t2s.py
@@ -63,12 +63,31 @@ class T2SMLX:
         pos = self.W["semantic_position_embedding.embedding.weight"][:T]  # (T,D)
         return se + pos[None]
 
+    # GPT-2 Conv1D matmul x@W (W stored [in,out]); uses 8-bit quantized_matmul
+    # when the weight has been quantized (sibling .scales/.biases present).
+    def _cw(self, x, k):
+        W = self.W
+        sk = k[:-7] + ".scales"
+        if sk in W:
+            return mx.quantized_matmul(
+                x,
+                W[k],
+                W[sk],
+                W[k[:-7] + ".biases"],
+                transpose=True,
+                group_size=64,
+                bits=8,
+            )
+        return x @ W[k]
+
     # ---- one GPT-2 block (optional KV cache) ----
     def _block(self, x, i, mask, cache=None):
         W = self.W
         p = f"transformer.h.{i}."
         h = layernorm(x, W[p + "ln_1.weight"], W[p + "ln_1.bias"])
-        qkv = h @ W[p + "attn.c_attn.weight"] + W[p + "attn.c_attn.bias"]  # (B,T,3D)
+        qkv = (
+            self._cw(h, p + "attn.c_attn.weight") + W[p + "attn.c_attn.bias"]
+        )  # (B,T,3D)
         B, T, _ = qkv.shape
         q, k, v = mx.split(qkv, 3, axis=-1)
 
@@ -86,11 +105,11 @@ class T2SMLX:
         attn = mx.softmax(scores, axis=-1)
         o = attn @ v
         o = o.transpose(0, 2, 1, 3).reshape(B, T, D_MODEL)
-        o = o @ W[p + "attn.c_proj.weight"] + W[p + "attn.c_proj.bias"]
+        o = self._cw(o, p + "attn.c_proj.weight") + W[p + "attn.c_proj.bias"]
         x = x + o
         h2 = layernorm(x, W[p + "ln_2.weight"], W[p + "ln_2.bias"])
-        h2 = gelu_new(h2 @ W[p + "mlp.c_fc.weight"] + W[p + "mlp.c_fc.bias"])
-        h2 = h2 @ W[p + "mlp.c_proj.weight"] + W[p + "mlp.c_proj.bias"]
+        h2 = gelu_new(self._cw(h2, p + "mlp.c_fc.weight") + W[p + "mlp.c_fc.bias"])
+        h2 = self._cw(h2, p + "mlp.c_proj.weight") + W[p + "mlp.c_proj.bias"]
         return x + h2, new_cache
 
     def transformer(self, inputs_embeds, caches=None):
@@ -125,8 +144,22 @@ class T2SMLX:
         return self._head(h)
 
     def _head(self, h_lnf):
-        h = layernorm(h_lnf, self.W["final_norm.weight"], self.W["final_norm.bias"])
-        return h @ self.W["semantic_head.weight"].T + self.W["semantic_head.bias"]
+        W = self.W
+        h = layernorm(h_lnf, W["final_norm.weight"], W["final_norm.bias"])
+        if "semantic_head.scales" in W:
+            return (
+                mx.quantized_matmul(
+                    h,
+                    W["semantic_head.weight"],
+                    W["semantic_head.scales"],
+                    W["semantic_head.biases"],
+                    transpose=True,
+                    group_size=64,
+                    bits=8,
+                )
+                + W["semantic_head.bias"]
+            )
+        return h @ W["semantic_head.weight"].T + W["semantic_head.bias"]
 
     def _sem_token_embed(self, tok, pos):
         """single semantic token id at absolute semantic position -> (1,1,D)."""

--- a/mlx_audio/tts/models/confucius4/t2s.py
+++ b/mlx_audio/tts/models/confucius4/t2s.py
@@ -12,8 +12,9 @@ GPT-2 Conv1D layout [in,out]).
 import glob
 import math
 import os
-import numpy as np
+
 import mlx.core as mx
+import numpy as np
 
 _WEIGHTS = os.path.join(os.path.dirname(__file__), "..", "weights")
 
@@ -23,8 +24,10 @@ N_HEADS = 20
 D_MODEL = 1280
 HEAD_DIM = D_MODEL // N_HEADS
 
-_CKPT_GLOB = ("/Users/tmduc3/.cache/huggingface/hub/"
-              "models--netease-youdao--Confucius4-TTS/snapshots/*/t2s_model.safetensors")
+_CKPT_GLOB = (
+    "/Users/tmduc3/.cache/huggingface/hub/"
+    "models--netease-youdao--Confucius4-TTS/snapshots/*/t2s_model.safetensors"
+)
 
 
 def find_ckpt():
@@ -39,7 +42,7 @@ def find_ckpt():
 
 def gelu_new(x):
     # GPT-2 'gelu_new' (tanh approximation), matches HF
-    return 0.5 * x * (1.0 + mx.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * x ** 3)))
+    return 0.5 * x * (1.0 + mx.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * x**3)))
 
 
 def layernorm(x, w, b, eps=1e-5):
@@ -55,7 +58,7 @@ class T2SMLX:
     # ---- embeddings ----
     def semantic_embed(self, ids):
         """ids: mx int array (B,T) -> (B,T,D) with learned semantic position added."""
-        se = self.W["semantic_embedding.weight"][ids]                 # (B,T,D)
+        se = self.W["semantic_embedding.weight"][ids]  # (B,T,D)
         T = ids.shape[-1]
         pos = self.W["semantic_position_embedding.embedding.weight"][:T]  # (T,D)
         return se + pos[None]
@@ -65,11 +68,13 @@ class T2SMLX:
         W = self.W
         p = f"transformer.h.{i}."
         h = layernorm(x, W[p + "ln_1.weight"], W[p + "ln_1.bias"])
-        qkv = h @ W[p + "attn.c_attn.weight"] + W[p + "attn.c_attn.bias"]   # (B,T,3D)
+        qkv = h @ W[p + "attn.c_attn.weight"] + W[p + "attn.c_attn.bias"]  # (B,T,3D)
         B, T, _ = qkv.shape
         q, k, v = mx.split(qkv, 3, axis=-1)
+
         def heads(t):
             return t.reshape(B, T, N_HEADS, HEAD_DIM).transpose(0, 2, 1, 3)
+
         q, k, v = heads(q), heads(k), heads(v)
         if cache is not None and cache[0] is not None:
             k = mx.concatenate([cache[0], k], axis=2)
@@ -93,7 +98,9 @@ class T2SMLX:
         caches=None means full causal pass (no cache); else incremental."""
         B, T, _ = inputs_embeds.shape
         if caches is None and T > 1:
-            mask = mx.triu(mx.full((T, T), -1e9, dtype=inputs_embeds.dtype), k=1)[None, None]
+            mask = mx.triu(mx.full((T, T), -1e9, dtype=inputs_embeds.dtype), k=1)[
+                None, None
+            ]
         elif caches is None:
             mask = None
         else:
@@ -105,7 +112,9 @@ class T2SMLX:
             c = caches[i] if caches is not None else None
             x, nc = self._block(x, i, mask, c)
             out_caches.append(nc)
-        h = layernorm(x, self.W["transformer.ln_f.weight"], self.W["transformer.ln_f.bias"])
+        h = layernorm(
+            x, self.W["transformer.ln_f.weight"], self.W["transformer.ln_f.bias"]
+        )
         return h, out_caches
 
     def _prefill_mask(self, T, dtype):
@@ -129,23 +138,37 @@ class T2SMLX:
         logits = np.array(logits, dtype=np.float64)
         if gen and rep_pen != 1.0:
             g = np.array(list(set(gen)))
-            logits[g] = np.where(logits[g] > 0, logits[g] / rep_pen, logits[g] * rep_pen)
+            logits[g] = np.where(
+                logits[g] > 0, logits[g] / rep_pen, logits[g] * rep_pen
+            )
         logits = logits / temperature
         if top_k and top_k < logits.shape[0]:
             kth = np.partition(logits, -top_k)[-top_k]
             logits[logits < kth] = -np.inf
         order = np.argsort(logits)[::-1]
         sp = logits[order]
-        probs = np.exp(sp - sp.max()); probs /= probs.sum()
+        probs = np.exp(sp - sp.max())
+        probs /= probs.sum()
         keep = np.cumsum(probs) <= top_p
         keep[0] = True
         sp[~keep] = -np.inf
-        full = np.full_like(logits, -np.inf); full[order] = sp
-        p = np.exp(full - np.nanmax(full)); p /= p.sum()
+        full = np.full_like(logits, -np.inf)
+        full[order] = sp
+        p = np.exp(full - np.nanmax(full))
+        p /= p.sum()
         return int(rng.choice(len(p), p=p))
 
-    def generate(self, cond_emb, text_emb, max_new=512, temperature=0.8,
-                 top_k=30, top_p=0.8, rep_pen=10.0, seed=0):
+    def generate(
+        self,
+        cond_emb,
+        text_emb,
+        max_new=512,
+        temperature=0.8,
+        top_k=30,
+        top_p=0.8,
+        rep_pen=10.0,
+        seed=0,
+    ):
         """KV-cached autoregressive sampling. cond_emb (1,1,D), text_emb (1,Tt,D).
         Returns (semantic_codes int[T], lm_latent float[1,T,D]) for S2A."""
         rng = np.random.default_rng(seed)
@@ -164,15 +187,17 @@ class T2SMLX:
             cur.append(tok)
             if tok == EOS:
                 break
-            e = self._sem_token_embed(tok, pos); pos += 1
+            e = self._sem_token_embed(tok, pos)
+            pos += 1
             h, caches = self.transformer(e, caches=caches)
             logits = self._head(h)[0, -1]
             mx.eval(logits)
-        gen_raw = cur[1:]                                  # includes EOS if emitted
+        gen_raw = cur[1:]  # includes EOS if emitted
         scodes = [BOS] + gen_raw
-        hful, _ = self.transformer(mx.concatenate(
-            [prefix, self.semantic_embed(mx.array([scodes]))], axis=1))   # post ln_f
-        latent = hful[:, 1 + Tt:-2]
+        hful, _ = self.transformer(
+            mx.concatenate([prefix, self.semantic_embed(mx.array([scodes]))], axis=1)
+        )  # post ln_f
+        latent = hful[:, 1 + Tt : -2]
         mx.eval(latent)
         return np.array(scodes[1:-1], dtype=np.int64), np.array(latent)
 
@@ -184,5 +209,7 @@ class T2SMLX:
         for i in range(N_LAYERS):
             x, nc = self._block(x, i, mask, (None, None))
             out_caches.append(nc)
-        h = layernorm(x, self.W["transformer.ln_f.weight"], self.W["transformer.ln_f.bias"])
+        h = layernorm(
+            x, self.W["transformer.ln_f.weight"], self.W["transformer.ln_f.bias"]
+        )
         return h, out_caches

--- a/mlx_audio/tts/models/confucius4/t2s.py
+++ b/mlx_audio/tts/models/confucius4/t2s.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
-# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
-# Licensed under the Apache License, Version 2.0.
+# Copyright © 2023-2024 Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 
 """T2S (Text2Semantic) GPT-2 core ported to MLX.
 

--- a/mlx_audio/tts/models/confucius4/t2s.py
+++ b/mlx_audio/tts/models/confucius4/t2s.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
+# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
+# Licensed under the Apache License, Version 2.0.
+
+"""T2S (Text2Semantic) GPT-2 core ported to MLX.
+
+Port phan loi: semantic embedding + learned pos + 24 GPT-2 blocks + ln_f +
+final_norm + semantic_head. Prefix (speaker/text encoder) van do torch tinh o
+B1 de co lap phep toan GPT-2. Weight doc thang tu t2s_model.safetensors (F32,
+GPT-2 Conv1D layout [in,out]).
+"""
+import glob
+import math
+import os
+import numpy as np
+import mlx.core as mx
+
+_WEIGHTS = os.path.join(os.path.dirname(__file__), "..", "weights")
+
+BOS, EOS = 8192, 8193
+N_LAYERS = 24
+N_HEADS = 20
+D_MODEL = 1280
+HEAD_DIM = D_MODEL // N_HEADS
+
+_CKPT_GLOB = ("/Users/tmduc3/.cache/huggingface/hub/"
+              "models--netease-youdao--Confucius4-TTS/snapshots/*/t2s_model.safetensors")
+
+
+def find_ckpt():
+    local = os.path.join(_WEIGHTS, "t2s_model.safetensors")
+    if os.path.exists(local):
+        return local
+    hits = glob.glob(_CKPT_GLOB)
+    if not hits:
+        raise FileNotFoundError(f"{local} or {_CKPT_GLOB}")
+    return hits[0]
+
+
+def gelu_new(x):
+    # GPT-2 'gelu_new' (tanh approximation), matches HF
+    return 0.5 * x * (1.0 + mx.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * x ** 3)))
+
+
+def layernorm(x, w, b, eps=1e-5):
+    mu = x.mean(-1, keepdims=True)
+    var = ((x - mu) ** 2).mean(-1, keepdims=True)
+    return (x - mu) * mx.rsqrt(var + eps) * w + b
+
+
+class T2SMLX:
+    def __init__(self, ckpt=None):
+        self.W = mx.load(ckpt or find_ckpt())  # dict[str, mx.array] F32
+
+    # ---- embeddings ----
+    def semantic_embed(self, ids):
+        """ids: mx int array (B,T) -> (B,T,D) with learned semantic position added."""
+        se = self.W["semantic_embedding.weight"][ids]                 # (B,T,D)
+        T = ids.shape[-1]
+        pos = self.W["semantic_position_embedding.embedding.weight"][:T]  # (T,D)
+        return se + pos[None]
+
+    # ---- one GPT-2 block (optional KV cache) ----
+    def _block(self, x, i, mask, cache=None):
+        W = self.W
+        p = f"transformer.h.{i}."
+        h = layernorm(x, W[p + "ln_1.weight"], W[p + "ln_1.bias"])
+        qkv = h @ W[p + "attn.c_attn.weight"] + W[p + "attn.c_attn.bias"]   # (B,T,3D)
+        B, T, _ = qkv.shape
+        q, k, v = mx.split(qkv, 3, axis=-1)
+        def heads(t):
+            return t.reshape(B, T, N_HEADS, HEAD_DIM).transpose(0, 2, 1, 3)
+        q, k, v = heads(q), heads(k), heads(v)
+        if cache is not None and cache[0] is not None:
+            k = mx.concatenate([cache[0], k], axis=2)
+            v = mx.concatenate([cache[1], v], axis=2)
+        new_cache = (k, v)
+        scores = (q @ k.transpose(0, 1, 3, 2)) * (1.0 / math.sqrt(HEAD_DIM))
+        if mask is not None:
+            scores = scores + mask
+        attn = mx.softmax(scores, axis=-1)
+        o = attn @ v
+        o = o.transpose(0, 2, 1, 3).reshape(B, T, D_MODEL)
+        o = o @ W[p + "attn.c_proj.weight"] + W[p + "attn.c_proj.bias"]
+        x = x + o
+        h2 = layernorm(x, W[p + "ln_2.weight"], W[p + "ln_2.bias"])
+        h2 = gelu_new(h2 @ W[p + "mlp.c_fc.weight"] + W[p + "mlp.c_fc.bias"])
+        h2 = h2 @ W[p + "mlp.c_proj.weight"] + W[p + "mlp.c_proj.bias"]
+        return x + h2, new_cache
+
+    def transformer(self, inputs_embeds, caches=None):
+        """inputs_embeds: (B,T,D) -> (last_hidden_state after ln_f, caches).
+        caches=None means full causal pass (no cache); else incremental."""
+        B, T, _ = inputs_embeds.shape
+        if caches is None and T > 1:
+            mask = mx.triu(mx.full((T, T), -1e9, dtype=inputs_embeds.dtype), k=1)[None, None]
+        elif caches is None:
+            mask = None
+        else:
+            # incremental step (T usually 1): new token sees all cached -> no mask
+            mask = None
+        x = inputs_embeds
+        out_caches = []
+        for i in range(N_LAYERS):
+            c = caches[i] if caches is not None else None
+            x, nc = self._block(x, i, mask, c)
+            out_caches.append(nc)
+        h = layernorm(x, self.W["transformer.ln_f.weight"], self.W["transformer.ln_f.bias"])
+        return h, out_caches
+
+    def _prefill_mask(self, T, dtype):
+        return mx.triu(mx.full((T, T), -1e9, dtype=dtype), k=1)[None, None]
+
+    def logits_from_embeds(self, inputs_embeds):
+        h, _ = self.transformer(inputs_embeds)
+        return self._head(h)
+
+    def _head(self, h_lnf):
+        h = layernorm(h_lnf, self.W["final_norm.weight"], self.W["final_norm.bias"])
+        return h @ self.W["semantic_head.weight"].T + self.W["semantic_head.bias"]
+
+    def _sem_token_embed(self, tok, pos):
+        """single semantic token id at absolute semantic position -> (1,1,D)."""
+        e = self.W["semantic_embedding.weight"][tok]
+        e = e + self.W["semantic_position_embedding.embedding.weight"][pos]
+        return e[None, None]
+
+    def _sample(self, logits, gen, temperature, top_k, top_p, rep_pen, rng):
+        logits = np.array(logits, dtype=np.float64)
+        if gen and rep_pen != 1.0:
+            g = np.array(list(set(gen)))
+            logits[g] = np.where(logits[g] > 0, logits[g] / rep_pen, logits[g] * rep_pen)
+        logits = logits / temperature
+        if top_k and top_k < logits.shape[0]:
+            kth = np.partition(logits, -top_k)[-top_k]
+            logits[logits < kth] = -np.inf
+        order = np.argsort(logits)[::-1]
+        sp = logits[order]
+        probs = np.exp(sp - sp.max()); probs /= probs.sum()
+        keep = np.cumsum(probs) <= top_p
+        keep[0] = True
+        sp[~keep] = -np.inf
+        full = np.full_like(logits, -np.inf); full[order] = sp
+        p = np.exp(full - np.nanmax(full)); p /= p.sum()
+        return int(rng.choice(len(p), p=p))
+
+    def generate(self, cond_emb, text_emb, max_new=512, temperature=0.8,
+                 top_k=30, top_p=0.8, rep_pen=10.0, seed=0):
+        """KV-cached autoregressive sampling. cond_emb (1,1,D), text_emb (1,Tt,D).
+        Returns (semantic_codes int[T], lm_latent float[1,T,D]) for S2A."""
+        rng = np.random.default_rng(seed)
+        prefix = mx.concatenate([cond_emb, text_emb], axis=1)
+        Tt = text_emb.shape[1]
+        # prefill over [cond, text, BOS]
+        bos_emb = self._sem_token_embed(BOS, 0)
+        x = mx.concatenate([prefix, bos_emb], axis=1)
+        h, caches = self._prefill(x)
+        logits = self._head(h[:, -1:])[0, -1]
+        mx.eval(logits)
+        cur = [BOS]
+        pos = 1
+        for _ in range(max_new):
+            tok = self._sample(logits, cur[1:], temperature, top_k, top_p, rep_pen, rng)
+            cur.append(tok)
+            if tok == EOS:
+                break
+            e = self._sem_token_embed(tok, pos); pos += 1
+            h, caches = self.transformer(e, caches=caches)
+            logits = self._head(h)[0, -1]
+            mx.eval(logits)
+        gen_raw = cur[1:]                                  # includes EOS if emitted
+        scodes = [BOS] + gen_raw
+        hful, _ = self.transformer(mx.concatenate(
+            [prefix, self.semantic_embed(mx.array([scodes]))], axis=1))   # post ln_f
+        latent = hful[:, 1 + Tt:-2]
+        mx.eval(latent)
+        return np.array(scodes[1:-1], dtype=np.int64), np.array(latent)
+
+    def _prefill(self, x):
+        """full causal pass that also returns per-layer caches."""
+        B, T, _ = x.shape
+        mask = self._prefill_mask(T, x.dtype)
+        out_caches = []
+        for i in range(N_LAYERS):
+            x, nc = self._block(x, i, mask, (None, None))
+            out_caches.append(nc)
+        h = layernorm(x, self.W["transformer.ln_f.weight"], self.W["transformer.ln_f.bias"])
+        return h, out_caches

--- a/mlx_audio/tts/models/confucius4/t2s.py
+++ b/mlx_audio/tts/models/confucius4/t2s.py
@@ -9,7 +9,6 @@ final_norm + semantic_head. Prefix (speaker/text encoder) van do torch tinh o
 B1 de co lap phep toan GPT-2. Weight doc thang tu t2s_model.safetensors (F32,
 GPT-2 Conv1D layout [in,out]).
 """
-import glob
 import math
 import os
 
@@ -24,20 +23,16 @@ N_HEADS = 20
 D_MODEL = 1280
 HEAD_DIM = D_MODEL // N_HEADS
 
-_CKPT_GLOB = (
-    "/Users/tmduc3/.cache/huggingface/hub/"
-    "models--netease-youdao--Confucius4-TTS/snapshots/*/t2s_model.safetensors"
-)
-
 
 def find_ckpt():
+    # In normal use the Model passes an explicit path; this default is only for
+    # standalone use with a sibling weights/ dir.
     local = os.path.join(_WEIGHTS, "t2s_model.safetensors")
     if os.path.exists(local):
         return local
-    hits = glob.glob(_CKPT_GLOB)
-    if not hits:
-        raise FileNotFoundError(f"{local} or {_CKPT_GLOB}")
-    return hits[0]
+    raise FileNotFoundError(
+        f"{local} not found; pass an explicit checkpoint path (see convert.py)."
+    )
 
 
 def gelu_new(x):

--- a/mlx_audio/tts/models/confucius4/t2s.py
+++ b/mlx_audio/tts/models/confucius4/t2s.py
@@ -52,8 +52,9 @@ def layernorm(x, w, b, eps=1e-5):
 
 
 class T2SMLX:
-    def __init__(self, ckpt=None):
-        self.W = mx.load(ckpt or find_ckpt())  # dict[str, mx.array] F32
+    def __init__(self, ckpt=None, group_size=64, bits=8):
+        self.W = mx.load(ckpt or find_ckpt())  # dict[str, mx.array]
+        self.qgs, self.qbits = group_size, bits  # for quantized_matmul (int8/int4)
 
     # ---- embeddings ----
     def semantic_embed(self, ids):
@@ -75,8 +76,8 @@ class T2SMLX:
                 W[sk],
                 W[k[:-7] + ".biases"],
                 transpose=True,
-                group_size=64,
-                bits=8,
+                group_size=self.qgs,
+                bits=self.qbits,
             )
         return x @ W[k]
 
@@ -154,8 +155,8 @@ class T2SMLX:
                     W["semantic_head.scales"],
                     W["semantic_head.biases"],
                     transpose=True,
-                    group_size=64,
-                    bits=8,
+                    group_size=self.qgs,
+                    bits=self.qbits,
                 )
                 + W["semantic_head.bias"]
             )

--- a/mlx_audio/tts/models/confucius4/vocoder.py
+++ b/mlx_audio/tts/models/confucius4/vocoder.py
@@ -9,6 +9,7 @@ fixed FIR filters). Weights b2/bigvgan_mlx.safetensors (weight_norm folded).
 Config: ups [4,4,2,2,2,2], init ch 1536, resblock k[3,7,11] dil[1,3,5].
 """
 import os
+
 import mlx.core as mx
 
 ST = os.path.join(os.path.dirname(__file__), "..", "weights", "bigvgan_mlx.safetensors")
@@ -19,7 +20,7 @@ RES_D = [[1, 3, 5], [1, 3, 5], [1, 3, 5]]
 
 
 def conv1d(x, W_oik, b=None, pad=0, dilation=1, stride=1, groups=1):
-    w = mx.transpose(W_oik, (0, 2, 1))                 # (Cout,k,Cin/groups)
+    w = mx.transpose(W_oik, (0, 2, 1))  # (Cout,k,Cin/groups)
     y = mx.conv1d(x, w, stride=stride, padding=pad, dilation=dilation, groups=groups)
     return y + b if b is not None else y
 
@@ -45,40 +46,55 @@ class BigVGANMLX:
         B, T, C = x.shape
         # upsample x2 (k=12): replicate pad 5, grouped conv_transpose, *2, crop 15
         fu = self.W[prefix + ".upsample.filter"].reshape(1, 12, 1)
-        wu = mx.broadcast_to(fu, (C, 12, 1))                       # (Cout=C,k,Cin/g=1)
+        wu = mx.broadcast_to(fu, (C, 12, 1))  # (Cout=C,k,Cin/g=1)
         xu = rep_pad(x, 5, 5)
         xu = 2.0 * mx.conv_transpose1d(xu, wu, stride=2, padding=0, groups=C)
-        xu = xu[:, 15:-15, :]                                      # (B,2T,C)
+        xu = xu[:, 15:-15, :]  # (B,2T,C)
         xu = self._snakebeta(xu, prefix + ".act")
         # downsample x2 (k=12): replicate pad (5,6), grouped conv stride2
         fd = self.W[prefix + ".downsample.lowpass.filter"].reshape(1, 12, 1)
         wd = mx.broadcast_to(fd, (C, 12, 1))
         xd = rep_pad(xu, 5, 6)
         xd = mx.conv1d(xd, wd, stride=2, padding=0, groups=C)
-        return xd                                                 # (B,T,C)
+        return xd  # (B,T,C)
 
     def _resblock(self, x, idx, k):
         for j, d in enumerate(RES_D[0]):
             p = f"resblocks.{idx}."
             xt = self._aa_act(x, p + f"activations.{2*j}")
-            xt = conv1d(xt, self.W[p + f"convs1.{j}.weight"], self.W[p + f"convs1.{j}.bias"],
-                        pad=d * (k - 1) // 2, dilation=d)
+            xt = conv1d(
+                xt,
+                self.W[p + f"convs1.{j}.weight"],
+                self.W[p + f"convs1.{j}.bias"],
+                pad=d * (k - 1) // 2,
+                dilation=d,
+            )
             xt = self._aa_act(xt, p + f"activations.{2*j+1}")
-            xt = conv1d(xt, self.W[p + f"convs2.{j}.weight"], self.W[p + f"convs2.{j}.bias"],
-                        pad=(k - 1) // 2, dilation=1)
+            xt = conv1d(
+                xt,
+                self.W[p + f"convs2.{j}.weight"],
+                self.W[p + f"convs2.{j}.bias"],
+                pad=(k - 1) // 2,
+                dilation=1,
+            )
             x = x + xt
         return x
 
     def __call__(self, mel_bct):
         """mel (1,80,T) -> wav (1, T*256)."""
-        x = mel_bct.transpose(0, 2, 1)                            # (1,T,80)
-        x = conv1d(x, self.W["conv_pre.weight"], self.W["conv_pre.bias"], pad=3)   # (1,T,1536)
+        x = mel_bct.transpose(0, 2, 1)  # (1,T,80)
+        x = conv1d(
+            x, self.W["conv_pre.weight"], self.W["conv_pre.bias"], pad=3
+        )  # (1,T,1536)
         for i in range(6):
             # upsample (ConvTranspose1d ch->ch/2)
-            wt = self.W[f"ups.{i}.0.weight"]                      # torch (Cin,Cout,k)
-            wt = mx.transpose(wt, (1, 2, 0))                      # (Cout,k,Cin)
+            wt = self.W[f"ups.{i}.0.weight"]  # torch (Cin,Cout,k)
+            wt = mx.transpose(wt, (1, 2, 0))  # (Cout,k,Cin)
             k, u = UP_KERNELS[i], UP_RATES[i]
-            x = mx.conv_transpose1d(x, wt, stride=u, padding=(k - u) // 2) + self.W[f"ups.{i}.0.bias"]
+            x = (
+                mx.conv_transpose1d(x, wt, stride=u, padding=(k - u) // 2)
+                + self.W[f"ups.{i}.0.bias"]
+            )
             xs = None
             for j in range(3):
                 r = self._resblock(x, i * 3 + j, RES_K[j])
@@ -86,6 +102,6 @@ class BigVGANMLX:
             x = xs / 3.0
             mx.eval(x)
         x = self._aa_act(x, "activation_post")
-        x = conv1d(x, self.W["conv_post.weight"], pad=3)          # no bias (1,T*256,1)
+        x = conv1d(x, self.W["conv_post.weight"], pad=3)  # no bias (1,T*256,1)
         x = mx.clip(x, -1.0, 1.0)
-        return x.transpose(0, 2, 1).reshape(1, -1)                # (1, T*256)
+        return x.transpose(0, 2, 1).reshape(1, -1)  # (1, T*256)

--- a/mlx_audio/tts/models/confucius4/vocoder.py
+++ b/mlx_audio/tts/models/confucius4/vocoder.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
-# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
-# Licensed under the Apache License, Version 2.0.
+# Copyright © 2023-2024 Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 
 """BigVGAN v2 vocoder (mel -> waveform) ported to MLX.
 

--- a/mlx_audio/tts/models/confucius4/vocoder.py
+++ b/mlx_audio/tts/models/confucius4/vocoder.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
+# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
+# Licensed under the Apache License, Version 2.0.
+
+"""BigVGAN v2 vocoder (mel -> waveform) ported to MLX.
+
+snakebeta logscale + anti-aliased activation (upsample->snake->downsample with
+fixed FIR filters). Weights b2/bigvgan_mlx.safetensors (weight_norm folded).
+Config: ups [4,4,2,2,2,2], init ch 1536, resblock k[3,7,11] dil[1,3,5].
+"""
+import os
+import mlx.core as mx
+
+ST = os.path.join(os.path.dirname(__file__), "..", "weights", "bigvgan_mlx.safetensors")
+UP_RATES = [4, 4, 2, 2, 2, 2]
+UP_KERNELS = [8, 8, 4, 4, 4, 4]
+RES_K = [3, 7, 11]
+RES_D = [[1, 3, 5], [1, 3, 5], [1, 3, 5]]
+
+
+def conv1d(x, W_oik, b=None, pad=0, dilation=1, stride=1, groups=1):
+    w = mx.transpose(W_oik, (0, 2, 1))                 # (Cout,k,Cin/groups)
+    y = mx.conv1d(x, w, stride=stride, padding=pad, dilation=dilation, groups=groups)
+    return y + b if b is not None else y
+
+
+def rep_pad(x, l, r):
+    B, T, C = x.shape
+    left = mx.broadcast_to(x[:, :1, :], (B, l, C))
+    right = mx.broadcast_to(x[:, -1:, :], (B, r, C))
+    return mx.concatenate([left, x, right], axis=1)
+
+
+class BigVGANMLX:
+    def __init__(self, st=ST):
+        self.W = mx.load(st)
+
+    def _snakebeta(self, x, prefix):
+        a = mx.exp(self.W[prefix + ".alpha"]).reshape(1, 1, -1)
+        b = mx.exp(self.W[prefix + ".beta"]).reshape(1, 1, -1)
+        return x + (1.0 / (b + 1e-9)) * mx.sin(x * a) ** 2
+
+    def _aa_act(self, x, prefix):
+        """anti-aliased snakebeta on (B,T,C). up x2 -> snake -> down x2."""
+        B, T, C = x.shape
+        # upsample x2 (k=12): replicate pad 5, grouped conv_transpose, *2, crop 15
+        fu = self.W[prefix + ".upsample.filter"].reshape(1, 12, 1)
+        wu = mx.broadcast_to(fu, (C, 12, 1))                       # (Cout=C,k,Cin/g=1)
+        xu = rep_pad(x, 5, 5)
+        xu = 2.0 * mx.conv_transpose1d(xu, wu, stride=2, padding=0, groups=C)
+        xu = xu[:, 15:-15, :]                                      # (B,2T,C)
+        xu = self._snakebeta(xu, prefix + ".act")
+        # downsample x2 (k=12): replicate pad (5,6), grouped conv stride2
+        fd = self.W[prefix + ".downsample.lowpass.filter"].reshape(1, 12, 1)
+        wd = mx.broadcast_to(fd, (C, 12, 1))
+        xd = rep_pad(xu, 5, 6)
+        xd = mx.conv1d(xd, wd, stride=2, padding=0, groups=C)
+        return xd                                                 # (B,T,C)
+
+    def _resblock(self, x, idx, k):
+        for j, d in enumerate(RES_D[0]):
+            p = f"resblocks.{idx}."
+            xt = self._aa_act(x, p + f"activations.{2*j}")
+            xt = conv1d(xt, self.W[p + f"convs1.{j}.weight"], self.W[p + f"convs1.{j}.bias"],
+                        pad=d * (k - 1) // 2, dilation=d)
+            xt = self._aa_act(xt, p + f"activations.{2*j+1}")
+            xt = conv1d(xt, self.W[p + f"convs2.{j}.weight"], self.W[p + f"convs2.{j}.bias"],
+                        pad=(k - 1) // 2, dilation=1)
+            x = x + xt
+        return x
+
+    def __call__(self, mel_bct):
+        """mel (1,80,T) -> wav (1, T*256)."""
+        x = mel_bct.transpose(0, 2, 1)                            # (1,T,80)
+        x = conv1d(x, self.W["conv_pre.weight"], self.W["conv_pre.bias"], pad=3)   # (1,T,1536)
+        for i in range(6):
+            # upsample (ConvTranspose1d ch->ch/2)
+            wt = self.W[f"ups.{i}.0.weight"]                      # torch (Cin,Cout,k)
+            wt = mx.transpose(wt, (1, 2, 0))                      # (Cout,k,Cin)
+            k, u = UP_KERNELS[i], UP_RATES[i]
+            x = mx.conv_transpose1d(x, wt, stride=u, padding=(k - u) // 2) + self.W[f"ups.{i}.0.bias"]
+            xs = None
+            for j in range(3):
+                r = self._resblock(x, i * 3 + j, RES_K[j])
+                xs = r if xs is None else xs + r
+            x = xs / 3.0
+            mx.eval(x)
+        x = self._aa_act(x, "activation_post")
+        x = conv1d(x, self.W["conv_post.weight"], pad=3)          # no bias (1,T*256,1)
+        x = mx.clip(x, -1.0, 1.0)
+        return x.transpose(0, 2, 1).reshape(1, -1)                # (1, T*256)

--- a/mlx_audio/tts/models/confucius4/w2vbert.py
+++ b/mlx_audio/tts/models/confucius4/w2vbert.py
@@ -34,39 +34,53 @@ def swish(x):
 
 
 class W2VBertMLX:
-    def __init__(self, st=ST):
+    def __init__(self, st=ST, group_size=64, bits=8):
         self.W = mx.load(st)
-        # precompute relative position index for attention (built per call by length)
+        self.qgs, self.qbits = group_size, bits  # for optional int8/int4 linears
 
     def g(self, k):
         return self.W[k]
 
+    # Linear (weight [out,in]); 8-bit quantized_matmul when sibling .scales present.
+    def _lin(self, x, wk, bk=None):
+        W = self.W
+        sk = wk[:-7] + ".scales"
+        if sk in W:
+            y = mx.quantized_matmul(
+                x,
+                W[wk],
+                W[sk],
+                W[wk[:-7] + ".biases"],
+                transpose=True,
+                group_size=self.qgs,
+                bits=self.qbits,
+            )
+        else:
+            y = x @ W[wk].T
+        return y + W[bk] if bk is not None else y
+
     def _ffn(self, x, p):
         h = swish(
-            lin(
-                x,
-                self.g(p + ".intermediate_dense.weight"),
-                self.g(p + ".intermediate_dense.bias"),
+            self._lin(
+                x, p + ".intermediate_dense.weight", p + ".intermediate_dense.bias"
             )
         )
-        return lin(
-            h, self.g(p + ".output_dense.weight"), self.g(p + ".output_dense.bias")
-        )
+        return self._lin(h, p + ".output_dense.weight", p + ".output_dense.bias")
 
     def _attn(self, x, p):
         B, T, _ = x.shape
         q = (
-            lin(x, self.g(p + ".linear_q.weight"), self.g(p + ".linear_q.bias"))
+            self._lin(x, p + ".linear_q.weight", p + ".linear_q.bias")
             .reshape(B, T, NH, HD)
             .transpose(0, 2, 1, 3)
         )
         k = (
-            lin(x, self.g(p + ".linear_k.weight"), self.g(p + ".linear_k.bias"))
+            self._lin(x, p + ".linear_k.weight", p + ".linear_k.bias")
             .reshape(B, T, NH, HD)
             .transpose(0, 2, 1, 3)
         )
         v = (
-            lin(x, self.g(p + ".linear_v.weight"), self.g(p + ".linear_v.bias"))
+            self._lin(x, p + ".linear_v.weight", p + ".linear_v.bias")
             .reshape(B, T, NH, HD)
             .transpose(0, 2, 1, 3)
         )
@@ -80,7 +94,7 @@ class W2VBertMLX:
         scores = scores + rel
         a = mx.softmax(scores, axis=-1) @ v  # (B,NH,T,HD)
         a = a.transpose(0, 2, 1, 3).reshape(B, T, H)
-        return lin(a, self.g(p + ".linear_out.weight"), self.g(p + ".linear_out.bias"))
+        return self._lin(a, p + ".linear_out.weight", p + ".linear_out.bias")
 
     def _conv(self, x, p):
         B, T, _ = x.shape

--- a/mlx_audio/tts/models/confucius4/w2vbert.py
+++ b/mlx_audio/tts/models/confucius4/w2vbert.py
@@ -10,6 +10,7 @@ Weights: b4/w2vbert_mlx.safetensors (fp32, torch layout).
 """
 import math
 import os
+
 import mlx.core as mx
 
 H, NH, HD, NLAYERS = 1024, 16, 64, 17
@@ -41,55 +42,115 @@ class W2VBertMLX:
         return self.W[k]
 
     def _ffn(self, x, p):
-        h = swish(lin(x, self.g(p + ".intermediate_dense.weight"), self.g(p + ".intermediate_dense.bias")))
-        return lin(h, self.g(p + ".output_dense.weight"), self.g(p + ".output_dense.bias"))
+        h = swish(
+            lin(
+                x,
+                self.g(p + ".intermediate_dense.weight"),
+                self.g(p + ".intermediate_dense.bias"),
+            )
+        )
+        return lin(
+            h, self.g(p + ".output_dense.weight"), self.g(p + ".output_dense.bias")
+        )
 
     def _attn(self, x, p):
         B, T, _ = x.shape
-        q = lin(x, self.g(p + ".linear_q.weight"), self.g(p + ".linear_q.bias")).reshape(B, T, NH, HD).transpose(0, 2, 1, 3)
-        k = lin(x, self.g(p + ".linear_k.weight"), self.g(p + ".linear_k.bias")).reshape(B, T, NH, HD).transpose(0, 2, 1, 3)
-        v = lin(x, self.g(p + ".linear_v.weight"), self.g(p + ".linear_v.bias")).reshape(B, T, NH, HD).transpose(0, 2, 1, 3)
+        q = (
+            lin(x, self.g(p + ".linear_q.weight"), self.g(p + ".linear_q.bias"))
+            .reshape(B, T, NH, HD)
+            .transpose(0, 2, 1, 3)
+        )
+        k = (
+            lin(x, self.g(p + ".linear_k.weight"), self.g(p + ".linear_k.bias"))
+            .reshape(B, T, NH, HD)
+            .transpose(0, 2, 1, 3)
+        )
+        v = (
+            lin(x, self.g(p + ".linear_v.weight"), self.g(p + ".linear_v.bias"))
+            .reshape(B, T, NH, HD)
+            .transpose(0, 2, 1, 3)
+        )
         scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(HD)
         # relative_key: distance = r - l, clamp[-LEFT,RIGHT], +LEFT -> distance_embedding (T,T,HD)
         l = mx.arange(T).reshape(T, 1)
         r = mx.arange(T).reshape(1, T)
-        dist = mx.clip(r - l, -LEFT, RIGHT) + LEFT                      # (T,T) in [0,72]
-        pe = self.g(p + ".distance_embedding.weight")[dist]            # (T,T,HD)
-        rel = mx.einsum("bhld,lrd->bhlr", q, pe) / math.sqrt(HD)        # (B,NH,T,T)
+        dist = mx.clip(r - l, -LEFT, RIGHT) + LEFT  # (T,T) in [0,72]
+        pe = self.g(p + ".distance_embedding.weight")[dist]  # (T,T,HD)
+        rel = mx.einsum("bhld,lrd->bhlr", q, pe) / math.sqrt(HD)  # (B,NH,T,T)
         scores = scores + rel
-        a = mx.softmax(scores, axis=-1) @ v                            # (B,NH,T,HD)
+        a = mx.softmax(scores, axis=-1) @ v  # (B,NH,T,HD)
         a = a.transpose(0, 2, 1, 3).reshape(B, T, H)
         return lin(a, self.g(p + ".linear_out.weight"), self.g(p + ".linear_out.bias"))
 
     def _conv(self, x, p):
         B, T, _ = x.shape
-        h = layernorm(x, self.g(p + ".layer_norm.weight"), self.g(p + ".layer_norm.bias"))
+        h = layernorm(
+            x, self.g(p + ".layer_norm.weight"), self.g(p + ".layer_norm.bias")
+        )
         # pointwise_conv1 (k1, no bias): 1024->2048
-        h = h @ self.g(p + ".pointwise_conv1.weight")[:, :, 0].T       # (B,T,2048)
+        h = h @ self.g(p + ".pointwise_conv1.weight")[:, :, 0].T  # (B,T,2048)
         a, bb = mx.split(h, 2, axis=-1)
-        h = a * mx.sigmoid(bb)                                          # GLU -> (B,T,1024)
+        h = a * mx.sigmoid(bb)  # GLU -> (B,T,1024)
         # causal depthwise k31: left pad 30, groups=1024
-        wdw = mx.transpose(self.g(p + ".depthwise_conv.weight"), (0, 2, 1))   # (1024,31,1)
+        wdw = mx.transpose(
+            self.g(p + ".depthwise_conv.weight"), (0, 2, 1)
+        )  # (1024,31,1)
         hp = mx.concatenate([mx.zeros((B, 30, H)), h], axis=1)
-        h = mx.conv1d(hp, wdw, stride=1, padding=0, groups=H)          # (B,T,1024)
-        h = layernorm(h, self.g(p + ".depthwise_layer_norm.weight"), self.g(p + ".depthwise_layer_norm.bias"))
+        h = mx.conv1d(hp, wdw, stride=1, padding=0, groups=H)  # (B,T,1024)
+        h = layernorm(
+            h,
+            self.g(p + ".depthwise_layer_norm.weight"),
+            self.g(p + ".depthwise_layer_norm.bias"),
+        )
         h = swish(h)
-        h = h @ self.g(p + ".pointwise_conv2.weight")[:, :, 0].T       # (B,T,1024)
+        h = h @ self.g(p + ".pointwise_conv2.weight")[:, :, 0].T  # (B,T,1024)
         return h
 
     def _layer(self, x, i):
         p = f"encoder.layers.{i}."
-        x = x + 0.5 * self._ffn(layernorm(x, self.g(p + "ffn1_layer_norm.weight"), self.g(p + "ffn1_layer_norm.bias")), p + "ffn1")
-        x = x + self._attn(layernorm(x, self.g(p + "self_attn_layer_norm.weight"), self.g(p + "self_attn_layer_norm.bias")), p + "self_attn")
+        x = x + 0.5 * self._ffn(
+            layernorm(
+                x,
+                self.g(p + "ffn1_layer_norm.weight"),
+                self.g(p + "ffn1_layer_norm.bias"),
+            ),
+            p + "ffn1",
+        )
+        x = x + self._attn(
+            layernorm(
+                x,
+                self.g(p + "self_attn_layer_norm.weight"),
+                self.g(p + "self_attn_layer_norm.bias"),
+            ),
+            p + "self_attn",
+        )
         x = x + self._conv(x, p + "conv_module")
-        x = x + 0.5 * self._ffn(layernorm(x, self.g(p + "ffn2_layer_norm.weight"), self.g(p + "ffn2_layer_norm.bias")), p + "ffn2")
-        return layernorm(x, self.g(p + "final_layer_norm.weight"), self.g(p + "final_layer_norm.bias"))
+        x = x + 0.5 * self._ffn(
+            layernorm(
+                x,
+                self.g(p + "ffn2_layer_norm.weight"),
+                self.g(p + "ffn2_layer_norm.bias"),
+            ),
+            p + "ffn2",
+        )
+        return layernorm(
+            x,
+            self.g(p + "final_layer_norm.weight"),
+            self.g(p + "final_layer_norm.bias"),
+        )
 
     def hidden17(self, input_features):
         """input_features (1,T,160) -> hidden_states[17] (1,T,1024)."""
-        x = layernorm(input_features, self.g("feature_projection.layer_norm.weight"),
-                      self.g("feature_projection.layer_norm.bias"))
-        x = lin(x, self.g("feature_projection.projection.weight"), self.g("feature_projection.projection.bias"))
+        x = layernorm(
+            input_features,
+            self.g("feature_projection.layer_norm.weight"),
+            self.g("feature_projection.layer_norm.bias"),
+        )
+        x = lin(
+            x,
+            self.g("feature_projection.projection.weight"),
+            self.g("feature_projection.projection.bias"),
+        )
         for i in range(NLAYERS):
             x = self._layer(x, i)
         return x

--- a/mlx_audio/tts/models/confucius4/w2vbert.py
+++ b/mlx_audio/tts/models/confucius4/w2vbert.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
+# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
+# Licensed under the Apache License, Version 2.0.
+
+"""Wav2Vec2-BERT (w2v-bert-2.0) conformer encoder -> hidden_states[17], in MLX.
+
+feature_projection + 17 conformer layers. Each layer: ffn1(*0.5) -> self_attn
+(relative_key) -> conv_module (causal depthwise) -> ffn2(*0.5) -> final LN.
+Weights: b4/w2vbert_mlx.safetensors (fp32, torch layout).
+"""
+import math
+import os
+import mlx.core as mx
+
+H, NH, HD, NLAYERS = 1024, 16, 64, 17
+LEFT, RIGHT = 64, 8
+ST = os.path.join(os.path.dirname(__file__), "..", "weights", "w2vbert_mlx.safetensors")
+
+
+def lin(x, W, b=None):
+    y = x @ W.T
+    return y + b if b is not None else y
+
+
+def layernorm(x, w, b, eps=1e-5):
+    mu = x.mean(-1, keepdims=True)
+    var = ((x - mu) ** 2).mean(-1, keepdims=True)
+    return (x - mu) * mx.rsqrt(var + eps) * w + b
+
+
+def swish(x):
+    return x * mx.sigmoid(x)
+
+
+class W2VBertMLX:
+    def __init__(self, st=ST):
+        self.W = mx.load(st)
+        # precompute relative position index for attention (built per call by length)
+
+    def g(self, k):
+        return self.W[k]
+
+    def _ffn(self, x, p):
+        h = swish(lin(x, self.g(p + ".intermediate_dense.weight"), self.g(p + ".intermediate_dense.bias")))
+        return lin(h, self.g(p + ".output_dense.weight"), self.g(p + ".output_dense.bias"))
+
+    def _attn(self, x, p):
+        B, T, _ = x.shape
+        q = lin(x, self.g(p + ".linear_q.weight"), self.g(p + ".linear_q.bias")).reshape(B, T, NH, HD).transpose(0, 2, 1, 3)
+        k = lin(x, self.g(p + ".linear_k.weight"), self.g(p + ".linear_k.bias")).reshape(B, T, NH, HD).transpose(0, 2, 1, 3)
+        v = lin(x, self.g(p + ".linear_v.weight"), self.g(p + ".linear_v.bias")).reshape(B, T, NH, HD).transpose(0, 2, 1, 3)
+        scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(HD)
+        # relative_key: distance = r - l, clamp[-LEFT,RIGHT], +LEFT -> distance_embedding (T,T,HD)
+        l = mx.arange(T).reshape(T, 1)
+        r = mx.arange(T).reshape(1, T)
+        dist = mx.clip(r - l, -LEFT, RIGHT) + LEFT                      # (T,T) in [0,72]
+        pe = self.g(p + ".distance_embedding.weight")[dist]            # (T,T,HD)
+        rel = mx.einsum("bhld,lrd->bhlr", q, pe) / math.sqrt(HD)        # (B,NH,T,T)
+        scores = scores + rel
+        a = mx.softmax(scores, axis=-1) @ v                            # (B,NH,T,HD)
+        a = a.transpose(0, 2, 1, 3).reshape(B, T, H)
+        return lin(a, self.g(p + ".linear_out.weight"), self.g(p + ".linear_out.bias"))
+
+    def _conv(self, x, p):
+        B, T, _ = x.shape
+        h = layernorm(x, self.g(p + ".layer_norm.weight"), self.g(p + ".layer_norm.bias"))
+        # pointwise_conv1 (k1, no bias): 1024->2048
+        h = h @ self.g(p + ".pointwise_conv1.weight")[:, :, 0].T       # (B,T,2048)
+        a, bb = mx.split(h, 2, axis=-1)
+        h = a * mx.sigmoid(bb)                                          # GLU -> (B,T,1024)
+        # causal depthwise k31: left pad 30, groups=1024
+        wdw = mx.transpose(self.g(p + ".depthwise_conv.weight"), (0, 2, 1))   # (1024,31,1)
+        hp = mx.concatenate([mx.zeros((B, 30, H)), h], axis=1)
+        h = mx.conv1d(hp, wdw, stride=1, padding=0, groups=H)          # (B,T,1024)
+        h = layernorm(h, self.g(p + ".depthwise_layer_norm.weight"), self.g(p + ".depthwise_layer_norm.bias"))
+        h = swish(h)
+        h = h @ self.g(p + ".pointwise_conv2.weight")[:, :, 0].T       # (B,T,1024)
+        return h
+
+    def _layer(self, x, i):
+        p = f"encoder.layers.{i}."
+        x = x + 0.5 * self._ffn(layernorm(x, self.g(p + "ffn1_layer_norm.weight"), self.g(p + "ffn1_layer_norm.bias")), p + "ffn1")
+        x = x + self._attn(layernorm(x, self.g(p + "self_attn_layer_norm.weight"), self.g(p + "self_attn_layer_norm.bias")), p + "self_attn")
+        x = x + self._conv(x, p + "conv_module")
+        x = x + 0.5 * self._ffn(layernorm(x, self.g(p + "ffn2_layer_norm.weight"), self.g(p + "ffn2_layer_norm.bias")), p + "ffn2")
+        return layernorm(x, self.g(p + "final_layer_norm.weight"), self.g(p + "final_layer_norm.bias"))
+
+    def hidden17(self, input_features):
+        """input_features (1,T,160) -> hidden_states[17] (1,T,1024)."""
+        x = layernorm(input_features, self.g("feature_projection.layer_norm.weight"),
+                      self.g("feature_projection.layer_norm.bias"))
+        x = lin(x, self.g("feature_projection.projection.weight"), self.g("feature_projection.projection.bias"))
+        for i in range(NLAYERS):
+            x = self._layer(x, i)
+        return x

--- a/mlx_audio/tts/models/confucius4/w2vbert.py
+++ b/mlx_audio/tts/models/confucius4/w2vbert.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2026 Hert4 (https://github.com/Hert4)
-# MLX port of Confucius4-TTS (netease-youdao, Apache-2.0).
-# Licensed under the Apache License, Version 2.0.
+# Copyright © 2023-2024 Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 
 """Wav2Vec2-BERT (w2v-bert-2.0) conformer encoder -> hidden_states[17], in MLX.
 


### PR DESCRIPTION
Adds **Confucius4-TTS** ([netease-youdao](https://huggingface.co/netease-youdao/Confucius4-TTS), Apache-2.0) — multilingual, cross-lingual, zero-shot voice-cloning TTS (14 languages incl. Vietnamese). Follows up #796.

### What's here
`mlx_audio/tts/models/confucius4/` — a pure-MLX implementation:
- **T2S** GPT-2 autoregressive decoder (KV-cached)
- **S2A** conditional flow-matching (DiT + WaveNet, 25-step Euler + CFG)
- **BigVGAN v2** vocoder (anti-aliased snakebeta)
- **w2v-bert-2.0** conformer semantic encoder; **ECAPA** + **CAMPPlus** speaker encoders
- numpy SeamlessM4T-style fbank + `tokenizers` tokenizer

### Torch-free
No `torch`/`transformers` in the inference path (verified). `torch` is used only in `convert.py` (weight conversion), per the requirement in #796. CAMPPlus is reused from `chatterbox/s3gen/xvector.py` as suggested.

### Validated numerically vs the original PyTorch model
| Stage | vs torch |
|---|---|
| T2S | argmax 99.2% (teacher-forcing) |
| S2A mel | rel. err 0.77% |
| BigVGAN wav | corr 0.9998 |
| w2v-bert hidden[17] | mean abs 0.003 |
| ECAPA / CAMPPlus | rel 5e-4 / cos 0.997 |

### Benchmark (Apple M5, 24 GB)
~3.8 s of audio end-to-end in ~8–11 s (RTF ~2.1).

### Usage
```python
from mlx_audio.tts.utils import load
model = load("path/to/confucius4-model")
for r in model.generate("Xin chào", ref_audio="voice.wav", lang="vi"):
    ...
```
Weights: `python -m mlx_audio.tts.models.confucius4.convert --out DIR`, or the prebuilt repo `beyoru/Confucius4-TTS-mlx`.

Happy to adjust structure/conventions per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
