### PR TITLE
Improve MOSS-Transcribe-Diarize performance

### DIFF
--- a/mlx_audio/audio_io.py
+++ b/mlx_audio/audio_io.py
@@ -56,11 +56,15 @@ def _detect_format_from_bytes(data: bytes) -> str:
 
 def _decode_ffmpeg(
     input_data: Union[str, Path, bytes],
+    sample_rate: Optional[int] = None,
+    nchannels: Optional[int] = None,
 ) -> Tuple[np.ndarray, int, int]:
     """Decode audio using ffmpeg (for formats not supported by miniaudio like M4A).
 
     Args:
         input_data: Path to the audio file or raw bytes data.
+        sample_rate: Optional target sample rate. Preserves the input rate when omitted.
+        nchannels: Optional target channel count. Preserves the input channels when omitted.
 
     Returns:
         Tuple of (samples as int16 numpy array, sample_rate, nchannels).
@@ -131,8 +135,8 @@ def _decode_ffmpeg(
         raise RuntimeError("No audio streams found in file")
 
     stream = probe_info["streams"][0]
-    sample_rate = int(stream.get("sample_rate", 44100))
-    nchannels = int(stream.get("channels", 2))
+    output_sample_rate = sample_rate or int(stream.get("sample_rate", 44100))
+    output_nchannels = nchannels or int(stream.get("channels", 2))
 
     # Decode to raw PCM using ffmpeg
     if isinstance(input_data, bytes):
@@ -145,9 +149,9 @@ def _decode_ffmpeg(
             "-acodec",
             "pcm_s16le",
             "-ar",
-            str(sample_rate),
+            str(output_sample_rate),
             "-ac",
-            str(nchannels),
+            str(output_nchannels),
             "pipe:1",
         ]
         decode_result = subprocess.run(
@@ -165,9 +169,9 @@ def _decode_ffmpeg(
             "-acodec",
             "pcm_s16le",
             "-ar",
-            str(sample_rate),
+            str(output_sample_rate),
             "-ac",
-            str(nchannels),
+            str(output_nchannels),
             "pipe:1",
         ]
         decode_result = subprocess.run(decode_cmd, capture_output=True)
@@ -178,13 +182,15 @@ def _decode_ffmpeg(
     # Convert raw PCM bytes to numpy array
     samples = np.frombuffer(decode_result.stdout, dtype=np.int16)
 
-    return samples, sample_rate, nchannels
+    return samples, output_sample_rate, output_nchannels
 
 
 def read(
     file: Union[str, Path, io.BytesIO],
     always_2d: bool = False,
     dtype: str = "float64",
+    sample_rate: Optional[int] = None,
+    nchannels: Optional[int] = None,
 ) -> Tuple[np.ndarray, int]:
     """Read an audio file using miniaudio (or ffmpeg for M4A/AAC/OGG/Opus/WebM).
 
