### PR TITLE
fix(higgs): strip delay-pattern BOS/EOS columns before codec decode

### DIFF
--- a/mlx_audio/tts/models/higgs_audio/generation.py
+++ b/mlx_audio/tts/models/higgs_audio/generation.py
@@ -31,6 +31,49 @@ def revert_delay_pattern(data: mx.array) -> mx.array:
     return mx.concatenate(rows, axis=0)
 
 
+def strip_stream_marker_columns(
+    aligned: mx.array,
+    bos_id: int,
+    eos_id: int,
+) -> mx.array:
+    """Drop delay-aligned columns that still carry stream BOS/EOS markers.
+
+    After ``revert_delay_pattern``, the EOS ramp-out leaves a trailing band of
+    mixed real-codes + ``audio_stream_eos_id`` (and a leading BOS band). The
+    common ``[:, 1:-1]`` trim only removes the all-marker edges; interior
+    contaminated columns survive and then ``clip(..., codebook_size - 1)`` maps
+    EOS/BOS onto the last valid codec id (1023), which decodes as a systematic
+    end-of-utterance breath / click.
+
+    This keeps only columns where every codebook is a real codec token.
+    """
+    assert aligned.ndim == 2, f"expected 2D [K, T], got {aligned.shape}"
+    if aligned.shape[1] == 0:
+        return aligned
+
+    # CPU scan is fine: T is O(seconds * 25 Hz), and we already sync elsewhere.
+    cols = aligned.tolist()  # list of K rows, each length T
+    num_codebooks = len(cols)
+    num_frames = len(cols[0]) if num_codebooks else 0
+    keep: list[int] = []
+    for t in range(num_frames):
+        if any(cols[k][t] == bos_id or cols[k][t] == eos_id for k in range(num_codebooks)):
+            continue
+        keep.append(t)
+
+    if not keep:
+        return mx.zeros((aligned.shape[0], 0), dtype=aligned.dtype)
+    if len(keep) == num_frames:
+        return aligned
+
+    # Contiguous keep range when markers only contaminate edges (normal case).
+    if keep[-1] - keep[0] + 1 == len(keep):
+        return aligned[:, keep[0] : keep[-1] + 1]
+
+    parts = [aligned[:, t : t + 1] for t in keep]
+    return mx.concatenate(parts, axis=1)
+
+
 def apply_delay_pattern(codebook_ids: mx.array, bos_id: int) -> mx.array:
     """Apply the delay pattern to a sequence of aligned codebook frames.
 

--- a/mlx_audio/tts/models/higgs_audio/higgs_audio.py
+++ b/mlx_audio/tts/models/higgs_audio/higgs_audio.py
@@ -29,6 +29,7 @@ from .generation import (
     lookup_audio_embedding,
     revert_delay_pattern,
     sample_audio,
+    strip_stream_marker_columns,
 )
 
 
@@ -433,10 +434,11 @@ class HiggsAudioModel(nn.Module):
                 through the audio dual-FFN path.
             max_new_frames: hard cap on generation length.
             temperature / top_p / top_k: sampling controls.
-            trim_boundaries: drop the synthetic BOS-seed (col 0) and EOS-seal
-                (col -1) columns after revert_delay_pattern. Default True;
-                required for clean codec decode (otherwise those columns
-                clip to codec token 1023 → audible click at sample-zero and end).
+            trim_boundaries: drop delay-pattern columns that still carry stream
+                BOS/EOS markers after revert (leading AUDIO_INIT / trailing EOS
+                ramp). Default True; required for clean codec decode — otherwise
+                ``clip`` maps those markers onto the last codec id and they
+                decode as a systematic breath/click at the ends.
 
         Returns:
             (aligned_tokens, info):
@@ -467,8 +469,12 @@ class HiggsAudioModel(nn.Module):
 
         sequence = mx.stack(frames, axis=1).astype(mx.int32)  # [K, N]
         aligned = revert_delay_pattern(sequence)  # [K, N-K+1]
-        if trim_boundaries and aligned.shape[1] >= 2:
-            aligned = aligned[:, 1:-1]
+        if trim_boundaries and aligned.shape[1] > 0:
+            aligned = strip_stream_marker_columns(
+                aligned,
+                bos_id=self.config.audio_stream_bos_id,
+                eos_id=self.config.audio_stream_eos_id,
+            )
         aligned = mx.clip(aligned, 0, self.config.audio_codebook_size - 1)
         info = {
             "num_frames_raw": sequence.shape[1],

--- a/mlx_audio/tts/models/higgs_audio/serve.py
+++ b/mlx_audio/tts/models/higgs_audio/serve.py
@@ -36,6 +36,7 @@ from .generation import (
     build_delay_pattern_mask,
     lookup_audio_embedding,
     revert_delay_pattern,
+    strip_stream_marker_columns,
 )
 from .higgs_audio import HiggsAudioModel
 
@@ -649,9 +650,13 @@ def iter_overlap_add_pcm(
     def _decode_current() -> Optional[np.ndarray]:
         sequence = mx.stack(frames_raw, axis=1).astype(mx.int32)
         aligned = revert_delay_pattern(sequence)
-        if aligned.shape[1] < 2:
+        if aligned.shape[1] == 0:
             return None
-        aligned = aligned[:, 1:-1]
+        aligned = strip_stream_marker_columns(
+            aligned,
+            bos_id=config.audio_stream_bos_id,
+            eos_id=config.audio_stream_eos_id,
+        )
         if aligned.shape[1] == 0:
             return None
         aligned = mx.clip(aligned, 0, audio_codebook_size - 1)

--- a/mlx_audio/tts/tests/test_higgs_audio.py
+++ b/mlx_audio/tts/tests/test_higgs_audio.py
@@ -13,6 +13,7 @@ from mlx_audio.tts.models.higgs_audio.generation import (
     lookup_audio_embedding,
     revert_delay_pattern,
     sample_audio,
+    strip_stream_marker_columns,
 )
 from mlx_audio.tts.models.higgs_audio.higgs_audio import HiggsAudioModel
 
@@ -77,6 +78,39 @@ class TestDelayPattern(unittest.TestCase):
         # After revert, shape is [K, L+K-1-K+1] = [K, L]
         self.assertEqual(reverted.shape, (K, L))
         np.testing.assert_array_equal(np.array(reverted), np.array(content))
+
+
+class TestStripStreamMarkerColumns(unittest.TestCase):
+    """EOS/BOS marker columns must not survive into codec decode."""
+
+    def test_strips_mixed_eos_tail_that_one_colon_misses(self):
+        """[:, 1:-1] leaves mixed EOS+code columns; strip removes them."""
+        bos_id, eos_id = 1024, 1025
+        # [K=4, T=6]: leading BOS, clean middle, trailing mixed/full EOS
+        aligned = mx.array(
+            [
+                [bos_id, 10, 11, 12, eos_id, eos_id],
+                [bos_id, 20, 21, eos_id, eos_id, 25],
+                [bos_id, 30, 31, 32, eos_id, 35],
+                [bos_id, 40, 41, 42, 43, eos_id],
+            ],
+            dtype=mx.int32,
+        )
+        naive = np.array(aligned[:, 1:-1])
+        self.assertTrue(np.any(naive == eos_id), "precondition: naive trim keeps EOS")
+
+        cleaned = strip_stream_marker_columns(aligned, bos_id=bos_id, eos_id=eos_id)
+        cleaned_np = np.array(cleaned)
+        self.assertEqual(cleaned_np.shape, (4, 2))
+        np.testing.assert_array_equal(
+            cleaned_np, np.array([[10, 11], [20, 21], [30, 31], [40, 41]])
+        )
+        self.assertFalse(np.any((cleaned_np == bos_id) | (cleaned_np == eos_id)))
+
+    def test_strip_noop_on_clean_codes(self):
+        aligned = mx.arange(12, dtype=mx.int32).reshape(3, 4)
+        out = strip_stream_marker_columns(aligned, bos_id=1024, eos_id=1025)
+        np.testing.assert_array_equal(np.array(out), np.array(aligned))
 
 
 class TestAudioEmbedding(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Higgs delay-pattern EOS ramp leaves mixed marker+code columns after `revert_delay_pattern`.
- `[:, 1:-1]` only drops all-marker edges; surviving `audio_stream_eos_id` values were `clip`'d to 1023 and decoded as a systematic end breath.
- Replace that trim with `strip_stream_marker_columns` (oneshot + overlap-add decode paths).

Fixes #842

## Why this is not the Qwen3 fix
Qwen3 trailing breath is late `codec_eos` sampling after PR 695 (tracked separately). Higgs is a **post-revert token hygiene** bug in the delay-pattern pipeline.

## Test plan
- [ ] `python -m unittest mlx_audio.tts.tests.test_higgs_audio.TestStripStreamMarkerColumns`
- [ ] Voice-clone oneshot: check end of WAV no longer has the systematic breath
- [ ] `stream=True` overlap-add path: same check on final chunk