### PR TITLE
Optimize inference for Granite Speech NAR

### DIFF
--- a/mlx_audio/stt/models/granite_speech_nar/editor.py
+++ b/mlx_audio/stt/models/granite_speech_nar/editor.py
@@ -115,7 +115,6 @@ class GraniteAttention(nn.Module):
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads
         self.head_dim = head_dim
-        self.kv_groups = num_heads // num_kv_heads
         self.attention_multiplier = attention_multiplier  # = 1/128, not 1/sqrt(128)
 
         self.q_proj = nn.Linear(hidden_size, num_heads * head_dim, bias=False)
@@ -147,12 +146,11 @@ class GraniteAttention(nn.Module):
         # Apply RoPE to Q and K (V is not rotated)
         q, k = apply_rotary_pos_emb(q, k, cos, sin)
 
-        # GQA: repeat K and V along the head axis to match num_heads.
-        # mx.repeat gives repeat_interleave semantics: [a, b] → [a, a, b, b] (verified).
-        k = mx.repeat(k, self.kv_groups, axis=1)  # [B, num_heads, T, head_dim]
-        v = mx.repeat(v, self.kv_groups, axis=1)
-
-        # Bidirectional attention: no mask. Granite scale = attention_multiplier (1/128).
+        # Bidirectional GQA attention w/o mask. MLX's scaled_dot_product_attention
+        # handles grouped-query heads natively (gqa_factor = num_heads/num_kv_heads),
+        # so we pass the un-repeated K,V (num_kv_heads=4) directly to avoid explicitly
+        # materializing the 4x K,V repeat.
+        # Granite scale = attention_multiplier (1/128), not 1/sqrt(head_dim).
         attn = mx.fast.scaled_dot_product_attention(
             q,
             k,

--- a/mlx_audio/stt/models/granite_speech_nar/editor.py
+++ b/mlx_audio/stt/models/granite_speech_nar/editor.py
@@ -36,65 +36,6 @@ class GraniteRMSNorm(nn.Module):
         return (self.weight.astype(mx.float32) * h).astype(dtype)
 
 
-class GraniteRotaryEmbedding(nn.Module):
-    """RoPE position encoding.
-
-    inv_freq is precomputed in __init__ and stored under an underscored name so
-    MLX's parameter tree skips it — the analog of PyTorch's
-    `register_buffer(..., persistent=False)` used upstream.
-
-    Forward returns (cos, sin) tensors of shape [seq_len, head_dim] in the caller's
-    requested dtype. cos/sin are computed in fp32 for numerical stability.
-    """
-
-    def __init__(self, head_dim: int, max_position: int, theta: float = 10000.0):
-        super().__init__()
-        self.head_dim = head_dim
-        self.max_position = max_position
-        self.theta = theta
-        # inv_freq[i] = 1 / (theta ** (2i / head_dim)) for i in 0..head_dim/2-1
-        idx = mx.arange(0, head_dim, 2, dtype=mx.float32)
-        self._inv_freq = 1.0 / (theta ** (idx / head_dim))  # [head_dim/2]
-
-    def __call__(self, position_ids: mx.array, dtype) -> tuple[mx.array, mx.array]:
-        # position_ids: [seq_len], int
-        positions = position_ids.astype(mx.float32)
-        # Outer product via broadcast: [seq_len, head_dim/2]
-        freqs = positions[:, None] * self._inv_freq[None, :]
-        # Duplicate along last dim to match head_dim: [seq_len, head_dim]
-        emb = mx.concatenate([freqs, freqs], axis=-1)
-        cos = mx.cos(emb)
-        sin = mx.sin(emb)
-        return cos.astype(dtype), sin.astype(dtype)
-
-
-def rotate_half(x: mx.array) -> mx.array:
-    """Splits last dim in half, returns concat([-second_half, first_half])."""
-    half = x.shape[-1] // 2
-    x1 = x[..., :half]
-    x2 = x[..., half:]
-    return mx.concatenate([-x2, x1], axis=-1)
-
-
-def apply_rotary_pos_emb(
-    q: mx.array, k: mx.array, cos: mx.array, sin: mx.array
-) -> tuple[mx.array, mx.array]:
-    """Apply RoPE rotation to query and key.
-
-    q, k: [batch, num_heads, seq, head_dim]  (or any shape ending in [seq, head_dim])
-    cos, sin: [seq, head_dim]
-    """
-    # Broadcast cos/sin: prepend (q.ndim - cos.ndim) leading size-1 axes so that
-    # shapes align regardless of whether q is 3-D or 4-D.
-    n_extra = q.ndim - cos.ndim
-    for _ in range(n_extra):
-        cos = cos[None]
-        sin = sin[None]
-    q_rot = q * cos + rotate_half(q) * sin
-    k_rot = k * cos + rotate_half(k) * sin
-    return q_rot, k_rot
-
-
 class GraniteAttention(nn.Module):
     """Bidirectional GQA self-attention with Granite's custom `attention_multiplier` scale.
 
@@ -109,6 +50,7 @@ class GraniteAttention(nn.Module):
         num_kv_heads: int,
         head_dim: int,
         attention_multiplier: float,
+        rope_theta: float,
     ):
         super().__init__()
         assert num_heads % num_kv_heads == 0
@@ -116,13 +58,14 @@ class GraniteAttention(nn.Module):
         self.num_kv_heads = num_kv_heads
         self.head_dim = head_dim
         self.attention_multiplier = attention_multiplier  # = 1/128, not 1/sqrt(128)
+        self.rope_theta = rope_theta
 
         self.q_proj = nn.Linear(hidden_size, num_heads * head_dim, bias=False)
         self.k_proj = nn.Linear(hidden_size, num_kv_heads * head_dim, bias=False)
         self.v_proj = nn.Linear(hidden_size, num_kv_heads * head_dim, bias=False)
         self.o_proj = nn.Linear(num_heads * head_dim, hidden_size, bias=False)
 
-    def __call__(self, x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    def __call__(self, x: mx.array) -> mx.array:
         B, T, H = x.shape
         dtype = x.dtype
 
@@ -143,8 +86,25 @@ class GraniteAttention(nn.Module):
             .transpose(0, 2, 1, 3)
         )
 
-        # Apply RoPE to Q and K (V is not rotated)
-        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        # Apply RoPE to Q and K (V is not rotated) via the fused mx.fast.rope kernel.
+        # traditional=False = half rotation (NeoX/Llama, matching rotate_half from
+        # previous code); offset=0 reproduces the contiguous arange positions.
+        q = mx.fast.rope(
+            q,
+            self.head_dim,
+            traditional=False,
+            base=self.rope_theta,
+            scale=1.0,
+            offset=0,
+        )
+        k = mx.fast.rope(
+            k,
+            self.head_dim,
+            traditional=False,
+            base=self.rope_theta,
+            scale=1.0,
+            offset=0,
+        )
 
         # Bidirectional GQA attention w/o mask. MLX's scaled_dot_product_attention
         # handles grouped-query heads natively (gqa_factor = num_heads/num_kv_heads),
@@ -202,6 +162,7 @@ class GraniteDecoderLayer(nn.Module):
         attention_multiplier: float,
         residual_multiplier: float,
         eps: float,
+        rope_theta: float,
     ):
         super().__init__()
         self.residual_multiplier = residual_multiplier
@@ -212,16 +173,17 @@ class GraniteDecoderLayer(nn.Module):
             num_kv_heads,
             head_dim,
             attention_multiplier,
+            rope_theta,
         )
         self.post_attention_layernorm = GraniteRMSNorm(hidden_size, eps=eps)
         self.mlp = GraniteMLP(hidden_size, intermediate_size)
 
-    def __call__(self, x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    def __call__(self, x: mx.array) -> mx.array:
         dtype = x.dtype
         # Attention block
         residual = x
         h = self.input_layernorm(x)
-        h = self.self_attn(h, cos, sin)
+        h = self.self_attn(h)
         x = residual + h * self.residual_multiplier
         # MLP block
         residual = x
@@ -251,11 +213,6 @@ class GraniteEditor(nn.Module):
 
         self.embed_tokens = nn.Embedding(cfg.vocab_size, cfg.hidden_size)
         head_dim = cfg.hidden_size // cfg.num_attention_heads
-        self.rotary_emb = GraniteRotaryEmbedding(
-            head_dim=head_dim,
-            max_position=cfg.max_position_embeddings,
-            theta=cfg.rope_theta,
-        )
         self.layers = [
             GraniteDecoderLayer(
                 hidden_size=cfg.hidden_size,
@@ -266,6 +223,7 @@ class GraniteEditor(nn.Module):
                 attention_multiplier=cfg.attention_multiplier,
                 residual_multiplier=cfg.residual_multiplier,
                 eps=cfg.rms_norm_eps,
+                rope_theta=cfg.rope_theta,
             )
             for _ in range(cfg.num_hidden_layers)
         ]
@@ -290,15 +248,11 @@ class GraniteEditor(nn.Module):
         # Apply embedding multiplier to ALL inputs uniformly
         h = inputs_embeds * self.embedding_multiplier
 
-        # Compute RoPE cos/sin once for the full sequence
-        if position_ids.ndim == 2:
-            # Take the first row — we don't support packed sequences in Plan 4
-            position_ids = position_ids[0]
-        cos, sin = self.rotary_emb(position_ids, dtype=h.dtype)
-
+        # RoPE is applied per-layer inside each GraniteAttention via mx.fast.rope
+        # (offset=0 reproduces the contiguous arange positions the caller passes).
         # 40 decoder layers (run over the FULL sequence -- attention needs it)
         for layer in self.layers:
-            h = layer(h, cos, sin)
+            h = layer(h)
 
         h = self.norm(h)
 

--- a/mlx_audio/stt/models/granite_speech_nar/editor.py
+++ b/mlx_audio/stt/models/granite_speech_nar/editor.py
@@ -29,11 +29,7 @@ class GraniteRMSNorm(nn.Module):
         self.weight = mx.ones(dim)
 
     def __call__(self, x: mx.array) -> mx.array:
-        dtype = x.dtype
-        h = x.astype(mx.float32)
-        variance = (h * h).mean(axis=-1, keepdims=True)
-        h = h * mx.rsqrt(variance + self.eps)
-        return (self.weight.astype(mx.float32) * h).astype(dtype)
+        return mx.fast.rms_norm(x, self.weight, self.eps).astype(x.dtype)
 
 
 class GraniteAttention(nn.Module):

--- a/mlx_audio/stt/models/granite_speech_nar/editor.py
+++ b/mlx_audio/stt/models/granite_speech_nar/editor.py
@@ -277,8 +277,15 @@ class GraniteEditor(nn.Module):
         # for both nn.Embedding (bf16 weight) and nn.QuantizedEmbedding (packed
         # weight + scales/biases), so the tied lm_head survives quantization.
 
-    def __call__(self, inputs_embeds: mx.array, position_ids: mx.array) -> mx.array:
+    def __call__(
+        self,
+        inputs_embeds: mx.array,
+        position_ids: mx.array,
+        logits_start: int | None = None,
+    ) -> mx.array:
         # inputs_embeds: [B, T, hidden]; position_ids: [T] or [B, T]
+        # logits_start: if given, only compute vocab logits for positions >=
+        # logits_start (usually just the text tail), skipping the audio prefix.
         B, T, _ = inputs_embeds.shape
         dtype = inputs_embeds.dtype
 
@@ -291,14 +298,17 @@ class GraniteEditor(nn.Module):
             position_ids = position_ids[0]
         cos, sin = self.rotary_emb(position_ids, dtype=h.dtype)
 
-        # 40 decoder layers
+        # 40 decoder layers (run over the FULL sequence -- attention needs it)
         for layer in self.layers:
             h = layer(h, cos, sin)
 
         h = self.norm(h)
 
         # Tied lm_head via as_linear (quantization-safe; equivalent to h @ W.T
-        # when the embedding is unquantized).
+        # when the embedding is unquantized). Slice to the text tail first when
+        # logits_start is given so we don't project (and discard) audio positions.
+        if logits_start is not None:
+            h = h[:, logits_start:, :]
         logits = self.embed_tokens.as_linear(h)
         logits = logits / self.logits_scaling
         return logits.astype(dtype)

--- a/mlx_audio/stt/models/granite_speech_nar/encoder.py
+++ b/mlx_audio/stt/models/granite_speech_nar/encoder.py
@@ -162,14 +162,17 @@ class ConformerConvModule(nn.Module):
     ):
         super().__init__()
         inner = hidden_dim * expansion
+        self._pad = kernel_size // 2
         self.norm = nn.LayerNorm(hidden_dim, eps=1e-5)
         # MLX Conv1d uses [B, T, C] inputs. Weights stored as [C_out, K, C_in/groups].
         self.up_conv = nn.Conv1d(hidden_dim, 2 * inner, kernel_size=1, bias=True)
+        # with nonzero padding, conv uses im2col with a gemm instead of the much faster
+        # depthwise_conv_1d. We omit padding here and re-add it in __call__
         self.depth_conv = nn.Conv1d(
             inner,
             inner,
             kernel_size=kernel_size,
-            padding=kernel_size // 2,
+            padding=0,
             groups=inner,
             bias=False,
         )
@@ -183,6 +186,8 @@ class ConformerConvModule(nn.Module):
         # GLU along channel dim: split into (a, gate), output = a * sigmoid(gate)
         a, gate = mx.split(h, 2, axis=-1)
         h = a * mx.sigmoid(gate)  # [B, T, inner]
+        # Apply the depthwise conv's (k//2) zero-padding outside
+        h = mx.pad(h, [(0, 0), (self._pad, self._pad), (0, 0)])
         h = self.depth_conv(h)  # [B, T, inner]
         h = self.bn(h)
         h = nn.silu(h)  # upstream order: silu(batch_norm(x))

--- a/mlx_audio/stt/models/granite_speech_nar/granite_speech_nar.py
+++ b/mlx_audio/stt/models/granite_speech_nar/granite_speech_nar.py
@@ -169,9 +169,12 @@ class Model(nn.Module):
         flat_embeds = mx.concatenate([audio_embeds[0], text_embeds], axis=0)[None]
         position_ids = mx.arange(audio_len + text_len, dtype=mx.int32)
 
-        logits = self.editor(inputs_embeds=flat_embeds, position_ids=position_ids)
-        text_logits = logits[0, audio_len:, :]
-        edited_argmax = mx.argmax(text_logits, axis=-1).astype(mx.int32)
+        logits = self.editor(
+            inputs_embeds=flat_embeds, position_ids=position_ids, logits_start=audio_len
+        )
+        # At this point we ONLY have the logits for the text tail, so we don't need to
+        # do anything else (logits_start=audio_len).
+        edited_argmax = mx.argmax(logits[0], axis=-1).astype(mx.int32)
         return ctc_collapse_decode(edited_argmax, blank_id=blank)
 
     def generate(


### PR DESCRIPTION
## Context

Granite speech NAR is extremely useful for homelab speech-to-text, as it runs much faster than realtime (and still much faster than the Whisper models above tiny). However, at least on M1 the provided kernels are slightly suboptimal. This PR pushes ~15% extra performance while maintaining accuracy with the original model. I've tested these results both in the standard BF16 as well as FP16, which is even faster on M1 and M1 Pro.

## Description

Provided a set of optimizations for Granite-Speech-4.1-2B-nar on MLX, mostly by targeting specialized mlx primitives. See additional information for benchmarks and accuracy tests

## Changes in the codebase

### Bit-identical changes

- Re-order padding in `Conv1d` layer, allowing use of MLX's faster `depthwise_conv_1d` backend. The padding is added back in after the convolution is done
- Pre-slice off audio logits when unneeded in the editor layer. We already sliced these off in a later step, so this just saves the work of projecting the bits we end up discarding
- Allow `mx.fast.scaled_dot_product_attention` to perform the required broadcast for the attention mechanism, avoiding explicit formation of tiled kv heads

### Floating-point identical changes

- Use mx.fast.RoPE instead of the hand-coded variant.
- Use mx.fast.rms_norm instead of the hand-coded variant. NOTE: I kept the helper class `GraniteRMSNorm` for backwards compatibility, but this is basically dead code now.



## Changes outside the codebase

N/A

## Additional information

### Performance (see script below to reproduce)

```
=== bf16 === (Original model, unquantized)
stage          original ms  optimized ms   speedup
--------------------------------------------------
io                 1.26          1.23      1.02x
features           1.15          0.96      1.19x
encoder          563.68        480.25      1.17x
projector         36.99         36.72      1.01x
editor           513.69        460.84      1.11x
decode             1.92          1.23      1.56x
--------------------------------------------------
original        1118.69 ms                RTFx 25.3x
optimized        981.23 ms                RTFx 28.9x


=== fp16 === (Pseudo-quantized, no memory savings but better latency)
stage          original ms  optimized ms   speedup
--------------------------------------------------
io                 1.33          1.23      1.09x
features           1.13          0.95      1.18x
encoder          489.82        417.00      1.17x
projector         32.53         32.27      1.01x
editor           447.90        390.72      1.15x
decode             1.85          1.25      1.48x
--------------------------------------------------
original         974.57 ms                RTFx 29.0x
optimized        843.42 ms                RTFx 33.6x
```

### Parity test (see script below to reproduce)

While the text output of this model is nearly identical to the original, the fast RoPE implementation accumulates enough floating-point differences to occasionally output different tokens. These changes yield a (barely) statistically significant change in WER, so it's up to the maintainers whether to accept or revert the `mx.fast` changes. All commits through [fe8d809](https://github.com/janbridley/mlx-audio/pull/1/commits/fe8d809c97b46c0ae1dc3eed3ecad2ca729217cb) are bit exact.
```
unnormalized WER (mean +/- stddev), 1000/dataset
----------------------------------------------------------------------
dataset                     original %     optimized %    Δ (opt-orig)
----------------------------------------------------------------------
ami_cleaned               21.23±14.05    21.26±14.03   +0.031±0.60
earnings22                22.87±14.29    22.92±14.31   +0.046±0.75
voxpopuli_cleaned_aa      24.80±10.01    24.83±9.94   +0.022±0.66
----------------------------------------------------------------------
pooled                    22.71±13.37    22.75±13.35   +0.034±0.68
----------------------------------------------------------------------
paired Δ = +0.0345%  (stddev 0.676%, SE 0.0132% over 2628 clips)
t = 2.62, 95% CI [+0.009, +0.060]%
Cohen's d = 0.051
----------------------------------------------------------------------
```

<!-- Optional: Add a checklist for contributors -->
## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Issue referenced (e.g., "Closes #...")