@@ -192,11 +198,18 @@ def read(
         file: Path to the audio file or a BytesIO object.
         always_2d: If True, always return a 2D array (samples, channels).
         dtype: Data type for the output array. Supports 'float32', 'float64', 'int16'.
+        sample_rate: Optional target sample rate. Preserves the input rate when omitted.
+        nchannels: Optional target channel count. Preserves the input channels when omitted.
 
     Returns:
         Tuple of (audio_data, sample_rate).
         audio_data is a numpy array with shape (samples,) for mono or (samples, channels) for multi-channel.
     """
+    if sample_rate is not None and sample_rate <= 0:
+        raise ValueError(f"sample_rate must be positive, got {sample_rate}")
+    if nchannels is not None and nchannels <= 0:
+        raise ValueError(f"nchannels must be positive, got {nchannels}")
+
     # Check if this is a file that needs ffmpeg
     use_ffmpeg = False
     if isinstance(file, (str, Path)):
@@ -221,7 +234,11 @@ def read(
             input_data = file.read()
         else:
             input_data = file
-        samples, sample_rate, nchannels = _decode_ffmpeg(input_data)
+        samples, sample_rate, nchannels = _decode_ffmpeg(
+            input_data,
+            sample_rate=sample_rate,
+            nchannels=nchannels,
+        )
     else:
         # Use miniaudio for other formats
         import miniaudio
@@ -231,8 +248,8 @@ def read(
             info = miniaudio.get_file_info(str(file))
             decoded = miniaudio.decode_file(
                 str(file),
-                nchannels=info.nchannels,
-                sample_rate=info.sample_rate,
+                nchannels=nchannels or info.nchannels,
+                sample_rate=sample_rate or info.sample_rate,
             )
         elif isinstance(file, io.BytesIO):
             file.seek(0)
@@ -251,8 +268,8 @@ def read(
                 raise ValueError(f"Unsupported format: {fmt}")
             decoded = miniaudio.decode(
                 data,
-                nchannels=info.nchannels,
-                sample_rate=info.sample_rate,
+                nchannels=nchannels or info.nchannels,
+                sample_rate=sample_rate or info.sample_rate,
             )
         else:
             raise TypeError(f"Unsupported file type: {type(file)}")
@@ -270,7 +287,8 @@ def read(
 
     # Convert to requested dtype
     if dtype in ("float32", "float64"):
-        samples = samples.astype(dtype) / 32768.0
+        samples = samples.astype(dtype)
+        samples /= 32768.0
     elif dtype == "int16":
         pass  # Already int16
     else:

--- a/mlx_audio/stt/models/moss_transcribe_diarize/moss_transcribe_diarize.py
+++ b/mlx_audio/stt/models/moss_transcribe_diarize/moss_transcribe_diarize.py
@@ -589,7 +589,7 @@ class Model(nn.Module):
         sampler: Optional[Callable[[mx.array], mx.array]] = None,
         logits_processors: Optional[List[Callable]] = None,
         prompt: Optional[str] = None,
-        prefill_step_size: int = 2048,
+        prefill_step_size: int = 4096,
         verbose: bool = False,
     ) -> Generator[Tuple[mx.array, mx.array], None, None]:
         from mlx_lm.generate import generate_step
@@ -661,7 +661,7 @@ class Model(nn.Module):
         repetition_penalty: Optional[float] = None,
         repetition_context_size: int = 100,
         prompt: Optional[str] = None,
-        prefill_step_size: int = 2048,
+        prefill_step_size: int = 4096,
         verbose: bool = False,
         stream: bool = False,
         **kwargs,

--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx_lm.models.base import create_attention_mask, scaled_dot_product_attention
 from tqdm import tqdm
 
 from mlx_audio.stt.models.base import STTOutput
@@ -487,6 +488,7 @@ class TextAttention(nn.Module):
     def __call__(
         self,
         hidden_states: mx.array,
+        mask: Optional[Union[str, mx.array]] = None,
         cache: Optional[Any] = None,
     ) -> mx.array:
         B, L, _ = hidden_states.shape
@@ -519,12 +521,13 @@ class TextAttention(nn.Module):
             keys, values = cache.update_and_fetch(keys, values)
 
         query_len = queries.shape[2]
-        mask = create_additive_causal_mask(query_len, offset=offset).astype(
-            queries.dtype
-        )
-
-        output = mx.fast.scaled_dot_product_attention(
-            queries, keys, values, scale=self.scale, mask=mask
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=cache,
+            scale=self.scale,
+            mask=mask,
         )
 
         output = output.transpose(0, 2, 1, 3).reshape(B, query_len, -1)
@@ -568,11 +571,12 @@ class TextDecoderLayer(nn.Module):
     def __call__(
         self,
         hidden_states: mx.array,
+        mask: Optional[Union[str, mx.array]] = None,
         cache: Optional[Any] = None,
     ) -> mx.array:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
-        hidden_states = self.self_attn(hidden_states, cache=cache)
+        hidden_states = self.self_attn(hidden_states, mask=mask, cache=cache)
         hidden_states = residual + hidden_states
 
         residual = hidden_states
@@ -610,9 +614,10 @@ class TextModel(nn.Module):
 
         if cache is None:
             cache = [None] * len(self.layers)
+        mask = create_attention_mask(hidden_states, cache[0])
 
         for i, layer in enumerate(self.layers):
-            hidden_states = layer(hidden_states, cache=cache[i])
+            hidden_states = layer(hidden_states, mask=mask, cache=cache[i])
 
         return self.norm(hidden_states)
 

--- a/mlx_audio/stt/tests/test_models.py
+++ b/mlx_audio/stt/tests/test_models.py
@@ -1802,6 +1802,26 @@ class TestQwen3ASRModel(unittest.TestCase):
 
         self.assertEqual(output.shape, (1, 5, self.text_config.hidden_size))
 
+    def test_text_model_cached_chunks_match_full_causal_pass(self):
+        from mlx_lm.models.cache import KVCache
+
+        model = self.TextModel(self.text_config)
+        input_ids = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+
+        full = model(input_ids=input_ids)
+        cache = [KVCache() for _ in model.layers]
+        first = model(input_ids=input_ids[:, :3], cache=cache)
+        mx.eval(first, [entry.state for entry in cache])
+        second = model(input_ids=input_ids[:, 3:], cache=cache)
+        mx.eval(full, second)
+
+        np.testing.assert_allclose(
+            np.array(second),
+            np.array(full[:, 3:]),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
     def test_qwen3_asr_model_init(self):
         model = self.Qwen3ASRModel(self.model_config)
 

--- a/mlx_audio/stt/utils.py
+++ b/mlx_audio/stt/utils.py
@@ -61,10 +61,8 @@ def load_audio(
     """
     from mlx_audio.audio_io import read as audio_read
 
-    audio, sample_rate = audio_read(file, always_2d=True)
-    if sample_rate != sr:
-        audio = resample_audio(audio, sample_rate, sr)
-    return mx.array(audio, dtype=dtype).mean(axis=1)
+    audio, _ = audio_read(file, dtype="float32", sample_rate=sr, nchannels=1)
+    return mx.array(audio, dtype=dtype)
 
 
 def load_model(

--- a/mlx_audio/tests/test_audio_io.py
+++ b/mlx_audio/tests/test_audio_io.py
@@ -63,6 +63,27 @@ class TestAudioIOFormats:
         assert read_samplerate == samplerate
         assert read_data.shape == data.shape
 
+    def test_read_wav_target_sample_rate_and_channels(
+        self, sample_audio_stereo, tmp_path
+    ):
+        """Test decoder-side resampling and mono conversion."""
+        data, samplerate = sample_audio_stereo
+        output_file = tmp_path / "test_resampled_mono.wav"
+        target_samplerate = samplerate // 2
+
+        write(output_file, data, samplerate, format="wav")
+
+        read_data, read_samplerate = read(
+            output_file,
+            dtype="float32",
+            sample_rate=target_samplerate,
+            nchannels=1,
+        )
+        assert read_samplerate == target_samplerate
+        assert read_data.dtype == np.float32
+        assert read_data.ndim == 1
+        assert abs(read_data.shape[0] - target_samplerate) <= 1
+
     @pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg not installed")
     def test_write_read_mp3(self, sample_audio_mono, tmp_path):
         """Test writing and reading MP3 file."""

--- a/mlx_audio/utils.py
+++ b/mlx_audio/utils.py
@@ -678,17 +678,12 @@ def load_audio(
     if not os.path.exists(audio):
         raise FileNotFoundError(f"Audio file not found: {audio}")
 
-    samples, orig_sample_rate = audio_read(audio)
-    shape = samples.shape
-
-    # Collapse multi channel as mono
-    if len(shape) > 1:
-        samples = samples.sum(axis=1)
-        samples = samples / shape[1]
-
-    # Resample if needed
-    if sample_rate != orig_sample_rate:
-        samples = resample_audio(samples, orig_sample_rate, sample_rate)
+    samples, _ = audio_read(
+        audio,
+        dtype="float32",
+        sample_rate=sample_rate,
+        nchannels=1,
+    )
 
     # Random segment selection
     if segment_duration is not None:


### PR DESCRIPTION
Avoid recomputing attention masks per layer and use a larger prefill chunk size. This improves TTFT on a 66 minute audio file from 13.9s -> 12.4s, and improves decode from 55.9 token/sec -> 68.9 tokens/sec on my M5 Max.

Note: merge https://github.com/Blaizzy/mlx-audio/pull/825 first