### PR TITLE
Higgs audio 3 stt support

### DIFF
--- a/mlx_audio/stt/models/higgs_audio_3/README.md
+++ b/mlx_audio/stt/models/higgs_audio_3/README.md
@@ -1,0 +1,34 @@
+# Higgs-Audio v3 STT
+
+[Higgs-Audio v3 STT](https://huggingface.co/bosonai/higgs-audio-v3-stt) is a speech-to-text model from Boson AI that pairs a Whisper-style audio encoder with a Qwen3 text backbone for transcription.
+
+## Quick Start
+
+```python
+from mlx_audio.stt.utils import load_model
+
+model = load_model("bosonai/higgs-audio-v3-stt")
+
+result = model.generate("audio.wav")
+print(result.text)
+```
+
+## CLI
+
+```bash
+mlx_audio.stt.generate --model bosonai/higgs-audio-v3-stt --audio audio.wav
+```
+
+## Models
+
+| Model | Size | Quantization | HuggingFace |
+|-------|------|-------------|-------------|
+| higgs-audio-v3-stt | ~5.35GB | bf16 | [bosonai/higgs-audio-v3-stt](https://huggingface.co/bosonai/higgs-audio-v3-stt) |
+
+## Architecture
+
+- **Audio Encoder**: Whisper-style encoder (32 transformer layers, 1280-dim) + AvgPool1d
+- **Projector**: depthwise temporal Conv1d (stride 2) + 2-layer MLP with ReLU (1280 -> 2048)
+- **LLM**: Qwen3 (28 layers, 2048 hidden)
+
+Audio is converted to a 128-channel mel spectrogram at 16kHz, segmented with a Silero VAD into chunks of at most `chunk_size_seconds`, encoded and projected per chunk, and merged into the `<|AUDIO|>` placeholder positions of the text prompt before autoregressive generation. When the VAD is unavailable the audio is split into fixed-length chunks.

--- a/mlx_audio/stt/models/higgs_audio_3/__init__.py
+++ b/mlx_audio/stt/models/higgs_audio_3/__init__.py
@@ -1,0 +1,4 @@
+from .config import AudioEncoderConfig, ModelConfig, TextConfig
+from .higgs_audio_3 import Model
+
+__all__ = ["AudioEncoderConfig", "TextConfig", "ModelConfig", "Model"]

--- a/mlx_audio/stt/models/higgs_audio_3/audio.py
+++ b/mlx_audio/stt/models/higgs_audio_3/audio.py
@@ -1,0 +1,41 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_audio.utils import hanning, mel_filters, stft
+
+SAMPLE_RATE = 16000
+N_FFT = 400
+HOP_LENGTH = 160
+
+
+class AudioFeatureExtractor(nn.Module):
+    def __init__(
+        self,
+        num_mel_bins: int = 128,
+        sample_rate: int = SAMPLE_RATE,
+        n_fft: int = N_FFT,
+        hop_length: int = HOP_LENGTH,
+    ):
+        super().__init__()
+        self.num_mel_bins = num_mel_bins
+        self.sample_rate = sample_rate
+        self.n_fft = n_fft
+        self.hop_length = hop_length
+
+    def __call__(self, audio: mx.array) -> mx.array:
+        audio = audio.reshape(-1).astype(mx.float32)
+        window = hanning(self.n_fft)
+        freqs = stft(audio, window=window, n_fft=self.n_fft, hop_length=self.hop_length)
+        magnitudes = freqs[:-1, :].abs().square()
+        filters = mel_filters(
+            self.sample_rate,
+            self.n_fft,
+            self.num_mel_bins,
+            norm="slaney",
+            mel_scale=None,
+        )
+        mel_spec = magnitudes @ filters.T
+        log_spec = mx.maximum(mel_spec, 1e-10).log10()
+        log_spec = mx.maximum(log_spec, log_spec.max() - 8.0)
+        log_spec = (log_spec + 4.0) / 4.0
+        return log_spec.T[None]

--- a/mlx_audio/stt/models/higgs_audio_3/config.py
+++ b/mlx_audio/stt/models/higgs_audio_3/config.py
@@ -1,10 +1,11 @@
-import inspect
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
+from mlx_audio.base import BaseModelArgs
+
 
 @dataclass
-class AudioEncoderConfig:
+class AudioEncoderConfig(BaseModelArgs):
     num_mel_bins: int = 128
     encoder_layers: int = 32
     encoder_attention_heads: int = 20
@@ -18,19 +19,9 @@ class AudioEncoderConfig:
     frame_rate: int = 25
     model_type: str = "higgs_audio_encoder"
 
-    @classmethod
-    def from_dict(cls, params: Dict[str, Any]) -> "AudioEncoderConfig":
-        return cls(
-            **{
-                k: v
-                for k, v in params.items()
-                if k in inspect.signature(cls).parameters
-            }
-        )
-
 
 @dataclass
-class TextConfig:
+class TextConfig(BaseModelArgs):
     model_type: str = "qwen3"
     vocab_size: int = 151936
     hidden_size: int = 2048
@@ -48,19 +39,9 @@ class TextConfig:
     attention_dropout: float = 0.0
     tie_word_embeddings: bool = True
 
-    @classmethod
-    def from_dict(cls, params: Dict[str, Any]) -> "TextConfig":
-        return cls(
-            **{
-                k: v
-                for k, v in params.items()
-                if k in inspect.signature(cls).parameters
-            }
-        )
-
 
 @dataclass
-class ModelConfig:
+class ModelConfig(BaseModelArgs):
     audio_encoder_config: AudioEncoderConfig = field(default_factory=AudioEncoderConfig)
     text_config: TextConfig = field(default_factory=TextConfig)
     model_type: str = "higgs_audio_3"
@@ -81,24 +62,9 @@ class ModelConfig:
     split_vads: bool = False
 
     def __post_init__(self):
-        if self.audio_encoder_config is None:
-            self.audio_encoder_config = AudioEncoderConfig()
-        elif isinstance(self.audio_encoder_config, dict):
+        if isinstance(self.audio_encoder_config, dict):
             self.audio_encoder_config = AudioEncoderConfig.from_dict(
                 self.audio_encoder_config
             )
-
-        if self.text_config is None:
-            self.text_config = TextConfig()
-        elif isinstance(self.text_config, dict):
+        if isinstance(self.text_config, dict):
             self.text_config = TextConfig.from_dict(self.text_config)
-
-    @classmethod
-    def from_dict(cls, params: Dict[str, Any]) -> "ModelConfig":
-        return cls(
-            **{
-                k: v
-                for k, v in params.items()
-                if k in inspect.signature(cls).parameters
-            }
-        )

--- a/mlx_audio/stt/models/higgs_audio_3/config.py
+++ b/mlx_audio/stt/models/higgs_audio_3/config.py
@@ -1,0 +1,102 @@
+import inspect
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class AudioEncoderConfig:
+    num_mel_bins: int = 128
+    encoder_layers: int = 32
+    encoder_attention_heads: int = 20
+    encoder_ffn_dim: int = 5120
+    d_model: int = 1280
+    dropout: float = 0.0
+    attention_dropout: float = 0.0
+    activation_function: str = "gelu"
+    scale_embedding: bool = False
+    max_source_positions: int = 1500
+    frame_rate: int = 25
+    model_type: str = "higgs_audio_encoder"
+
+    @classmethod
+    def from_dict(cls, params: Dict[str, Any]) -> "AudioEncoderConfig":
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )
+
+
+@dataclass
+class TextConfig:
+    model_type: str = "qwen3"
+    vocab_size: int = 151936
+    hidden_size: int = 2048
+    intermediate_size: int = 6144
+    num_hidden_layers: int = 28
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    hidden_act: str = "silu"
+    max_position_embeddings: int = 32768
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1000000.0
+    rope_scaling: Optional[Dict[str, Any]] = None
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    tie_word_embeddings: bool = True
+
+    @classmethod
+    def from_dict(cls, params: Dict[str, Any]) -> "TextConfig":
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )
+
+
+@dataclass
+class ModelConfig:
+    audio_encoder_config: AudioEncoderConfig = None
+    text_config: TextConfig = None
+    model_type: str = "higgs_audio_3"
+    model_path: str = None
+    audio_adapter_type: str = "stack"
+    projector_type: str = "mlp"
+    projector_temporal_downsample: int = 2
+    audio_num_codebooks: int = 1
+    audio_codebook_size: int = 1
+    audio_in_token_idx: int = 151672
+    audio_out_token_idx: int = 151673
+    audio_bos_token_id: int = 151669
+    audio_eos_token_id: int = 151670
+    chunk_size_seconds: float = 4.0
+    pad_token_id: int = 151643
+    sample_rate: int = 16000
+
+    def __post_init__(self):
+        if self.audio_encoder_config is None:
+            self.audio_encoder_config = AudioEncoderConfig()
+        elif isinstance(self.audio_encoder_config, dict):
+            self.audio_encoder_config = AudioEncoderConfig.from_dict(
+                self.audio_encoder_config
+            )
+
+        if self.text_config is None:
+            self.text_config = TextConfig()
+        elif isinstance(self.text_config, dict):
+            self.text_config = TextConfig.from_dict(self.text_config)
+
+    @classmethod
+    def from_dict(cls, params: Dict[str, Any]) -> "ModelConfig":
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )

