### PR TITLE
Fix circular import by moving wired_limit to stt/utils.py

### DIFF
--- a/mlx_audio/stt/generate.py
+++ b/mlx_audio/stt/generate.py
@@ -10,10 +10,9 @@ from typing import List, Optional, Union
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx.utils import tree_reduce
 
 from mlx_audio.stt.models.base import STTOutput
-from mlx_audio.stt.utils import load_model
+from mlx_audio.stt.utils import load_model, wired_limit
 
 
 def parse_args(argv: Optional[List[str]] = None):
@@ -239,46 +238,6 @@ def save_as_json(segments, output_path: str):
 
 # A stream on the default device just for generation
 generation_stream = mx.new_stream(mx.default_device())
-
-
-@contextlib.contextmanager
-def wired_limit(model: nn.Module, streams: Optional[List[mx.Stream]] = None):
-    """
-    A context manager to temporarily change the wired limit.
-
-    Note, the wired limit should not be changed during an async eval.  If an
-    async eval could be running pass in the streams to synchronize with prior
-    to exiting the context manager.
-    """
-    if not mx.metal.is_available():
-        try:
-            yield
-        finally:
-            pass
-    else:
-        model_bytes = tree_reduce(
-            lambda acc, x: acc + x.nbytes if isinstance(x, mx.array) else acc, model, 0
-        )
-        max_rec_size = mx.metal.device_info()["max_recommended_working_set_size"]
-        if model_bytes > 0.9 * max_rec_size:
-            model_mb = model_bytes // 2**20
-            max_rec_mb = max_rec_size // 2**20
-            print(
-                f"[WARNING] Generating with a model that requires {model_mb} MB "
-                f"which is close to the maximum recommended size of {max_rec_mb} "
-                "MB. This can be slow. See the documentation for possible work-arounds: "
-                "https://github.com/ml-explore/mlx-lm/tree/main#large-models"
-            )
-        old_limit = mx.set_wired_limit(max_rec_size)
-        try:
-            yield
-        finally:
-            if streams is not None:
-                for s in streams:
-                    mx.synchronize(s)
-            else:
-                mx.synchronize()
-            mx.set_wired_limit(old_limit)
 
 
 def generate_transcription(

--- a/mlx_audio/stt/models/glmasr/glmasr.py
+++ b/mlx_audio/stt/models/glmasr/glmasr.py
@@ -13,8 +13,7 @@ import mlx.nn as nn
 import numpy as np
 from tqdm import tqdm
 
-from mlx_audio.stt.generate import wired_limit
-from mlx_audio.stt.utils import get_model_path
+from mlx_audio.stt.utils import get_model_path, wired_limit
 
 from ..base import STTOutput
 from .config import LlamaConfig, ModelConfig, WhisperConfig

--- a/mlx_audio/stt/models/voxtral/voxtral.py
+++ b/mlx_audio/stt/models/voxtral/voxtral.py
@@ -10,8 +10,7 @@ import mlx.nn as nn
 import numpy as np
 from tqdm import tqdm
 
-from mlx_audio.stt.generate import wired_limit
-from mlx_audio.stt.utils import get_model_path
+from mlx_audio.stt.utils import get_model_path, wired_limit
 
 from ..base import STTOutput
 from .config import AudioConfig, ModelConfig

--- a/mlx_audio/stt/utils.py
+++ b/mlx_audio/stt/utils.py
@@ -1,13 +1,56 @@
+import contextlib
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx.utils import tree_reduce
 
 from mlx_audio.utils import base_load_model, get_model_path, load_config
 
 SAMPLE_RATE = 16000
+
+
+@contextlib.contextmanager
+def wired_limit(model: nn.Module, streams: Optional[List[mx.Stream]] = None):
+    """
+    A context manager to temporarily change the wired limit.
+
+    Note, the wired limit should not be changed during an async eval.  If an
+    async eval could be running pass in the streams to synchronize with prior
+    to exiting the context manager.
+    """
+    if not mx.metal.is_available():
+        try:
+            yield
+        finally:
+            pass
+    else:
+        model_bytes = tree_reduce(
+            lambda acc, x: acc + x.nbytes if isinstance(x, mx.array) else acc, model, 0
+        )
+        max_rec_size = mx.metal.device_info()["max_recommended_working_set_size"]
+        if model_bytes > 0.9 * max_rec_size:
+            model_mb = model_bytes // 2**20
+            max_rec_mb = max_rec_size // 2**20
+            print(
+                f"[WARNING] Generating with a model that requires {model_mb} MB "
+                f"which is close to the maximum recommended size of {max_rec_mb} "
+                "MB. This can be slow. See the documentation for possible work-arounds: "
+                "https://github.com/ml-explore/mlx-lm/tree/main#large-models"
+            )
+        old_limit = mx.set_wired_limit(max_rec_size)
+        try:
+            yield
+        finally:
+            if streams is not None:
+                for s in streams:
+                    mx.synchronize(s)
+            else:
+                mx.synchronize()
+            mx.set_wired_limit(old_limit)
+
 
 MODEL_REMAPPING = {
     "cohere_asr": "cohere_asr",


### PR DESCRIPTION
# Fix circular import between `stt.generate` and STT model modules

## Issue: #828 

## Context

Running the STT CLI entry point crashed immediately with an `ImportError`, making transcription unusable from the command line:

```
ImportError: cannot import name 'wired_limit' from partially initialized module
'mlx_audio.stt.generate' (most likely due to a circular import)
```

Any user invoking `mlx_audio.stt.generate` hit this before their audio was even touched, so the fix restores a core workflow of the package.

## Description

The failure was a circular import:

1. `mlx_audio/stt/generate.py` starts loading and imports `mlx_audio.stt.models.base`.
2. `mlx_audio/stt/models/__init__.py` eagerly imports all model subpackages, including `glmasr`.
3. `glmasr.py` (and `voxtral.py`) did `from mlx_audio.stt.generate import wired_limit` — but `generate.py` was still mid-import, so `wired_limit` (defined further down the file) didn't exist yet, raising the `ImportError`.

The cycle only triggered when `generate.py` was imported first (exactly what the CLI entry point does), which is why it could go unnoticed in code paths that import the models package first.

The fix moves `wired_limit` out of the CLI module into `mlx_audio/stt/utils.py`, which is a leaf module (it imports nothing from `stt.models` or `stt.generate`), so model code can use it without reaching back into the entry point.

## Changes in the codebase

- **`mlx_audio/stt/utils.py`**: `wired_limit` context manager moved here verbatim, along with the imports it needs (`contextlib`, `typing.List`, `mlx.utils.tree_reduce`).
- **`mlx_audio/stt/generate.py`**: function definition removed; now imports `wired_limit` from `stt.utils` and re-exports it, so any external code doing `from mlx_audio.stt.generate import wired_limit` keeps working. Dropped the now-unused `tree_reduce` import.
- **`mlx_audio/stt/models/glmasr/glmasr.py`** and **`mlx_audio/stt/models/voxtral/voxtral.py`**: import `wired_limit` from `mlx_audio.stt.utils` instead of `mlx_audio.stt.generate`, breaking the cycle in both models that had it.

No behavioral changes — `wired_limit` itself is unmodified.

## Changes outside the codebase

None. No changes to external services, infrastructure, dependencies, or model weights.

## Additional information

### Before (on `main`)

```
❯ uv run mlx_audio.stt.generate \
  --model mlx-community/VibeVoice-ASR-bf16 \
  --audio test.wav \
  --output-path output \
  --format json \
  --verbose
Traceback (most recent call last):
  File ".venv/bin/mlx_audio.stt.generate", line 4, in <module>
    from mlx_audio.stt.generate import main
  File "mlx_audio/stt/generate.py", line 15, in <module>
    from mlx_audio.stt.models.base import STTOutput
  File "mlx_audio/stt/models/__init__.py", line 1, in <module>
    from . import (
    ...<15 lines>...
    )
  File "mlx_audio/stt/models/glmasr/__init__.py", line 2, in <module>
    from .glmasr import Model, StreamingResult, STTOutput
  File "mlx_audio/stt/models/glmasr/glmasr.py", line 16, in <module>
    from mlx_audio.stt.generate import wired_limit
ImportError: cannot import name 'wired_limit' from partially initialized module
'mlx_audio.stt.generate' (most likely due to a circular import)
```

### After (this branch)

The same command imports cleanly and proceeds to model download/transcription:

```
❯ uv run mlx_audio.stt.generate \
  --model mlx-community/VibeVoice-ASR-bf16 \
  --audio test.wav \
  --output-path output \
  --format json \
  --verbose
Fetching 6 files:  17%|...
```

### Tests

STT test suite passes (weight-requiring tests deselected via `uv run pytest mlx_audio/tests/ mlx_audio/stt/tests/ -m "not requires_weights"`):

```
336 passed, 3 skipped, 6 deselected, 8 warnings in 9.32s
```

### Notes

<img width="1706" height="490" alt="image" src="https://github.com/user-attachments/assets/e217f929-5bd1-4064-848b-514cdcadaf1a" />

---
<img width="1718" height="213" alt="image" src="https://github.com/user-attachments/assets/9680af52-dcb1-4c47-b450-276ad10b4d7b" />

---
<img width="1717" height="937" alt="image" src="https://github.com/user-attachments/assets/6bd38858-7917-49ba-8d81-866a7eab3b76" />


## Checklist

- [ ] Closes #828 
