### PR TITLE
Point OmniVoice docs to the MLX-ready mlx-community/OmniVoice-bfloat16

### DIFF
--- a/mlx_audio/tts/models/omnivoice/README.md
+++ b/mlx_audio/tts/models/omnivoice/README.md
@@ -10,6 +10,7 @@ Architecture: bidirectional Qwen3-0.6B backbone with iterative masked diffusion 
 
 | Repo ID | Description |
 |---------|-------------|
+| `mlx-community/OmniVoice-bfloat16` | MLX-ready weights (bfloat16) — recommended |
 | `k2-fsa/OmniVoice` | Original weights (bfloat16) |
 
 ## Usage
@@ -18,12 +19,13 @@ Architecture: bidirectional Qwen3-0.6B backbone with iterative masked diffusion 
 
 ```python
 from transformers import AutoTokenizer
+from huggingface_hub import snapshot_download
 from mlx_audio.codec.models.higgs_audio.higgs_audio import HiggsAudioTokenizer
 from mlx_audio.tts.models.omnivoice.omnivoice import Model, OmniVoiceConfig
 from mlx_audio.audio_io import write as audio_write
 import mlx.core as mx, json, numpy as np
 
-model_path = "path/to/OmniVoice"
+model_path = snapshot_download("mlx-community/OmniVoice-bfloat16")
 
 # Load model
 with open(f"{model_path}/config.json") as f:
@@ -70,7 +72,7 @@ audio_write("output_cloned.wav", np.array(result.audio), result.sample_rate)
 
 ```bash
 python -m mlx_audio.tts.generate \
-  --model path/to/OmniVoice \
+  --model mlx-community/OmniVoice-bfloat16 \
   --text "Hello, this is OmniVoice." \
   --duration_s 5.0 \
   --language en


### PR DESCRIPTION
Per review feedback: keep strict tokenizer weight loading (so genuine weight mismatches are still surfaced) and instead update the OmniVoice docs to recommend the MLX-ready conversion `mlx-community/OmniVoice-bfloat16` (model table + Python/CLI examples).

Verified on Apple Silicon: that repo loads with strict loading and generates non-silent audio (`audio_tokenizer` loads, `max|amp| ≈ 0.998`, not all-zeros). Addresses #714.