--- a/mlx_audio/stt/models/higgs_audio_3/config.py
+++ b/mlx_audio/stt/models/higgs_audio_3/config.py
@@ -1,5 +1,5 @@
 import inspect
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 
@@ -61,10 +61,10 @@ class TextConfig:
 
 @dataclass
 class ModelConfig:
-    audio_encoder_config: AudioEncoderConfig = None
-    text_config: TextConfig = None
+    audio_encoder_config: AudioEncoderConfig = field(default_factory=AudioEncoderConfig)
+    text_config: TextConfig = field(default_factory=TextConfig)
     model_type: str = "higgs_audio_3"
-    model_path: str = None
+    model_path: Optional[str] = None
     audio_adapter_type: str = "stack"
     projector_type: str = "mlp"
     projector_temporal_downsample: int = 2
@@ -77,6 +77,8 @@ class ModelConfig:
     chunk_size_seconds: float = 4.0
     pad_token_id: int = 151643
     sample_rate: int = 16000
+    vad_cut: bool = True
+    split_vads: bool = False
 
     def __post_init__(self):
         if self.audio_encoder_config is None:

--- a/mlx_audio/stt/models/higgs_audio_3/higgs_audio_3.py
+++ b/mlx_audio/stt/models/higgs_audio_3/higgs_audio_3.py
@@ -12,6 +12,7 @@ from mlx_lm.models.qwen3 import Qwen3Model
 
 from mlx_audio.stt.models.base import STTOutput
 
+from .audio import AudioFeatureExtractor
 from .config import AudioEncoderConfig, ModelConfig
 
 DEFAULT_PROMPT = "Transcribe the speech. Output only the spoken words in lowercase with no punctuation."
@@ -153,38 +154,11 @@ class Model(nn.Module):
         )
 
         self.audio_in_token_idx = config.audio_in_token_idx
-        self._processor = None
+        self.feature_extractor = AudioFeatureExtractor(
+            num_mel_bins=config.audio_encoder_config.num_mel_bins,
+            sample_rate=config.sample_rate,
+        )
         self._vad_backend = None
-        self._init_mel_constants()
-
-    def _init_mel_constants(self) -> None:
-        n_mels = self.config.audio_encoder_config.num_mel_bins
-        n_fft = 400
-        hop_length = 160
-        sample_rate = self.config.sample_rate
-
-        self._mel_n_fft = n_fft
-        self._mel_hop_length = hop_length
-        self._mel_window = np.hanning(n_fft + 1)[:-1].astype(np.float32)
-
-        fmax = sample_rate / 2.0
-        n_freqs = n_fft // 2 + 1
-        mel_max = 2595.0 * np.log10(1.0 + fmax / 700.0)
-        mel_points = np.linspace(0.0, mel_max, n_mels + 2)
-        hz_points = 700.0 * (10.0 ** (mel_points / 2595.0) - 1.0)
-        bin_points = np.floor((n_fft + 1) * hz_points / sample_rate).astype(int)
-
-        f = np.arange(n_freqs, dtype=np.float32)
-        filterbank = np.zeros((n_mels, n_freqs), dtype=np.float32)
-        for m in range(1, n_mels + 1):
-            lower, center, upper = bin_points[m - 1], bin_points[m], bin_points[m + 1]
-            if center > lower:
-                mask = (f >= lower) & (f < center)
-                filterbank[m - 1, mask] = (f[mask] - lower) / (center - lower)
-            if upper > center:
-                mask = (f >= center) & (f < upper)
-                filterbank[m - 1, mask] = (upper - f[mask]) / (upper - center)
-        self._mel_filterbank = filterbank
 
     @property
     def layers(self):
