### PR TITLE
Improve audio loading performance

### DIFF
--- a/mlx_audio/audio_io.py
+++ b/mlx_audio/audio_io.py
@@ -56,11 +56,15 @@ def _detect_format_from_bytes(data: bytes) -> str:
 
 def _decode_ffmpeg(
     input_data: Union[str, Path, bytes],
+    sample_rate: Optional[int] = None,
+    nchannels: Optional[int] = None,
 ) -> Tuple[np.ndarray, int, int]:
     """Decode audio using ffmpeg (for formats not supported by miniaudio like M4A).
 
     Args:
         input_data: Path to the audio file or raw bytes data.
+        sample_rate: Optional target sample rate. Preserves the input rate when omitted.
+        nchannels: Optional target channel count. Preserves the input channels when omitted.
 
     Returns:
         Tuple of (samples as int16 numpy array, sample_rate, nchannels).
@@ -131,8 +135,8 @@ def _decode_ffmpeg(
         raise RuntimeError("No audio streams found in file")
 
     stream = probe_info["streams"][0]
-    sample_rate = int(stream.get("sample_rate", 44100))
-    nchannels = int(stream.get("channels", 2))
+    output_sample_rate = sample_rate or int(stream.get("sample_rate", 44100))
+    output_nchannels = nchannels or int(stream.get("channels", 2))
 
     # Decode to raw PCM using ffmpeg
     if isinstance(input_data, bytes):
@@ -145,9 +149,9 @@ def _decode_ffmpeg(
             "-acodec",
             "pcm_s16le",
             "-ar",
-            str(sample_rate),
+            str(output_sample_rate),
             "-ac",
-            str(nchannels),
+            str(output_nchannels),
             "pipe:1",
         ]
         decode_result = subprocess.run(
@@ -165,9 +169,9 @@ def _decode_ffmpeg(
             "-acodec",
             "pcm_s16le",
             "-ar",
-            str(sample_rate),
+            str(output_sample_rate),
             "-ac",
-            str(nchannels),
+            str(output_nchannels),
             "pipe:1",
         ]
         decode_result = subprocess.run(decode_cmd, capture_output=True)
@@ -178,13 +182,15 @@ def _decode_ffmpeg(
     # Convert raw PCM bytes to numpy array
     samples = np.frombuffer(decode_result.stdout, dtype=np.int16)
 
-    return samples, sample_rate, nchannels
+    return samples, output_sample_rate, output_nchannels
 
 
 def read(
     file: Union[str, Path, io.BytesIO],
     always_2d: bool = False,
     dtype: str = "float64",
+    sample_rate: Optional[int] = None,
+    nchannels: Optional[int] = None,
 ) -> Tuple[np.ndarray, int]:
     """Read an audio file using miniaudio (or ffmpeg for M4A/AAC/OGG/Opus/WebM).
 
