### PR TITLE
fix: SineGen length alignment + log-magnitude clamp for Kokoro TTS NaN/broadcast crashes

### DIFF
--- a/mlx_audio/tts/models/kitten_tts/istftnet.py
+++ b/mlx_audio/tts/models/kitten_tts/istftnet.py
@@ -638,6 +638,14 @@ class SineGen:
         # Generate UV signal
         uv = self._f02uv(f0)
 
+        # Guard against interpolation rounding — _f02sine's scale_factor
+        # can produce sine_waves 1 frame longer than f0, causing a
+        # broadcast crash with noise_amp below. Trim both to the
+        # minimum common length so shapes always align.
+        min_len = min(sine_waves.shape[1], uv.shape[1])
+        sine_waves = sine_waves[:, :min_len, :]
+        uv = uv[:, :min_len, :]
+
         # Generate noise
         noise_amp = uv * self.noise_std + (1 - uv) * self.sine_amp / 3
         noise = noise_amp * mx.random.normal(sine_waves.shape)

--- a/mlx_audio/tts/models/kokoro/istftnet.py
+++ b/mlx_audio/tts/models/kokoro/istftnet.py
@@ -626,6 +626,14 @@ class SineGen:
         # Generate UV signal
         uv = self._f02uv(f0)
 
+        # Guard against interpolation rounding — _f02sine's scale_factor
+        # can produce sine_waves 1 frame longer than f0, causing a
+        # broadcast crash with noise_amp below. Trim both to the
+        # minimum common length so shapes always align.
+        min_len = min(sine_waves.shape[1], uv.shape[1])
+        sine_waves = sine_waves[:, :min_len, :]
+        uv = uv[:, :min_len, :]
+
         # Generate noise
         noise_amp = uv * self.noise_std + (1 - uv) * self.sine_amp / 3
         noise = noise_amp * mx.random.normal(sine_waves.shape)

--- a/mlx_audio/tts/models/kokoro/istftnet.py
+++ b/mlx_audio/tts/models/kokoro/istftnet.py
@@ -819,7 +819,10 @@ class Generator(nn.Module):
         x = self.conv_post(x, mx.conv1d)
         x = x.swapaxes(2, 1)
 
-        spec = mx.exp(x[:, : self.post_n_fft // 2 + 1, :])
+        # Clamp log-magnitude to [-10, 10] before exp to prevent float32
+        # overflow (inf → NaN in iSTFT). The conv_post output can reach
+        # ~1e11, which produces inf after mx.exp().
+        spec = mx.exp(mx.clip(x[:, : self.post_n_fft // 2 + 1, :], -10.0, 10.0))
         phase = mx.sin(x[:, self.post_n_fft // 2 + 1 :, :])
         result = self.stft.inverse(spec, phase)
         return result


### PR DESCRIPTION
## Fixes two bugs in Kokoro (and KittenTTS) TTS

### Bug 1 — Shape broadcast crash (kokoro + kitten_tts istftnet.py)

`_f02sine` interpolation with `scale_factor` can produce `sine_waves` with a slightly different length than `f0`, causing a broadcast crash in `SineGen.__call__` when noise is generated from `sine_waves.shape` but `noise_amp` comes from `uv` (which matches `f0` length).

**Error:**
```
ValueError: [broadcast_shapes] Shapes (1,N,1) and (1,N+300,9) cannot be broadcast.
```

**Fix:** Trim both `sine_waves` and `uv` to the minimum common length before noise generation.

### Bug 2 — NaN output from mx.exp overflow (kokoro istftnet.py)

The `Generator.conv_post` layer can output values up to ~1e11, which produces `inf` after `mx.exp()` in float32. This `inf` propagates through iSTFT reconstruction and produces NaN in the final audio output.

**Fix:** Clip log-magnitude to [-10, 10] before `mx.exp()`, matching common TTS spectrogram processing practices.

### Testing

Tested on English (`af_heart`) and Spanish (`ef_dora`) — both produce clean audio with zero NaN samples:

```
English: NaN=0/120000, mean_abs=37.1
Spanish: NaN=0/105000, mean_abs=42.0
```

### Related

Issue #815 originally reported both bugs.