@@ -250,7 +224,7 @@ class Model(nn.Module):
     @classmethod
     def post_load_hook(cls, model: "Model", model_path: Path) -> "Model":
         import transformers
-        from transformers import AutoTokenizer, WhisperFeatureExtractor
+        from transformers import AutoTokenizer
 
         prev = transformers.logging.get_verbosity()
         transformers.logging.set_verbosity_error()
@@ -258,33 +232,13 @@ class Model(nn.Module):
             model._tokenizer = AutoTokenizer.from_pretrained(
                 str(model_path), trust_remote_code=True
             )
-            model._feature_extractor = WhisperFeatureExtractor(
-                feature_size=model.config.audio_encoder_config.num_mel_bins
-            )
         finally:
             transformers.logging.set_verbosity(prev)
         return model
 
-    def _extract_features(self, wav: np.ndarray) -> mx.array:
-        n_fft = self._mel_n_fft
-        hop_length = self._mel_hop_length
-        pad = n_fft // 2
-        audio = np.pad(wav.astype(np.float32), (pad, pad), mode="reflect")
-        n_frames = (len(audio) - n_fft) // hop_length + 1
-        frames = np.lib.stride_tricks.as_strided(
-            audio,
-            shape=(n_frames, n_fft),
-            strides=(audio.strides[0] * hop_length, audio.strides[0]),
-        ).copy()
-        windowed = frames * self._mel_window[np.newaxis, :]
-        spec = np.fft.rfft(windowed, n=n_fft)
-        power = spec.real**2 + spec.imag**2
-        mel_spec = power @ self._mel_filterbank.T
-        log_mel = np.log10(np.clip(mel_spec, 1e-10, None))
-        log_mel = np.maximum(log_mel, log_mel.max() - 8.0)
-        log_mel = (log_mel + 4.0) / 4.0
+    def _extract_features(self, wav: mx.array) -> mx.array:
         dtype = self.audio_tower.conv1.weight.dtype
-        return mx.array(log_mel.T[np.newaxis], dtype=dtype)
+        return self.feature_extractor(wav).astype(dtype)
 
     def _get_vad_backend(self):
         if self._vad_backend is None:
@@ -317,7 +271,8 @@ class Model(nn.Module):
         for c in chunks:
             if len(c) < max_frames:
                 c = np.pad(c, (0, max_frames - len(c)))
-            feature_list.append(self.get_audio_features(self._extract_features(c)))
+            mel = self._extract_features(mx.array(c, dtype=mx.float32))
+            feature_list.append(self.get_audio_features(mel))
 
         tok = self._tokenizer
 
@@ -386,10 +341,8 @@ class Model(nn.Module):
         from mlx_lm.generate import generate_step
         from mlx_lm.sample_utils import make_logits_processors, make_sampler
 