@@ -192,11 +198,18 @@ def read(
         file: Path to the audio file or a BytesIO object.
         always_2d: If True, always return a 2D array (samples, channels).
         dtype: Data type for the output array. Supports 'float32', 'float64', 'int16'.
+        sample_rate: Optional target sample rate. Preserves the input rate when omitted.
+        nchannels: Optional target channel count. Preserves the input channels when omitted.
 
     Returns:
         Tuple of (audio_data, sample_rate).
         audio_data is a numpy array with shape (samples,) for mono or (samples, channels) for multi-channel.
     """
+    if sample_rate is not None and sample_rate <= 0:
+        raise ValueError(f"sample_rate must be positive, got {sample_rate}")
+    if nchannels is not None and nchannels <= 0:
+        raise ValueError(f"nchannels must be positive, got {nchannels}")
+
     # Check if this is a file that needs ffmpeg
     use_ffmpeg = False
     if isinstance(file, (str, Path)):
@@ -221,7 +234,11 @@ def read(
             input_data = file.read()
         else:
             input_data = file
-        samples, sample_rate, nchannels = _decode_ffmpeg(input_data)
+        samples, sample_rate, nchannels = _decode_ffmpeg(
+            input_data,
+            sample_rate=sample_rate,
+            nchannels=nchannels,
+        )
     else:
         # Use miniaudio for other formats
         import miniaudio
@@ -231,8 +248,8 @@ def read(
             info = miniaudio.get_file_info(str(file))
             decoded = miniaudio.decode_file(
                 str(file),
-                nchannels=info.nchannels,
-                sample_rate=info.sample_rate,
+                nchannels=nchannels or info.nchannels,
+                sample_rate=sample_rate or info.sample_rate,
             )
         elif isinstance(file, io.BytesIO):
             file.seek(0)
@@ -251,8 +268,8 @@ def read(
                 raise ValueError(f"Unsupported format: {fmt}")
             decoded = miniaudio.decode(
                 data,
-                nchannels=info.nchannels,
-                sample_rate=info.sample_rate,
+                nchannels=nchannels or info.nchannels,
+                sample_rate=sample_rate or info.sample_rate,
             )
         else:
             raise TypeError(f"Unsupported file type: {type(file)}")
@@ -270,7 +287,8 @@ def read(
 
     # Convert to requested dtype
     if dtype in ("float32", "float64"):
-        samples = samples.astype(dtype) / 32768.0
+        samples = samples.astype(dtype)
+        samples /= 32768.0
     elif dtype == "int16":
         pass  # Already int16
     else:

--- a/mlx_audio/stt/utils.py
+++ b/mlx_audio/stt/utils.py
@@ -61,10 +61,8 @@ def load_audio(
     """
     from mlx_audio.audio_io import read as audio_read
 
-    audio, sample_rate = audio_read(file, always_2d=True)
-    if sample_rate != sr:
-        audio = resample_audio(audio, sample_rate, sr)
-    return mx.array(audio, dtype=dtype).mean(axis=1)
+    audio, _ = audio_read(file, dtype="float32", sample_rate=sr, nchannels=1)
+    return mx.array(audio, dtype=dtype)
 
 
 def load_model(

--- a/mlx_audio/tests/test_audio_io.py
+++ b/mlx_audio/tests/test_audio_io.py
@@ -63,6 +63,27 @@ class TestAudioIOFormats:
         assert read_samplerate == samplerate
         assert read_data.shape == data.shape
 
+    def test_read_wav_target_sample_rate_and_channels(
+        self, sample_audio_stereo, tmp_path
+    ):
+        """Test decoder-side resampling and mono conversion."""
+        data, samplerate = sample_audio_stereo
+        output_file = tmp_path / "test_resampled_mono.wav"
+        target_samplerate = samplerate // 2
+
+        write(output_file, data, samplerate, format="wav")
+
+        read_data, read_samplerate = read(
+            output_file,
+            dtype="float32",
+            sample_rate=target_samplerate,
+            nchannels=1,
+        )
+        assert read_samplerate == target_samplerate
+        assert read_data.dtype == np.float32
+        assert read_data.ndim == 1
+        assert abs(read_data.shape[0] - target_samplerate) <= 1
+
     @pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg not installed")
     def test_write_read_mp3(self, sample_audio_mono, tmp_path):
         """Test writing and reading MP3 file."""

--- a/mlx_audio/utils.py
+++ b/mlx_audio/utils.py
@@ -678,17 +678,12 @@ def load_audio(
     if not os.path.exists(audio):
         raise FileNotFoundError(f"Audio file not found: {audio}")
 
-    samples, orig_sample_rate = audio_read(audio)
-    shape = samples.shape
-
-    # Collapse multi channel as mono
-    if len(shape) > 1:
-        samples = samples.sum(axis=1)
-        samples = samples / shape[1]
-
-    # Resample if needed
-    if sample_rate != orig_sample_rate:
-        samples = resample_audio(samples, orig_sample_rate, sample_rate)
+    samples, _ = audio_read(
+        audio,
+        dtype="float32",
+        sample_rate=sample_rate,
+        nchannels=1,
+    )
 
     # Random segment selection
     if segment_duration is not None:


### PR DESCRIPTION
I noticed long audio loading was much slower than I would have expected, and when looking into it our PCM conversion pipeline using ffmpeg / miniaudio could be improved by directly resampling and converting channels at load time instead of a second-pass approach.

This improves loading and resampling a ~110mb stereo 44.1kHz mp3 file as 16kHz mono PCM from 16.2s -> ~2.4s on my M5 Max.