### PR TITLE
Add Higgs v3 continuous batching

### DIFF
--- a/mlx_audio/tts/models/higgs_audio_v3/continuous_batching.py
+++ b/mlx_audio/tts/models/higgs_audio_v3/continuous_batching.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+import mlx.core as mx
+from mlx_lm.models.cache import BatchKVCache
+
+from mlx_audio.tts.continuous import TTSBatchEvent, TTSBatchItem, TTSBatchOptions
+
+from .generation import HiggsSamplerState
+
+
+def _format_duration(seconds: float) -> str:
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    ms = int((seconds % 1) * 1000)
+    return f"{h:02d}:{m:02d}:{s:02d}.{ms:03d}"
+
+
+@dataclass
+class _ActiveRequest:
+    sequence_id: int
+    text: str
+    sampler: HiggsSamplerState
+    delayed_rows: list[mx.array] = field(default_factory=list)
+
+
+class HiggsAudioV3BatchSession:
+    """Step-wise non-streaming Higgs Audio v3 batch session."""
+
+    def __init__(self, model, options: TTSBatchOptions):
+        self.model = model
+        self.options = options
+        self._pending: list[TTSBatchItem] = []
+        self._active: list[_ActiveRequest] = []
+        self._cache: Optional[list[BatchKVCache]] = None
+        self._last_hidden_batch: Optional[mx.array] = None
+        self._start_time = time.perf_counter()
+        self._step_count = 0
+
+    @property
+    def idle(self) -> bool:
+        return not self._pending and not self._active
+
+    @property
+    def available_slots(self) -> int:
+        return max(0, int(self.options.max_batch_size) - len(self._active))
+
+    def add(self, items: list[TTSBatchItem]) -> None:
+        self._pending.extend(items)
+
+    def cancel(self, sequence_id: int) -> None:
+        self._pending = [
+            item for item in self._pending if item.sequence_id != sequence_id
+        ]
+        keep_positions = [
+            index
+            for index, state in enumerate(self._active)
+            if state.sequence_id != sequence_id
+        ]
+        if len(keep_positions) == len(self._active):
+            return
+
+        self._active = [self._active[index] for index in keep_positions]
+        if not self._active:
+            self._cache = None
+            self._last_hidden_batch = None
+            return
+
+        keep = mx.array(keep_positions, dtype=mx.int32)
+        if self._cache is not None:
+            for layer_cache in self._cache:
+                layer_cache.filter(keep)
+        if self._last_hidden_batch is not None:
+            self._last_hidden_batch = self._last_hidden_batch[keep]
+            mx.eval(self._last_hidden_batch)
+
+    def step(self) -> list[TTSBatchEvent]:
+        events: list[TTSBatchEvent] = []
+        if self._active:
+            events.extend(self._advance_active())
+
+        if self.available_slots > 0 and self._pending:
+            events.extend(self._admit_pending())
+
+        self._step_count += 1
+        if self._step_count > 0 and self._step_count % 50 == 0:
+            mx.clear_cache()
+
+        return events
+
+    def _take_pending_batch(self) -> list[TTSBatchItem]:
+        batch_size = min(self.available_slots, len(self._pending))
+        batch = self._pending[:batch_size]
+        del self._pending[:batch_size]
+        return batch
+
+    def _admit_pending(self) -> list[TTSBatchEvent]:
+        pending = self._take_pending_batch()
+        if not pending:
+            return []
+
+        if self.options.max_tokens <= 0:
+            return [self._empty_event(item.sequence_id) for item in pending]
+
+        self._validate_items(pending)
+        references_by_sequence = self.model._normalize_batch_references(
+            batch_size=len(pending),
+            ref_audios=[item.ref_audio for item in pending],
+            ref_texts=[item.ref_text for item in pending],
+        )
+
+        prompt_embeddings = []
+        prompt_lengths = []
+        for item, references in zip(pending, references_by_sequence):
+            prompt_embeds, _prompt_tokens = self.model._build_prompt_embeddings(
+                item.text,
+                references,
+            )
+            mx.eval(prompt_embeds)
+            prompt_embeddings.append(prompt_embeds)
+            prompt_lengths.append(int(prompt_embeds.shape[1]))
+
+        max_prompt_length = max(prompt_lengths)
+        left_padding = [max_prompt_length - length for length in prompt_lengths]
+        padded_prompt_embeddings = []
+        for prompt_embeds, pad in zip(prompt_embeddings, left_padding):
+            if pad:
+                prompt_embeds = mx.pad(prompt_embeds, [(0, 0), (pad, 0), (0, 0)])
+            padded_prompt_embeddings.append(prompt_embeds)
+
+        prompt_batch = mx.concatenate(padded_prompt_embeddings, axis=0)
+        cache = self._make_batch_cache(left_padding)
+        dummy = mx.zeros((len(pending), max_prompt_length), dtype=mx.int32)
+        hidden = self.model.backbone(dummy, cache=cache, input_embeddings=prompt_batch)
+        last_hidden_batch = hidden[:, -1, :]
+        mx.eval(last_hidden_batch)
+
+        new_states = [
+            _ActiveRequest(
+                sequence_id=item.sequence_id,
+                text=item.text,
+                sampler=HiggsSamplerState(
+                    num_codebooks=self.model.config.audio_num_codebooks
+                ),
+            )
+            for item in pending
+        ]
+
+        if self._cache is None:
+            self._cache = cache
+            self._last_hidden_batch = last_hidden_batch
+        else:
+            self._eval_cache(self._cache)
+            self._eval_cache(cache)
+            active_rows = self._extract_batch_cache_rows(
+                self._cache,
+                len(self._active),
+            )
+            new_rows = self._extract_batch_cache_rows(cache, len(pending))
+            self._cache = [
+                BatchKVCache.merge(
+                    [
+                        *(row[layer_index] for row in active_rows),
+                        *(row[layer_index] for row in new_rows),
+                    ]
+                )
+                for layer_index in range(len(self._cache))
+            ]
+            self._last_hidden_batch = mx.concatenate(
+                [self._last_hidden_batch, last_hidden_batch],
+                axis=0,
+            )
+            mx.eval(self._last_hidden_batch)
+
+        self._active.extend(new_states)
+        return []
+
+    def _advance_active(self) -> list[TTSBatchEvent]:
+        if self._cache is None or self._last_hidden_batch is None:
+            return []
+
+        states = list(self._active)
+        batch_size = len(states)
+        logits_batch = self.model._audio_logits(self._last_hidden_batch)
+        sampled_rows = self.model._step_batch_sampler(
+            logits_batch,
+            [state.sampler for state in states],
+            temperature=float(self.options.temperature),
+            top_p=self.options.top_p,
+            top_k=self.options.top_k,
+        )
+
+        keep_positions = []
+        next_codes = []
+        events: list[TTSBatchEvent] = []
+        still_active: list[_ActiveRequest] = []
+        for index, (state, codes) in enumerate(zip(states, sampled_rows)):
+            state.delayed_rows.append(codes)
+            if (
+                state.sampler.generation_done
+                or len(state.delayed_rows) >= self.options.max_tokens
+            ):
+                events.append(self._decode_state(state))
+            else:
+                keep_positions.append(index)
+                next_codes.append(codes)
+                still_active.append(state)
+
+        if not still_active:
+            self._active = []
+            self._cache = None
+            self._last_hidden_batch = None
+            return events
+
+        if len(still_active) != batch_size:
+            keep = mx.array(keep_positions, dtype=mx.int32)
+            for layer_cache in self._cache:
+                layer_cache.filter(keep)
+
+        codes_batch = mx.stack(next_codes, axis=0)
+        next_embed = self.model._embed_audio_codes(codes_batch)[:, None, :]
+        decode_dummy = mx.zeros((len(still_active), 1), dtype=mx.int32)
+        hidden = self.model.backbone(
+            decode_dummy,
+            cache=self._cache,
+            input_embeddings=next_embed,
+        )
+        self._last_hidden_batch = hidden[:, -1, :]
+        mx.eval(self._last_hidden_batch)
+        self._active = still_active
+        return events
+
+    def _validate_items(self, items: list[TTSBatchItem]) -> None:
+        for item in items:
+            if item.voice is not None:
+                raise ValueError(
+                    "Higgs Audio v3 continuous batching does not support voices"
+                )
+            if item.instruct is not None:
+                raise ValueError(
+                    "Higgs Audio v3 continuous batching does not support instructs"
+                )
+            if item.gender not in (None, "male"):
+                raise ValueError(
+                    "Higgs Audio v3 continuous batching does not support gender"
+                )
+            if item.speed not in (None, 1.0) or item.pitch not in (None, 1.0):
+                raise ValueError(
+                    "Higgs Audio v3 continuous batching does not support speed or pitch"
+                )
+
+    def _make_batch_cache(self, left_padding: list[int]) -> list[BatchKVCache]:
+        return [BatchKVCache(left_padding) for _ in self.model.layers]
+
+    def _eval_cache(self, cache: list[BatchKVCache]) -> None:
+        arrays = []
+        for layer_cache in cache:
+            if layer_cache.keys is not None:
+                arrays.extend([layer_cache.keys, layer_cache.values])
+            arrays.extend([layer_cache.offset, layer_cache.left_padding])
+        if arrays:
+            mx.eval(*arrays)
+
+    def _extract_batch_cache_rows(
+        self,
+        cache: list[BatchKVCache],
+        batch_size: int,
+    ) -> list[list[object]]:
+        rows: list[list[object]] = [[] for _ in range(batch_size)]
+        for layer_cache in cache:
+            for index in range(batch_size):
+                rows[index].append(layer_cache.extract(index))
+        return rows
+
+    def _decode_state(self, state: _ActiveRequest) -> TTSBatchEvent:
+        audio = self.model._decode_audio(state.delayed_rows)
+        mx.eval(audio)
+        audio = self.model._apply_fades(
+            audio,
+            fade_in_ms=30.0,
+            fade_out_ms=15.0,
+        )
+        mx.eval(audio)
+        samples = int(audio.shape[0])
+        duration_s = samples / self.model.sample_rate if self.model.sample_rate else 0.0
+        return TTSBatchEvent(
+            sequence_id=state.sequence_id,
+            audio=audio,
+            sample_rate=self.model.sample_rate,
+            samples=samples,
+            token_count=len(state.delayed_rows),
+            done=True,
+            metadata={
+                "audio_duration": _format_duration(duration_s),
+                "processing_time_seconds": time.perf_counter() - self._start_time,
+                "peak_memory_usage": mx.get_peak_memory() / 1e9,
+            },
+        )
+
+    def _empty_event(self, sequence_id: int) -> TTSBatchEvent:
+        audio = mx.zeros((0,), dtype=mx.float32)
+        return TTSBatchEvent(
+            sequence_id=sequence_id,
+            audio=audio,
+            sample_rate=self.model.sample_rate,
+            samples=0,
+            token_count=0,
+            done=True,
+            metadata={
+                "audio_duration": _format_duration(0.0),
+                "processing_time_seconds": time.perf_counter() - self._start_time,
+                "peak_memory_usage": mx.get_peak_memory() / 1e9,
+            },
+        )