-        if not hasattr(self, "_tokenizer") or not hasattr(self, "_feature_extractor"):
-            raise RuntimeError(
-                "Tokenizer/FeatureExtractor not initialized. Call post_load_hook first."
-            )
+        if not hasattr(self, "_tokenizer"):
+            raise RuntimeError("Tokenizer not initialized. Call post_load_hook first.")
 
         start_time = time.time()
         input_ids, inputs_embeds, prompt_tokens = self.get_input_embeddings(

--- a/mlx_audio/stt/models/higgs_audio_3/higgs_audio_3.py
+++ b/mlx_audio/stt/models/higgs_audio_3/higgs_audio_3.py
@@ -1,0 +1,434 @@
+import re
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from mlx_lm.models.cache import KVCache
+from mlx_lm.models.qwen3 import ModelArgs as Qwen3Args
+from mlx_lm.models.qwen3 import Qwen3Model
+
+from mlx_audio.stt.models.base import STTOutput
+
+from .config import AudioEncoderConfig, ModelConfig
+
+DEFAULT_PROMPT = "Transcribe the speech. Output only the spoken words in lowercase with no punctuation."
+
+
+class AudioAttention(nn.Module):
+    def __init__(self, config: AudioEncoderConfig):
+        super().__init__()
+        self.embed_dim = config.d_model
+        self.num_heads = config.encoder_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        self.scaling = self.head_dim**-0.5
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        B, T, _ = x.shape
+        q = self.q_proj(x) * self.scaling
+        k = self.k_proj(x)
+        v = self.v_proj(x)
+        q = q.reshape(B, T, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = k.reshape(B, T, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(B, T, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=1.0)
+        out = out.transpose(0, 2, 1, 3).reshape(B, T, self.embed_dim)
+        return self.out_proj(out)
+
+
+class AudioEncoderLayer(nn.Module):
+    def __init__(self, config: AudioEncoderConfig):
+        super().__init__()
+        self.embed_dim = config.d_model
+        self.self_attn = AudioAttention(config)
+        self.self_attn_layer_norm = nn.LayerNorm(self.embed_dim)
+        self.fc1 = nn.Linear(self.embed_dim, config.encoder_ffn_dim)
+        self.fc2 = nn.Linear(config.encoder_ffn_dim, self.embed_dim)
+        self.final_layer_norm = nn.LayerNorm(self.embed_dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        residual = x
+        x = self.self_attn_layer_norm(x)
+        x = self.self_attn(x)
+        x = residual + x
+
+        residual = x
+        x = self.final_layer_norm(x)
+        x = nn.gelu(self.fc1(x))
+        x = self.fc2(x)
+        x = residual + x
+        return x
+
+
+class HiggsAudioEncoder(nn.Module):
+    def __init__(self, config: AudioEncoderConfig):
+        super().__init__()
+        self.config = config
+        embed_dim = config.d_model
+        self.conv1 = nn.Conv1d(config.num_mel_bins, embed_dim, kernel_size=3, padding=1)
+        self.conv2 = nn.Conv1d(embed_dim, embed_dim, kernel_size=3, stride=2, padding=1)
+        self.embed_positions = nn.Embedding(config.max_source_positions, embed_dim)
+        self.layers = [AudioEncoderLayer(config) for _ in range(config.encoder_layers)]
+        self.layer_norm = nn.LayerNorm(embed_dim)
+
+    def __call__(self, input_features: mx.array) -> mx.array:
+        x = input_features.transpose(0, 2, 1)
+        x = nn.gelu(self.conv1(x))
+        x = nn.gelu(self.conv2(x))
+
+        T = x.shape[1]
+        x = x + self.embed_positions.weight[:T][None]
+
+        for layer in self.layers:
+            x = layer(x)
+
+        B, seq_len, D = x.shape
+        x = x[:, : (seq_len // 2) * 2, :].reshape(B, seq_len // 2, 2, D).mean(axis=2)
+        x = self.layer_norm(x)
+        return x
+
+
+class HiggsAudioFeatureProjector(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        audio_dim = config.audio_encoder_config.d_model
+        llm_hidden = config.text_config.hidden_size
+        self.stride = config.projector_temporal_downsample
+        if self.stride > 1:
+            self.temporal = nn.Conv1d(
+                audio_dim,
+                audio_dim,
+                kernel_size=3,
+                stride=2,
+                padding=1,
+                groups=audio_dim,
+                bias=True,
+            )
+        self.linear1 = nn.Linear(audio_dim, 2048, bias=True)
+        self.linear2 = nn.Linear(2048, llm_hidden, bias=True)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        if self.stride > 1:
+            x = self.temporal(x)
+        x = self.linear1(x)
+        x = nn.relu(x)
+        return self.linear2(x)
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.audio_tower = HiggsAudioEncoder(config.audio_encoder_config)
+        self.audio_encoder_proj = HiggsAudioFeatureProjector(config)
+
+        text_args = Qwen3Args.from_dict(
+            {
+                "model_type": "qwen3",
+                "hidden_size": config.text_config.hidden_size,
+                "num_hidden_layers": config.text_config.num_hidden_layers,
+                "intermediate_size": config.text_config.intermediate_size,
+                "num_attention_heads": config.text_config.num_attention_heads,
+                "num_key_value_heads": config.text_config.num_key_value_heads,
+                "head_dim": config.text_config.head_dim,
+                "rms_norm_eps": config.text_config.rms_norm_eps,
+                "vocab_size": config.text_config.vocab_size,
+                "max_position_embeddings": config.text_config.max_position_embeddings,
+                "rope_theta": config.text_config.rope_theta,
+                "rope_scaling": config.text_config.rope_scaling,
+                "tie_word_embeddings": False,
+            }
+        )
+        self.model = Qwen3Model(text_args)
+        self.lm_head = nn.Linear(
+            config.text_config.hidden_size,
+            config.text_config.vocab_size,
+            bias=False,
+        )
+
+        self.audio_in_token_idx = config.audio_in_token_idx
+        self._processor = None
+        self._init_mel_constants()
+
+    def _init_mel_constants(self) -> None:
+        n_mels = self.config.audio_encoder_config.num_mel_bins
+        n_fft = 400
+        hop_length = 160
+        sample_rate = self.config.sample_rate
+
+        self._mel_n_fft = n_fft
+        self._mel_hop_length = hop_length
+        self._mel_window = np.hanning(n_fft + 1)[:-1].astype(np.float32)
+
+        fmax = sample_rate / 2.0
+        n_freqs = n_fft // 2 + 1
+        mel_max = 2595.0 * np.log10(1.0 + fmax / 700.0)
+        mel_points = np.linspace(0.0, mel_max, n_mels + 2)
+        hz_points = 700.0 * (10.0 ** (mel_points / 2595.0) - 1.0)
+        bin_points = np.floor((n_fft + 1) * hz_points / sample_rate).astype(int)
+
+        f = np.arange(n_freqs, dtype=np.float32)
+        filterbank = np.zeros((n_mels, n_freqs), dtype=np.float32)
+        for m in range(1, n_mels + 1):
+            lower, center, upper = bin_points[m - 1], bin_points[m], bin_points[m + 1]
+            if center > lower:
+                mask = (f >= lower) & (f < center)
+                filterbank[m - 1, mask] = (f[mask] - lower) / (center - lower)
+            if upper > center:
+                mask = (f >= center) & (f < upper)
+                filterbank[m - 1, mask] = (upper - f[mask]) / (upper - center)
+        self._mel_filterbank = filterbank
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def sample_rate(self) -> int:
+        return self.config.sample_rate
+
+    def make_cache(self) -> List[KVCache]:
+        return [KVCache() for _ in range(len(self.layers))]
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[List[KVCache]] = None,
+        input_embeddings: Optional[mx.array] = None,
+    ) -> mx.array:
+        out = self.model(inputs, cache=cache, input_embeddings=input_embeddings)
+        return self.lm_head(out)
+
+    def get_audio_features(self, mel: mx.array) -> mx.array:
+        encoded = self.audio_tower(mel)
+        projected = self.audio_encoder_proj(encoded)
+        lm_dtype = self.model.embed_tokens.weight.dtype
+        return projected.astype(lm_dtype)
+
+    def model_quant_predicate(self, p: str, m: nn.Module) -> bool:
+        return not (p.startswith("audio_tower") or p.startswith("audio_encoder_proj"))
+
+    @staticmethod
+    def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        already_converted = any("scales" in k for k in weights)
+        sanitized = {}
+        for k, v in weights.items():
+            if k.startswith("audio_codebook_embeddings") or k.startswith(
+                "audio_decoder_proj.audio_lm_head"
+            ):
+                continue
+
+            if k == "audio_decoder_proj.text_lm_head.weight":
+                sanitized["lm_head.weight"] = v
+                continue
+
+            if k == "embed_tokens.weight":
+                sanitized["model.embed_tokens.weight"] = v
+                continue
+            if k == "norm.weight":
+                sanitized["model.norm.weight"] = v
+                continue
+            if k.startswith("layers."):
+                k = "model." + k
+
+            if not already_converted and "weight" in k and v.ndim == 3:
+                if "audio_tower.conv" in k:
+                    v = v.transpose(0, 2, 1)
+                elif "audio_encoder_proj.temporal" in k:
+                    v = v.transpose(0, 2, 1)
+
+            sanitized[k] = v
+        return sanitized
+
+    @classmethod
+    def post_load_hook(cls, model: "Model", model_path: Path) -> "Model":
+        import transformers
+        from transformers import AutoTokenizer, WhisperFeatureExtractor
+
+        prev = transformers.logging.get_verbosity()
+        transformers.logging.set_verbosity_error()
+        try:
+            model._tokenizer = AutoTokenizer.from_pretrained(
+                str(model_path), trust_remote_code=True
+            )
+            model._feature_extractor = WhisperFeatureExtractor(
+                feature_size=model.config.audio_encoder_config.num_mel_bins
+            )
+        finally:
+            transformers.logging.set_verbosity(prev)
+        return model
+
+    def _extract_features(self, wav: np.ndarray) -> mx.array:
+        n_fft = self._mel_n_fft
+        hop_length = self._mel_hop_length
+        pad = n_fft // 2
+        audio = np.pad(wav.astype(np.float32), (pad, pad), mode="reflect")
+        n_frames = (len(audio) - n_fft) // hop_length + 1
+        frames = np.lib.stride_tricks.as_strided(
+            audio,
+            shape=(n_frames, n_fft),
+            strides=(audio.strides[0] * hop_length, audio.strides[0]),
+        ).copy()
+        windowed = frames * self._mel_window[np.newaxis, :]
+        spec = np.fft.rfft(windowed, n=n_fft)
+        power = spec.real**2 + spec.imag**2
+        mel_spec = power @ self._mel_filterbank.T
+        log_mel = np.log10(np.clip(mel_spec, 1e-10, None))
+        log_mel = np.maximum(log_mel, log_mel.max() - 8.0)
+        log_mel = (log_mel + 4.0) / 4.0
+        dtype = self.audio_tower.conv1.weight.dtype
+        return mx.array(log_mel.T[np.newaxis], dtype=dtype)
+
+    def _chunk_waveform(self, wav: np.ndarray) -> List[np.ndarray]:
+        chunk = int(self.config.chunk_size_seconds * self.sample_rate)
+        if len(wav) <= chunk:
+            return [wav]
+        chunks = []
+        pos = 0
+        while pos < len(wav):
+            chunks.append(wav[pos : pos + chunk])
+            pos += chunk
+        return chunks
+
+    def get_input_embeddings(
+        self,
+        audio: Union[str, mx.array, np.ndarray],
+        user_prompt: str = DEFAULT_PROMPT,
+        verbose: bool = False,
+    ) -> Tuple[List[int], mx.array, int]:
+        wav = self._load_audio(audio)
+        chunks = self._chunk_waveform(wav)
+
+        max_frames = max(len(c) for c in chunks)
+        feature_list = []
+        for c in chunks:
+            if len(c) < max_frames:
+                c = np.pad(c, (0, max_frames - len(c)))
+            feature_list.append(self.get_audio_features(self._extract_features(c)))
+
+        tok = self._tokenizer
+
+        def enc(s):
+            return tok.encode(s, add_special_tokens=False)
+
+        prefix = enc("<|im_start|>user\n") + enc(user_prompt) + enc("<|audio_bos|>")
+        suffix = (
+            enc("<|audio_eos|>") + enc("<|im_end|>\n") + enc("<|im_start|>assistant\n")
+        )
+        audio_ids = [self.audio_in_token_idx] * len(chunks)
+        input_ids = prefix + audio_ids + suffix
+
+        text_embeds = self.model.embed_tokens(mx.array(input_ids)[None])
+        dtype = text_embeds.dtype
+
+        segments = [text_embeds[:, : len(prefix), :]]
+        for feat in feature_list:
+            segments.append(feat.astype(dtype))
+        segments.append(text_embeds[:, len(prefix) + len(chunks) :, :])
+        inputs_embeds = mx.concatenate(segments, axis=1)
+        mx.eval(inputs_embeds)
+
+        prompt_len = inputs_embeds.shape[1]
+        return input_ids, inputs_embeds, prompt_len
+
+    def _load_single_audio(self, audio: Union[str, mx.array, np.ndarray]) -> np.ndarray:
+        if isinstance(audio, str):
+            from mlx_audio.stt.utils import load_audio
+
+            return np.array(load_audio(audio), dtype=np.float32)
+        if isinstance(audio, mx.array):
+            return np.array(audio, dtype=np.float32)
+        return np.asarray(audio, dtype=np.float32)
+
+    def _load_audio(self, audio: Union[str, mx.array, np.ndarray, List]) -> np.ndarray:
+        if isinstance(audio, list):
+            audio = audio[0]
+        wav = self._load_single_audio(audio)
+        return wav.reshape(-1)
+
+    @staticmethod
+    def _parse_output(text: str) -> str:
+        text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+        if "<think>" in text:
+            text = text[text.index("<think>") + len("<think>") :]
+        text = re.sub(r"<\|.*?\|>", "", text)
+        return text.strip()
+
+    def generate(
+        self,
+        audio: Union[str, mx.array, np.ndarray, List],
+        *,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        top_k: int = 0,
+        min_p: float = 0.0,
+        repetition_penalty: Optional[float] = None,
+        repetition_context_size: int = 100,
+        prompt: str = DEFAULT_PROMPT,
+        prefill_step_size: int = 2048,
+        verbose: bool = False,
+        **kwargs,
+    ) -> STTOutput:
+        from mlx_lm.generate import generate_step
+        from mlx_lm.sample_utils import make_logits_processors, make_sampler
+
+        if not hasattr(self, "_tokenizer") or not hasattr(self, "_feature_extractor"):
+            raise RuntimeError(
+                "Tokenizer/FeatureExtractor not initialized. Call post_load_hook first."
+            )
+
+        start_time = time.time()
+        input_ids, inputs_embeds, prompt_tokens = self.get_input_embeddings(
+            audio, prompt, verbose
+        )
+        prefill_time = time.time() - start_time
+
+        sampler = make_sampler(temperature, top_p=top_p, min_p=min_p, top_k=top_k)
+        logits_processors = (
+            make_logits_processors(
+                repetition_penalty=repetition_penalty,
+                repetition_context_size=repetition_context_size,
+            )
+            if repetition_penalty
+            else None
+        )
+
+        eos_token_ids = {151645, 151643}
+        tokens = []
+        gen_start = time.time()
+        for token, _ in generate_step(
+            prompt=mx.array([], dtype=mx.int32),
+            input_embeddings=inputs_embeds.squeeze(0),
+            model=self,
+            max_tokens=max_tokens,
+            sampler=sampler,
+            logits_processors=logits_processors,
+            prefill_step_size=prefill_step_size,
+        ):
+            if token in eos_token_ids:
+                break
+            tokens.append(int(token))
+
+        full_text = self._tokenizer.decode(tokens, skip_special_tokens=False)
+        text = self._parse_output(full_text)
+        elapsed = time.time() - start_time
+        gen_time = time.time() - gen_start
+        gen_tokens = len(tokens)
+
+        return STTOutput(
+            text=text,
+            segments=[{"start": 0.0, "end": elapsed, "text": text}],
+            prompt_tokens=prompt_tokens,
+            generation_tokens=gen_tokens,
+            total_tokens=prompt_tokens + gen_tokens,
+            total_time=elapsed,
+            prompt_tps=prompt_tokens / prefill_time if prefill_time > 0 else 0,
+            generation_tps=gen_tokens / gen_time if gen_time > 0 else 0,
+        )

--- a/mlx_audio/stt/models/higgs_audio_3/higgs_audio_3.py
+++ b/mlx_audio/stt/models/higgs_audio_3/higgs_audio_3.py
@@ -154,6 +154,7 @@ class Model(nn.Module):
 
         self.audio_in_token_idx = config.audio_in_token_idx
         self._processor = None
+        self._vad_backend = None
         self._init_mel_constants()
 
     def _init_mel_constants(self) -> None:
@@ -285,16 +286,22 @@ class Model(nn.Module):
         dtype = self.audio_tower.conv1.weight.dtype
         return mx.array(log_mel.T[np.newaxis], dtype=dtype)
 
+    def _get_vad_backend(self):
+        if self._vad_backend is None:
+            from .vad import SileroVADBackend
+
+            self._vad_backend = SileroVADBackend(sample_rate=self.sample_rate)
+        return self._vad_backend
+
     def _chunk_waveform(self, wav: np.ndarray) -> List[np.ndarray]:
+        from .vad import vad_chunk_ranges
+
         chunk = int(self.config.chunk_size_seconds * self.sample_rate)
-        if len(wav) <= chunk:
-            return [wav]
-        chunks = []
-        pos = 0
-        while pos < len(wav):
-            chunks.append(wav[pos : pos + chunk])
-            pos += chunk
-        return chunks
+        backend = self._get_vad_backend() if self.config.vad_cut else None
+        ranges = vad_chunk_ranges(
+            wav, chunk, backend=backend, split_vads=self.config.split_vads
+        )
+        return [wav[s:e] for s, e in ranges]
 
     def get_input_embeddings(
         self,

--- a/mlx_audio/stt/models/higgs_audio_3/vad.py
+++ b/mlx_audio/stt/models/higgs_audio_3/vad.py
@@ -1,0 +1,88 @@
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+DEFAULT_SILERO_REPO = "mlx-community/silero-vad"
+
+
+class SileroVADBackend:
+    def __init__(
+        self,
+        sample_rate: int = 16000,
+        repo_id: str = DEFAULT_SILERO_REPO,
+        threshold: float = 0.5,
+        min_speech_duration_ms: int = 250,
+        min_silence_duration_ms: int = 100,
+        speech_pad_ms: int = 30,
+    ) -> None:
+        self.sample_rate = sample_rate
+        self.repo_id = repo_id
+        self.threshold = threshold
+        self.min_speech_duration_ms = min_speech_duration_ms
+        self.min_silence_duration_ms = min_silence_duration_ms
+        self.speech_pad_ms = speech_pad_ms
+        self._model = None
+
+    def _load(self):
+        from mlx_audio.vad import load as load_vad
+
+        self._model = load_vad(self.repo_id)
+        return self._model
+
+    def speech_ranges(self, wav: np.ndarray) -> List[Tuple[int, int]]:
+        model = self._model if self._model is not None else self._load()
+        timestamps = model.get_speech_timestamps(
+            wav.astype(np.float32),
+            sample_rate=self.sample_rate,
+            threshold=self.threshold,
+            min_speech_duration_ms=self.min_speech_duration_ms,
+            min_silence_duration_ms=self.min_silence_duration_ms,
+            speech_pad_ms=self.speech_pad_ms,
+            return_seconds=False,
+        )
+        ranges = [(int(t["start"]), int(t["end"])) for t in timestamps]
+        return [(s, e) for s, e in ranges if e > s]
+
+
+def _split_long(start: int, end: int, max_samples: int) -> List[Tuple[int, int]]:
+    out = []
+    pos = start
+    while pos < end:
+        nxt = min(end, pos + max_samples)
+        out.append((pos, nxt))
+        pos = nxt
+    return out
+
+
+def vad_chunk_ranges(
+    wav: np.ndarray,
+    chunk_samples: int,
+    backend: Optional[SileroVADBackend] = None,
+    split_vads: bool = False,
+) -> List[Tuple[int, int]]:
+    total = len(wav)
+    cuts: List[Tuple[int, int]] = []
+    if backend is not None:
+        try:
+            cuts = backend.speech_ranges(wav)
+        except Exception:
+            cuts = []
+    if not cuts:
+        return _split_long(0, total, chunk_samples)
+
+    if split_vads:
+        wv_chunks = list(cuts)
+    else:
+        wv_chunks = []
+        prev_e = 0
+        for idx, (start, end) in enumerate(cuts):
+            s = min(prev_e, start)
+            e = total if idx == len(cuts) - 1 else end
+            if e > s:
+                wv_chunks.append((s, e))
+            prev_e = e
+
+    out: List[Tuple[int, int]] = []
+    for s, e in wv_chunks:
+        out.extend(_split_long(s, e, chunk_samples))
+    return out or _split_long(0, total, chunk_samples)

--- a/mlx_audio/stt/tests/test_higgs_audio_3.py
+++ b/mlx_audio/stt/tests/test_higgs_audio_3.py
@@ -96,6 +96,7 @@ def test_forward_logits_shape():
 
 def test_get_input_embeddings_merges_audio():
     m = _tiny_model()
+    m.config.vad_cut = False
     m._tokenizer = _StubTokenizer(m.config.audio_in_token_idx)
     wav = np.zeros(16000, dtype=np.float32)
     ids, embeds, plen = m.get_input_embeddings(wav)
@@ -103,6 +104,40 @@ def test_get_input_embeddings_merges_audio():
     assert embeds.shape[1] > len(ids)
     assert embeds.shape[2] == m.config.text_config.hidden_size
     assert plen == embeds.shape[1]
+
+
+def test_vad_chunk_ranges_fallback_when_no_backend():
+    from mlx_audio.stt.models.higgs_audio_3.vad import vad_chunk_ranges
+
+    wav = np.zeros(10 * 16000, dtype=np.float32)
+    ranges = vad_chunk_ranges(wav, chunk_samples=4 * 16000, backend=None)
+    assert ranges == [(0, 64000), (64000, 128000), (128000, 160000)]
+
+
+def test_vad_chunk_ranges_respects_cuts():
+    from mlx_audio.stt.models.higgs_audio_3 import vad as vad_mod
+
+    class _StubBackend:
+        def speech_ranges(self, wav):
+            return [(16000, 48000), (96000, 144000)]
+
+    wav = np.zeros(10 * 16000, dtype=np.float32)
+    chunk = 4 * 16000
+
+    merged = vad_mod.vad_chunk_ranges(
+        wav, chunk, backend=_StubBackend(), split_vads=False
+    )
+    # start of first cut clamped to 0, last cut extended to the full length
+    assert merged[0][0] == 0
+    assert merged[-1][1] == 10 * 16000
+    assert all(e - s <= chunk for s, e in merged)
+
+    split = vad_mod.vad_chunk_ranges(
+        wav, chunk, backend=_StubBackend(), split_vads=True
+    )
+    # split_vads keeps only the detected speech ranges (sub-chunked)
+    assert split[0][0] == 16000
+    assert split[-1][1] == 144000
 
 
 def test_sanitize_remaps_and_transposes():

--- a/mlx_audio/stt/tests/test_higgs_audio_3.py
+++ b/mlx_audio/stt/tests/test_higgs_audio_3.py
@@ -1,0 +1,193 @@
+"""Tests for the Higgs-Audio v3 STT MLX model.
+
+The lightweight tests build a tiny randomly-initialized model and exercise the
+config, audio encoder/projector shapes, embedding merge, and weight-sanitize
+logic without any download. The integration test is gated behind the
+``requires_weights`` marker and an env var pointing at the model directory.
+"""
+
+import os
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx.utils import tree_flatten
+
+from mlx_audio.stt.models.higgs_audio_3 import Model, ModelConfig
+from mlx_audio.stt.models.higgs_audio_3.higgs_audio_3 import (
+    HiggsAudioEncoder,
+    HiggsAudioFeatureProjector,
+)
+
+
+def _tiny_config() -> dict:
+    return {
+        "model_type": "higgs_audio_3",
+        "projector_temporal_downsample": 2,
+        "projector_type": "mlp",
+        "audio_num_codebooks": 1,
+        "audio_codebook_size": 1,
+        "audio_in_token_idx": 40,
+        "audio_encoder_config": {
+            "num_mel_bins": 32,
+            "encoder_layers": 2,
+            "encoder_attention_heads": 2,
+            "encoder_ffn_dim": 64,
+            "d_model": 16,
+            "max_source_positions": 200,
+        },
+        "text_config": {
+            "vocab_size": 64,
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 8,
+        },
+    }
+
+
+def _tiny_model() -> Model:
+    model = ModelConfig.from_dict(_tiny_config())
+    m = Model(model)
+    mx.eval(m.parameters())
+    return m
+
+
+def test_config_parses_nested():
+    cfg = ModelConfig.from_dict(_tiny_config())
+    assert cfg.audio_encoder_config.d_model == 16
+    assert cfg.text_config.num_hidden_layers == 2
+    assert cfg.projector_temporal_downsample == 2
+    assert cfg.audio_in_token_idx == 40
+
+
+def test_encoder_halves_time_dim():
+    cfg = ModelConfig.from_dict(_tiny_config())
+    enc = HiggsAudioEncoder(cfg.audio_encoder_config)
+    mx.eval(enc.parameters())
+    mel = mx.zeros((1, cfg.audio_encoder_config.num_mel_bins, 80))
+    out = enc(mel)
+    # conv2 stride 2 then avg-pool stride 2 => time roughly /4
+    assert out.shape[0] == 1
+    assert out.shape[2] == cfg.audio_encoder_config.d_model
+    assert out.shape[1] == 80 // 4
+
+
+def test_projector_downsamples_and_projects():
+    cfg = ModelConfig.from_dict(_tiny_config())
+    proj = HiggsAudioFeatureProjector(cfg)
+    mx.eval(proj.parameters())
+    x = mx.zeros((1, 20, cfg.audio_encoder_config.d_model))
+    out = proj(x)
+    assert out.shape[0] == 1
+    assert out.shape[2] == cfg.text_config.hidden_size
+    # stride-2 temporal conv: ceil(20 / 2) == 10
+    assert out.shape[1] == 10
+
+
+def test_forward_logits_shape():
+    m = _tiny_model()
+    ids = mx.array([[1, 2, 3, 4, 5]])
+    logits = m(ids)
+    assert logits.shape == (1, 5, m.config.text_config.vocab_size)
+
+
+def test_get_input_embeddings_merges_audio():
+    m = _tiny_model()
+    m._tokenizer = _StubTokenizer(m.config.audio_in_token_idx)
+    wav = np.zeros(16000, dtype=np.float32)
+    ids, embeds, plen = m.get_input_embeddings(wav)
+    # one <|AUDIO|> placeholder expands into many audio rows
+    assert embeds.shape[1] > len(ids)
+    assert embeds.shape[2] == m.config.text_config.hidden_size
+    assert plen == embeds.shape[1]
+
+
+def test_sanitize_remaps_and_transposes():
+    cfg = ModelConfig.from_dict(_tiny_config())
+    d = cfg.audio_encoder_config.d_model
+    h = cfg.text_config.hidden_size
+    v = cfg.text_config.vocab_size
+    weights = {
+        "embed_tokens.weight": mx.zeros((v, h)),
+        "norm.weight": mx.zeros((h,)),
+        "layers.0.self_attn.q_proj.weight": mx.zeros((16, h)),
+        "audio_tower.conv1.weight": mx.zeros(
+            (d, cfg.audio_encoder_config.num_mel_bins, 3)
+        ),
+        "audio_encoder_proj.temporal.weight": mx.zeros((d, 1, 3)),
+        "audio_decoder_proj.text_lm_head.weight": mx.zeros((v, h)),
+        "audio_decoder_proj.audio_lm_head.weight": mx.zeros((3, h)),
+        "audio_codebook_embeddings.weight": mx.zeros((3, h)),
+    }
+    san = Model.sanitize(dict(weights))
+    assert "audio_decoder_proj.audio_lm_head.weight" not in san
+    assert "audio_codebook_embeddings.weight" not in san
+    assert "lm_head.weight" in san
+    assert "model.embed_tokens.weight" in san
+    assert "model.norm.weight" in san
+    assert "model.layers.0.self_attn.q_proj.weight" in san
+    # Conv1d weights transposed (out, in, k) -> (out, k, in)
+    assert san["audio_tower.conv1.weight"].shape == (
+        d,
+        3,
+        cfg.audio_encoder_config.num_mel_bins,
+    )
+    assert san["audio_encoder_proj.temporal.weight"].shape == (d, 3, 1)
+
+
+def test_sanitize_covers_all_model_keys():
+    m = _tiny_model()
+    model_keys = {k for k, _ in tree_flatten(m.parameters())}
+    weights = {}
+    for k in model_keys:
+        if k == "lm_head.weight":
+            weights["audio_decoder_proj.text_lm_head.weight"] = mx.zeros(
+                m.lm_head.weight.shape
+            )
+            continue
+        shape = dict(tree_flatten(m.parameters()))[k].shape
+        src = k
+        if k.startswith("model.embed_tokens"):
+            src = "embed_tokens.weight"
+        elif k.startswith("model.norm"):
+            src = "norm.weight"
+        elif k.startswith("model.layers"):
+            src = k[len("model.") :]
+        if "audio_tower.conv" in k and len(shape) == 3:
+            shape = (shape[0], shape[2], shape[1])
+        if "audio_encoder_proj.temporal" in k and len(shape) == 3:
+            shape = (shape[0], shape[2], shape[1])
+        weights[src] = mx.zeros(shape)
+    san = Model.sanitize(weights)
+    assert set(san.keys()) == model_keys
+
+
+class _StubTokenizer:
+    def __init__(self, audio_id):
+        self._audio_id = audio_id
+        self._counter = 1
+
+    def encode(self, text, add_special_tokens=False):
+        if "<|AUDIO|>" in text:
+            return [self._audio_id]
+        n = max(1, len(text.split()))
+        return list(range(1, 1 + n))
+
+
+@pytest.mark.requires_weights
+def test_real_model_transcribes():
+    path = os.environ.get("HIGGS_AUDIO_3_PATH")
+    if not path:
+        pytest.skip("set HIGGS_AUDIO_3_PATH to the higgs-audio-v3-stt model directory")
+    audio = os.environ.get("HIGGS_AUDIO_3_TEST_AUDIO")
+    if not audio:
+        pytest.skip("set HIGGS_AUDIO_3_TEST_AUDIO to a wav/flac file")
+
+    from mlx_audio.stt import load
+
+    model = load(path)
+    result = model.generate(audio, max_tokens=256)
+    assert result.text.strip()

--- a/mlx_audio/stt/tests/test_higgs_audio_3.py
+++ b/mlx_audio/stt/tests/test_higgs_audio_3.py
@@ -13,7 +13,9 @@ import numpy as np
 import pytest
 from mlx.utils import tree_flatten
 
-from mlx_audio.stt.models.higgs_audio_3 import Model, ModelConfig
+from mlx_audio.base import BaseModelArgs
+from mlx_audio.stt.models.higgs_audio_3 import AudioEncoderConfig, Model, ModelConfig
+from mlx_audio.stt.models.higgs_audio_3.audio import AudioFeatureExtractor
 from mlx_audio.stt.models.higgs_audio_3.higgs_audio_3 import (
     HiggsAudioEncoder,
     HiggsAudioFeatureProjector,
@@ -57,10 +59,21 @@ def _tiny_model() -> Model:
 
 def test_config_parses_nested():
     cfg = ModelConfig.from_dict(_tiny_config())
+    assert isinstance(cfg, BaseModelArgs)
+    assert isinstance(cfg.audio_encoder_config, AudioEncoderConfig)
     assert cfg.audio_encoder_config.d_model == 16
     assert cfg.text_config.num_hidden_layers == 2
     assert cfg.projector_temporal_downsample == 2
     assert cfg.audio_in_token_idx == 40
+
+
+def test_feature_extractor_returns_mel_array():
+    fx = AudioFeatureExtractor(num_mel_bins=128)
+    wav = mx.zeros(16000)
+    mel = fx(wav)
+    assert isinstance(mel, mx.array)
+    assert mel.shape[0] == 1
+    assert mel.shape[1] == 128
 
 
 def test_encoder_halves_time_dim():

--- a/mlx_audio/stt/utils.py
+++ b/mlx_audio/stt/utils.py
@@ -26,6 +26,7 @@ MODEL_REMAPPING = {
     "granite_speech_nar": "granite_speech_nar",
     "qwen2_audio": "qwen2_audio",
     "mega_asr": "mega_asr",
+    "higgs_audio_3": "higgs_audio_3",
 }
 
 


### PR DESCRIPTION
Adds support for higgs-audio-v3 STT (bosonai/higgs-audio-v3-stt), currently the top-ranked open model on the OpenASR.

It's a Qwen3-1.7B backbone with a Whisper-style audio encoder and an MLP projector (model_type: higgs_audio_3), living in mlx_audio/stt/models/higgs_audio_3/ and reusing mlx-audio's Qwen3 decoder and Silero VAD.

For tests, a tiny-config shape/forward/merge/sanitize coverage plus a gated real-weight transcription test. All previous existing tests pass

addresses #809 