--- a/mlx_audio/tts/models/higgs_audio_v3/model.py
+++ b/mlx_audio/tts/models/higgs_audio_v3/model.py
@@ -537,6 +537,14 @@ class Model(nn.Module):
             return False
         return True
 
+    def supports_tts_continuous_batch(self, **kwargs) -> bool:
+        return self.supports_tts_batch(**kwargs)
+
+    def create_tts_batch_session(self, options):
+        from .continuous_batching import HiggsAudioV3BatchSession
+
+        return HiggsAudioV3BatchSession(self, options)
+
     def batch_generate(
         self,
         texts: list[str],

--- a/mlx_audio/tts/tests/test_higgs_audio_v3.py
+++ b/mlx_audio/tts/tests/test_higgs_audio_v3.py
@@ -3,6 +3,7 @@ import unittest
 import mlx.core as mx
 import numpy as np
 
+from mlx_audio.tts.continuous import TTSBatchItem, TTSBatchOptions
 from mlx_audio.tts.models.higgs_audio_v3.config import (
     HiggsAudioV3Config,
     HiggsAudioV3TextConfig,
@@ -343,6 +344,13 @@ class TestHiggsAudioV3Model(unittest.TestCase):
         self.assertFalse(model.supports_tts_batch(stream=True))
         self.assertFalse(model.supports_tts_batch(voice="speaker"))
         self.assertFalse(model.supports_tts_batch(speed=1.2))
+        self.assertTrue(
+            model.supports_tts_continuous_batch(
+                ref_audio=np.zeros(100, dtype=np.float32),
+                ref_text="Reference transcript.",
+            )
+        )
+        self.assertFalse(model.supports_tts_continuous_batch(stream=True))
 
     def test_batch_generate_reuses_shared_reference_audio(self):
         model = Model(_tiny_config())
@@ -435,6 +443,82 @@ class TestHiggsAudioV3Model(unittest.TestCase):
 
         with self.assertRaisesRegex(NotImplementedError, "batch streaming"):
             list(model.batch_generate(["text"], stream=True))
+
+    def test_continuous_batch_session_matches_serial(self):
+        model = Model(_tiny_config())
+        model._prompt_builder = HiggsAudioV3PromptBuilder(FakeTokenizer())
+        model._codec = FakeCodec()
+        mx.eval(model.parameters())
+
+        texts = [
+            "short",
+            "this is a much longer text input for the second batch item",
+        ]
+        ref_audio = np.zeros(100, dtype=np.float32)
+        ref_text = "Reference transcript."
+        common_kwargs = {
+            "ref_audio": ref_audio,
+            "ref_text": ref_text,
+            "max_new_tokens": 5,
+            "temperature": 0.0,
+            "top_k": 1,
+            "fade_in_ms": 30.0,
+            "fade_out_ms": 15.0,
+        }
+        serial = [next(model.generate(text, **common_kwargs)) for text in texts]
+
+        session = model.create_tts_batch_session(
+            TTSBatchOptions(
+                temperature=0.0,
+                top_p=None,
+                top_k=1,
+                max_tokens=5,
+                max_batch_size=2,
+            )
+        )
+        self.assertEqual(session.available_slots, 2)
+        session.add(
+            [
+                TTSBatchItem(
+                    sequence_id=index,
+                    text=text,
+                    ref_audio=ref_audio,
+                    ref_text=ref_text,
+                )
+                for index, text in enumerate(texts)
+            ]
+        )
+
+        events = []
+        while not session.idle:
+            events.extend(session.step())
+
+        events = sorted(events, key=lambda event: event.sequence_id)
+        self.assertEqual([event.sequence_id for event in events], [0, 1])
+        self.assertTrue(all(event.done for event in events))
+        self.assertEqual(
+            [event.token_count for event in events],
+            [result.token_count for result in serial],
+        )
+        self.assertEqual(
+            [event.samples for event in events],
+            [result.samples for result in serial],
+        )
+
+    def test_continuous_batch_session_rejects_streaming(self):
+        model = Model(_tiny_config())
+
+        self.assertFalse(model.supports_tts_continuous_batch(stream=True))
+
+    def test_continuous_batch_session_cancels_pending(self):
+        model = Model(_tiny_config())
+        session = model.create_tts_batch_session(TTSBatchOptions(max_tokens=5))
+
+        session.add([TTSBatchItem(sequence_id=1, text="cancel me")])
+        session.cancel(1)
+
+        self.assertTrue(session.idle)
+        self.assertEqual(session.step(), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Context

Higgs Audio v3 now has fixed-window batch generation, which is the ideal path when multiple compatible requests are already queued together. In real serving traffic, requests often arrive while another request is already decoding, so waiting for the current request to finish can leave throughput and tail latency on the table.

This PR adds Higgs Audio v3 support for the existing TTS continuous batching interface so compatible non-streaming requests can join an active decode session at step boundaries.

## Description

This implements a Higgs Audio v3 `TTSBatchSession` using the existing `mlx_audio.tts.continuous` interfaces:

- `TTSBatchOptions`
- `TTSBatchItem`
- `TTSBatchEvent`

The session keeps pending and active requests, admits new compatible requests when slots are available, and advances active sequences with batched AR decode. It uses a persistent `BatchKVCache` for active sequences and supports dynamic admission by rebuilding the active batch cache when new requests join an existing session.

The model exposes:

- `supports_tts_continuous_batch(...)`
- `create_tts_batch_session(...)`

This connects Higgs Audio v3 to the server's existing continuous batching path.

## Changes in the codebase

- Added `mlx_audio/tts/models/higgs_audio_v3/continuous_batching.py`.
- Added continuous batching hooks to the Higgs Audio v3 model.
- Added tests for:
  - continuous batch support checks
  - session output consistency with serial generation
  - streaming rejection
  - pending cancellation

## Changes outside the codebase

None.

## Benchmark

`bosonai/higgs-audio-v3-tts-4b`, batch size 4, same reference audio, greedy decoding.

### Ideal fixed-batch comparison

64 max tokens, 3 runs:

| mode | mean | speedup vs serial |
|---|---:|---:|
| serial | 7.595s | 1.00x |
| fixed batch | 4.068s | 1.87x |
| continuous static | 4.047s | 1.88x |
| continuous dynamic | 4.495s | 1.69x |

128 max tokens, 2 runs:

| mode | mean | speedup vs serial |
|---|---:|---:|
| serial | 17.497s | 1.00x |
| fixed batch | 9.961s | 1.76x |
| continuous static | 9.698s | 1.80x |
| continuous dynamic | 10.511s | 1.66x |

### Staggered-arrival serving benchmark

Real `InferenceBroker + TTSExecutionAdapter + Higgs v3` path. Request 1 arrives first; requests 2-4 arrive 0.5s later. 64 max tokens, 3 runs.

| mode | makespan mean | avg latency mean | max latency mean |
|---|---:|---:|---:|
| fixed-window batch | 5.677s | 4.355s | 5.172s |
| continuous batching | 4.407s | 3.982s | 4.224s |

Continuous batching improved makespan by **1.29x**, average latency by **8.6%**, and max latency by **18.3%** in this staggered-arrival scenario.

## Additional information

Fixed batch remains the best case when all compatible requests are already queued together. Continuous batching targets the more realistic serving case where compatible requests arrive while another request is already decoding.

Dynamic admission can change the exact batching schedule, so this PR does not claim bit-exact equivalence across different schedules. Outputs are valid and deterministic for the same batching schedule.

Validation run locally:

- `pre-commit run --files ...`
- `.venv/bin/python -m unittest mlx_audio.tts.tests.test_higgs_audio_v3 -v`
- `git diff --check`
- Real server adapter continuous wrapper smoke test

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Issue referenced