### PR TITLE
feat: add dots tts support

### DIFF
--- a/docs/models/tts/dots.md
+++ b/docs/models/tts/dots.md
@@ -1,0 +1,102 @@
+# Dots TTS
+
+Dots TTS is a multilingual voice-cloning model ported to MLX for Apple Silicon. The current `mlx-audio` integration supports local converted checkpoints in the repo's `dots` layout and has been verified on the `shraey/dots-tts-mlx` checkpoints.
+
+## Model Variants
+
+| Model | Notes | HuggingFace |
+|-------|-------|-------------|
+| `shraey/dots-tts-mlx` `int4` | Verified in `mlx-audio`; 48 kHz output | [:octicons-link-external-16: Model Card](https://huggingface.co/shraey/dots-tts-mlx) |
+| `shraey/dots-tts-mlx` `int8` | Same layout, larger footprint | [:octicons-link-external-16: Model Card](https://huggingface.co/shraey/dots-tts-mlx) |
+| `shraey/dots-tts-mlx` `mf-int4` / `mf-int8` | Meanflow variants | [:octicons-link-external-16: Model Card](https://huggingface.co/shraey/dots-tts-mlx) |
+
+!!! note
+    The loader expects the local checkpoint directory itself to contain `config.json`, `llm_config.json`, `core.safetensors`, `vocoder.safetensors`, `speaker.safetensors`, `latent_stats.npz`, and a `tokenizer/` directory.
+
+## Features
+
+- Multilingual TTS
+- Zero-shot voice cloning
+- 48 kHz waveform output
+- Local-path friendly loading for converted checkpoints
+- Flow-matching and meanflow checkpoint variants
+
+## Usage
+
+### Basic Generation
+
+=== "CLI"
+
+    ```bash
+    mlx_audio.tts.generate \
+        --model /path/to/dots-checkpoint \
+        --text "Hello from Dots TTS on MLX." \
+        --lang_code en
+    ```
+
+=== "Python"
+
+    ```python
+    from mlx_audio.tts.utils import load_model
+
+    model = load_model("/path/to/dots-checkpoint")
+    result = next(model.generate(
+        text="Hello from Dots TTS on MLX.",
+        lang_code="en",
+    ))
+
+    audio = result.audio
+    ```
+
+### Voice Cloning
+
+Dots cloning requires both the reference audio and its transcript.
+
+=== "CLI"
+
+    ```bash
+    mlx_audio.tts.generate \
+        --model /path/to/dots-checkpoint \
+        --text "This should sound like the reference speaker." \
+        --lang_code en \
+        --ref_audio reference.wav \
+        --ref_text "This is what the reference speaker says."
+    ```
+
+=== "Python"
+
+    ```python
+    from mlx_audio.tts.utils import load_model
+
+    model = load_model("/path/to/dots-checkpoint")
+    result = next(model.generate(
+        text="This should sound like the reference speaker.",
+        ref_audio="reference.wav",
+        ref_text="This is what the reference speaker says.",
+        lang_code="en",
+    ))
+
+    audio = result.audio
+    ```
+
+!!! important
+    Dots currently supports a single `ref_audio` / `ref_text` pair per request. Passing
+    `ref_text` is recommended for cloning: native WAV prompt paths expect an explicit
+    transcript, while non-WAV references that go through the shared decoder can still fall
+    back to STT when an `stt_model` is available.
+
+## Languages
+
+The verified `shraey/dots-tts-mlx` checkpoints advertise support for 24 languages:
+Arabic, Cantonese, Chinese, Czech, Dutch, English, Finnish, French, German, Greek, Hindi, Indonesian, Italian, Japanese, Korean, Polish, Portuguese, Romanian, Russian, Spanish, Thai, Turkish, Ukrainian, and Vietnamese.
+
+## Notes
+
+- The wrapper preserves the raw reference audio path so the Dots runtime can handle its own prompt-audio loading and resampling.
+- The current implementation normalizes `lang_code="en"` style inputs to uppercase runtime language tags.
+- On memory-constrained Apple Silicon machines, set `MLX_AUDIO_DOTS_MEMORY_LIMIT_GB` to a conservative value before loading the model.
+
+## Links
+
+- [:octicons-mark-github-16: Source code](https://github.com/Blaizzy/mlx-audio/tree/main/mlx_audio/tts/models/dots)
+- [:octicons-link-external-16: shraey/dots-tts-mlx](https://huggingface.co/shraey/dots-tts-mlx)

--- a/docs/models/tts/index.md
+++ b/docs/models/tts/index.md
@@ -17,6 +17,7 @@ MLX-Audio supports a wide range of TTS models optimized for Apple Silicon. Each 
 | [**CSM / MisoTTS**](csm.md) | 1B / 8B | EN | Yes | Yes | Sesame-style conversational speech, voice cloning, multi-turn context |
 | [**Dia**](dia.md) | 1.6B | EN | -- | -- | Dialogue with `[S1]`/`[S2]` speaker tags |
 | [**Chatterbox**](chatterbox.md) | -- | EN + 15 languages | Yes | -- | Expressive, emotion exaggeration control |
+| [**Dots TTS**](dots.md) | -- | 24 languages | Yes | -- | 48 kHz multilingual cloning with transcript-conditioned prompts |
 | [KugelAudio](kugelaudio.md) | 7B | 24 European languages | -- | -- | VibeVoice-based multilingual TTS with diffusion decoding |
 | [Spark](https://github.com/Blaizzy/mlx-audio/tree/main/mlx_audio/tts/models/spark) | 0.5B | EN, ZH | -- | -- | SparkTTS model |
 | [OuteTTS](https://huggingface.co/mlx-community/OuteTTS-1.0-0.6B-fp16) | 0.6B | EN | -- | -- | Efficient TTS |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - CSM: models/tts/csm.md
       - Dia: models/tts/dia.md
       - Chatterbox: models/tts/chatterbox.md
+      - Dots TTS: models/tts/dots.md
     - Speech-to-Text:
       - models/stt/index.md
       - Whisper: models/stt/whisper.md

--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -144,8 +144,28 @@ def _model_accepts_ref_text(model: nn.Module) -> bool:
         return False
 
 
+def _model_bool_flag(model: nn.Module, name: str, default: bool) -> bool:
+    value = inspect.getattr_static(model, name, default)
+    if isinstance(value, bool):
+        return value
+    return default
+
+
 def _model_preserves_ref_audio_paths(model: nn.Module) -> bool:
-    return getattr(model, "preserve_ref_audio_path", False) is True
+    return _model_bool_flag(model, "preserve_ref_audio_path", False)
+
+
+def _model_supports_multiple_references(model: nn.Module) -> bool:
+    return _model_bool_flag(model, "supports_multiple_references", True)
+
+
+def _should_preserve_ref_audio_path_item(model: nn.Module, ref_audio_item: Any) -> bool:
+    if not _model_preserves_ref_audio_paths(model):
+        return False
+    if not isinstance(ref_audio_item, (str, PathLike)):
+        return False
+    suffix = os.path.splitext(os.fspath(ref_audio_item))[1].lower()
+    return suffix in {".wav", ".wave"}
 
 
 def generate_audio(
@@ -176,6 +196,7 @@ def generate_audio(
     streaming_interval: float = 2.0,
     save: bool = False,
     use_zero_spk_emb: bool = False,
+    subdir: Optional[str] = None,
     **kwargs,
 ) -> None:
     """
@@ -212,7 +233,7 @@ def generate_audio(
 
         if isinstance(model, str):
             # Load model
-            model = load_model(model_path=model)
+            model = load_model(model_path=model, subdir=subdir)
 
         ref_audio_values = _as_reference_list(ref_audio)
         ref_text_values = _as_reference_list(ref_text)
@@ -226,6 +247,13 @@ def generate_audio(
             raise ValueError(
                 "Multiple ref_text values require matching ref_audio values."
             )
+        if not _model_supports_multiple_references(model) and (
+            len(ref_audio_values) > 1 or len(ref_text_values) > 1
+        ):
+            raise ValueError(
+                f"{getattr(model, 'model_type', 'This model')} supports only a single "
+                "ref_audio/ref_text pair."
+            )
 
         # Load reference audio for voice matching if specified. Some models own
         # reference preprocessing and should receive paths unchanged.
@@ -235,27 +263,17 @@ def generate_audio(
                 normalize = True
 
             preserve_ref_paths = _model_preserves_ref_audio_paths(model)
-            if preserve_ref_paths:
-                loaded_ref_audio = []
-                for ref_audio_item in ref_audio_values:
-                    if isinstance(ref_audio_item, (str, PathLike)):
-                        ref_audio_path = os.fspath(ref_audio_item)
-                        if not os.path.exists(ref_audio_path):
-                            raise FileNotFoundError(
-                                f"Reference audio file not found: {ref_audio_path}"
-                            )
+            loaded_ref_audio = []
+            for ref_audio_item in ref_audio_values:
+                if isinstance(ref_audio_item, (str, PathLike)):
+                    ref_audio_path = os.fspath(ref_audio_item)
+                    if not os.path.exists(ref_audio_path):
+                        raise FileNotFoundError(
+                            f"Reference audio file not found: {ref_audio_path}"
+                        )
+                    if _should_preserve_ref_audio_path_item(model, ref_audio_item):
                         loaded_ref_audio.append(ref_audio_path)
                     else:
-                        loaded_ref_audio.append(ref_audio_item)
-            else:
-                loaded_ref_audio = []
-                for ref_audio_item in ref_audio_values:
-                    if isinstance(ref_audio_item, (str, PathLike)):
-                        ref_audio_path = os.fspath(ref_audio_item)
-                        if not os.path.exists(ref_audio_path):
-                            raise FileNotFoundError(
-                                f"Reference audio file not found: {ref_audio_path}"
-                            )
                         loaded_ref_audio.append(
                             load_audio(
                                 ref_audio_path,
@@ -263,13 +281,15 @@ def generate_audio(
                                 volume_normalize=normalize,
                             )
                         )
-                    else:
-                        loaded_ref_audio.append(ref_audio_item)
+                else:
+                    loaded_ref_audio.append(ref_audio_item)
             ref_audio = _collapse_reference_list(loaded_ref_audio)
 
             if ref_text_values:
                 ref_text = _collapse_reference_list(ref_text_values)
-            elif preserve_ref_paths:
+            elif preserve_ref_paths and any(
+                isinstance(item, (str, PathLike)) for item in loaded_ref_audio
+            ):
                 ref_text = None
             elif _model_accepts_ref_text(model):
                 if stt_model is None:
@@ -442,11 +462,13 @@ def generate_audio(
         print(
             "This might be due to incorrect Python path. Check your project structure."
         )
+        raise
     except Exception as e:
         print(f"Error loading model: {e}")
         import traceback
 
         traceback.print_exc()
+        raise
 
 
 def parse_args():
@@ -561,6 +583,15 @@ def parse_args():
     parser.add_argument("--play", action="store_true", help="Play the output audio")
     parser.add_argument(
         "--audio_format", type=str, default="wav", help="Output audio format"
+    )
+    parser.add_argument(
+        "--subdir",
+        type=str,
+        default=None,
+        help=(
+            "Optional checkpoint subdir for multi-variant repos such as Dots. "
+            "Defaults to int4 when loading a Dots multi-variant root."
+        ),
     )
     parser.add_argument(
         "--ref_audio",

--- a/mlx_audio/tts/models/dots/__init__.py
+++ b/mlx_audio/tts/models/dots/__init__.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Optional, cast
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_audio.tts.models.base import BaseModelArgs, GenerationResult
+from mlx_audio.utils import get_model_path
+
+DOTS_MODEL_TYPES = {"dots", "dots_tts", "dots_tts_mlx"}
+DOTS_DEFAULT_SUBDIR = "int4"
+
+
+def _load_config_if_exists(model_path: Path) -> dict:
+    config_path = model_path / "config.json"
+    if not config_path.exists():
+        return {}
+    return json.loads(config_path.read_text(encoding="utf-8"))
+
+
+def _looks_like_dots_checkpoint(
+    model_path: Path, config: Optional[dict] = None
+) -> bool:
+    config = config or {}
+    model_type = config.get("model_type") or config.get("architecture")
+    if isinstance(model_type, str) and model_type.lower() in DOTS_MODEL_TYPES:
+        return True
+    required = {
+        "config.json",
+        "llm_config.json",
+        "core.safetensors",
+        "vocoder.safetensors",
+        "speaker.safetensors",
+    }
+    if not model_path.exists() or not model_path.is_dir():
+        return False
+    names = {item.name for item in model_path.iterdir()}
+    return required.issubset(names)
+
+
+def _available_variant_dirs(model_root: Path) -> list[str]:
+    if not model_root.exists() or not model_root.is_dir():
+        return []
+    variants = []
+    for item in sorted(model_root.iterdir()):
+        if item.is_dir() and _looks_like_dots_checkpoint(
+            item, _load_config_if_exists(item)
+        ):
+            variants.append(item.name)
+    return variants
+
+
+def _resolve_checkpoint_path(
+    model_path: str | Path, subdir: Optional[str] = None, **kwargs
+) -> Path:
+    resolved_subdir = subdir or DOTS_DEFAULT_SUBDIR
+    if isinstance(model_path, str):
+        allow_patterns = kwargs.get("allow_patterns")
+        if allow_patterns is None:
+            allow_patterns = [f"{resolved_subdir}/*", f"{resolved_subdir}/**"]
+        resolved_path = get_model_path(
+            model_path,
+            revision=kwargs.get("revision", None),
+            force_download=kwargs.get("force_download", False),
+            allow_patterns=allow_patterns,
+        )
+    else:
+        resolved_path = Path(model_path).expanduser()
+
+    if _looks_like_dots_checkpoint(
+        resolved_path, _load_config_if_exists(resolved_path)
+    ):
+        return resolved_path
+
+    candidate = resolved_path / resolved_subdir
+    if _looks_like_dots_checkpoint(candidate, _load_config_if_exists(candidate)):
+        return candidate
+
+    available_variants = _available_variant_dirs(resolved_path)
+    if available_variants:
+        available = ", ".join(available_variants)
+        raise FileNotFoundError(
+            f"Dots checkpoint variant '{resolved_subdir}' not found under {resolved_path}. "
+            f"Available variants: {available}"
+        )
+
+    raise FileNotFoundError(
+        f"Could not resolve a Dots checkpoint from {resolved_path}. Expected either a "
+        "checkpoint directory or a multi-variant repo root containing a "
+        f"'{resolved_subdir}' subdirectory."
+    )
+
+
+@dataclass
+class ModelConfig(BaseModelArgs):
+    model_type: str = "dots"
+    model_path: str = ""
+    sample_rate: int = 48000
+    dtype: str = "bfloat16"
+    use_long_text: bool = False
+
+
+def _resolve_dtype(dtype_name: str) -> mx.Dtype:
+    mapping = {
+        "float16": mx.float16,
+        "bfloat16": mx.bfloat16,
+        "float32": mx.float32,
+    }
+    return mapping.get(dtype_name, mx.bfloat16)
+
+
+def _duration_string(samples: int, sample_rate: int) -> str:
+    if sample_rate <= 0:
+        return "00:00:00.000"
+    total_seconds = samples / sample_rate
+    hours = int(total_seconds // 3600)
+    minutes = int((total_seconds % 3600) // 60)
+    seconds = int(total_seconds % 60)
+    millis = int((total_seconds % 1) * 1000)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{millis:03d}"
+
+
+def _coerce_runtime_results(result: Any) -> list[Any]:
+    if isinstance(result, GenerationResult):
+        return [result]
+    if isinstance(result, dict):
+        return [result]
+    if isinstance(result, Iterable) and not isinstance(result, (str, bytes)):
+        return list(result)
+    raise TypeError(f"Unsupported dots runtime result type: {type(result)}")
+
+
+class Model(nn.Module):
+    preserve_ref_audio_path = True
+    supports_multiple_references = False
+
+    def __init__(self, config: ModelConfig | dict):
+        super().__init__()
+        self.config = (
+            config if isinstance(config, ModelConfig) else ModelConfig.from_dict(config)
+        )
+        self.sample_rate = int(self.config.sample_rate)
+        self._runtime = None
+
+    def load_runtime(self) -> "Model":
+        runtime = cast(
+            Any, getattr(self, "_runtime", None) or getattr(self, "runtime", None)
+        )
+        if runtime is None:
+            from .loader import from_pretrained
+
+            loaded = from_pretrained(
+                self.config.model_path,
+                dtype=_resolve_dtype(self.config.dtype),
+            )
+            runtime = loaded.model
+        self._runtime = runtime
+        sample_rate = getattr(runtime, "sample_rate", None)
+        if sample_rate is not None:
+            self.sample_rate = int(sample_rate)
+        return self
+
+    def eval(self):
+        return self
+
+    def generate(
+        self,
+        text: str,
+        ref_audio: str | Path | None = None,
+        ref_text: str | None = None,
+        lang_code: str | None = None,
+        language: str | None = None,
+        long: bool | None = None,
+        **kwargs,
+    ):
+        self.load_runtime()
+        if language is None and lang_code:
+            language = str(lang_code).upper()
+
+        use_long_text = bool(
+            long if long is not None else getattr(self.config, "use_long_text", False)
+        )
+        runtime_generate = getattr(
+            self._runtime,
+            "generate_long" if use_long_text else "generate",
+        )
+
+        runtime_kwargs = dict(kwargs)
+        runtime_kwargs.pop("voice", None)
+        runtime_kwargs.pop("speed", None)
+        runtime_kwargs.pop("temperature", None)
+        runtime_kwargs.pop("verbose", None)
+        runtime_kwargs.pop("stream", None)
+        runtime_kwargs.pop("streaming_interval", None)
+        runtime_kwargs.pop("instruct", None)
+        runtime_kwargs.pop("use_zero_spk_emb", None)
+        runtime_kwargs.pop("prompt", None)
+        runtime_kwargs.pop("sigma", None)
+        runtime_kwargs.pop("subdir", None)
+
+        max_tokens = runtime_kwargs.pop("max_tokens", None)
+        if max_tokens is not None and "max_generate_length" not in runtime_kwargs:
+            runtime_kwargs["max_generate_length"] = max_tokens
+
+        cfg_scale = runtime_kwargs.pop("cfg_scale", None)
+        if cfg_scale is not None and "guidance_scale" not in runtime_kwargs:
+            runtime_kwargs["guidance_scale"] = cfg_scale
+
+        ddpm_steps = runtime_kwargs.pop("ddpm_steps", None)
+        if ddpm_steps is not None and "num_steps" not in runtime_kwargs:
+            runtime_kwargs["num_steps"] = ddpm_steps
+
+        start_time = time.perf_counter()
+        result = runtime_generate(
+            text=text,
+            prompt_audio=ref_audio,
+            prompt_text=ref_text,
+            language=language,
+            **runtime_kwargs,
+        )
+        elapsed_time = time.perf_counter() - start_time
+
+        for index, item in enumerate(_coerce_runtime_results(result)):
+            if isinstance(item, GenerationResult):
+                yield item
+                continue
+
+            audio = item["audio"]
+            shape = getattr(audio, "shape", ())
+            if len(shape) > 1 and shape[0] == 1:
+                audio = audio[0]
+
+            sample_rate = int(item.get("sample_rate", self.sample_rate))
+            samples = int(item.get("samples", getattr(audio, "shape", [0])[-1]))
+            processing_time = float(item.get("processing_time_seconds", elapsed_time))
+            prompt = dict(item.get("prompt", {}))
+            if "tokens-per-sec" not in prompt:
+                prompt["tokens-per-sec"] = (
+                    int(item.get("token_count", item.get("num_patches", 0)))
+                    / processing_time
+                    if processing_time > 0
+                    else 0.0
+                )
+
+            audio_samples = dict(item.get("audio_samples", {}))
+            audio_samples.setdefault("samples", samples)
+            if "samples-per-sec" not in audio_samples:
+                audio_samples["samples-per-sec"] = (
+                    samples / processing_time if processing_time > 0 else 0.0
+                )
+
+            yield GenerationResult(
+                audio=audio,
+                samples=samples,
+                sample_rate=sample_rate,
+                segment_idx=int(item.get("segment_idx", index)),
+                token_count=int(item.get("token_count", item.get("num_patches", 0))),
+                audio_duration=item.get(
+                    "audio_duration",
+                    _duration_string(samples, sample_rate),
+                ),
+                real_time_factor=(
+                    (samples / sample_rate / processing_time)
+                    if processing_time > 0 and sample_rate > 0
+                    else 0.0
+                ),
+                prompt=prompt,
+                audio_samples=audio_samples,
+                processing_time_seconds=processing_time,
+                peak_memory_usage=float(
+                    item.get("peak_memory_usage", mx.get_peak_memory() / 1e9)
+                ),
+            )
+
+
+def load_model(
+    model_path: str | Path,
+    lazy: bool = False,
+    strict: bool = True,
+    subdir: Optional[str] = None,
+    **kwargs,
+) -> Model:
+    del strict
+    resolved_path = _resolve_checkpoint_path(model_path, subdir=subdir, **kwargs)
+    config_path = resolved_path / "config.json"
+    config_data = {}
+    if config_path.exists():
+        config_data = json.loads(config_path.read_text(encoding="utf-8"))
+    config_data.setdefault("model_type", "dots")
+    config_data.setdefault("sample_rate", 48000)
+    config_data["model_path"] = str(resolved_path)
+    model = Model(ModelConfig.from_dict(config_data))
+    if not lazy:
+        model.load_runtime()
+    return model
+
+
+__all__ = ["DOTS_MODEL_TYPES", "Model", "ModelConfig", "load_model"]

--- a/mlx_audio/tts/models/dots/audiovae.py
+++ b/mlx_audio/tts/models/dots/audiovae.py
@@ -1,0 +1,302 @@
+"""Pure-MLX AudioVAE encode + decode paths (BigVGAN-style alias-free causal vocoder).
+
+Imports ONLY mlx — never torch, never numpy. Ports two halves of
+``dots_tts.modules.vocoder.bigvgan.AudioVAE``:
+
+  decode (``inference_from_latents``, do_sample=False):
+    post_proj (Conv1d k=1) -> [B,C,T]->[B,T,C]
+      -> dec_mi_layer (Linear, SLSTM x4, Linear)
+      -> [B,T,C]->[B,C,T] -> Decoder -> clamp(-1, 1)  (48 kHz waveform)
+
+  encode (``extract_latents``, do_sample=False):
+    audio_encoder (Encoder: Conv1d_S stack + ResStacks, /1920) -> [B,C,T]->[B,T,C]
+      -> enc_mi_layer (Linear, SLSTM x4, Linear) -> [B,T,C]->[B,C,T]
+      -> pre_proj (Conv1d k=1, -> 2*latent_dim)  (the mean/log_std pair [B,256,T])
+
+All tensors flow internally as NLC ``[B, T, C]`` (MLX-native). The SnakeBeta
+*activation* math is forced fp32 (see ``_snakebeta``); everything else runs at the
+runtime ``dtype`` EXCEPT the tiny alias-free filter taps, which ``loader.py`` keeps
+fp32 unconditionally (cheap + parity-stable). Alias-free low-pass filters are LOADED
+from the checkpoint (no Kaiser recompute). Weights are bound by ``loader.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import mlx.core as mx
+
+from .config import VocoderConfig
+from .layers import Conv1d, ConvTranspose1d, hp_matmul, replicate_pad
+
+
+def _snakebeta(x: mx.array, alpha: mx.array, beta: mx.array) -> mx.array:
+    """SnakeBeta (logscale) over an NLC tensor: ``x + 1/(exp(beta)+eps) * sin(x*exp(alpha))^2``.
+
+    ``alpha`` / ``beta`` are ``[C]``; broadcast over (B, T). Computed in fp32.
+    """
+    x32 = x.astype(mx.float32)
+    a = mx.exp(alpha.astype(mx.float32))
+    b = mx.exp(beta.astype(mx.float32))
+    s = mx.sin(x32 * a)
+    return x32 + (1.0 / (b + 1e-9)) * (s * s)
+
+
+@dataclass
+class _AliasFreeResampler:
+    """Causal alias-free up/down sampler around a SnakeBeta activation.
+
+    Filters are depthwise MLX-layout kernels ``[C, k, 1]`` loaded from the
+    checkpoint. ``up_filter`` drives ``UpSample1d`` (conv_transpose, scale x ratio,
+    causal trim of ``k_up - ratio``); ``down_filter`` drives the ``LowPassFilter1d``
+    (causal left-pad ``k_down - 1``, replicate pad, depthwise conv stride=ratio).
+    """
+
+    up_filter: mx.array
+    down_filter: mx.array
+    alpha: mx.array
+    beta: mx.array
+    ratio: int = 2
+
+    @property
+    def _k_up(self) -> int:
+        return self.up_filter.shape[1]
+
+    @property
+    def _k_down(self) -> int:
+        return self.down_filter.shape[1]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        c = x.shape[2]
+        x32 = x.astype(mx.float32)
+        # The depthwise up/down filters + the replicate (edge-clamp) pad bypass the
+        # layers.py Conv1d classes on purpose: those handle channel-mixing zero-pad
+        # convs, whereas here we need grouped (depthwise, groups=c) convs with a
+        # replicate left-pad, so we call mx.conv* directly. Filter taps are fp32
+        # (kept so by loader.py), matching the fp32 x32 here.
+        # UpSample1d (causal pad=0): conv_transpose, scale x ratio, trim last (k-stride).
+        up = self.ratio * mx.conv_transpose1d(
+            x32, self.up_filter, stride=self.ratio, padding=0, groups=c
+        )
+        up = up[:, : -(self._k_up - self.ratio), :]
+        # SnakeBeta activation at the upsampled rate.
+        act = _snakebeta(up, self.alpha, self.beta)
+        # DownSample1d -> LowPassFilter1d (causal): replicate-pad k-1, conv stride=ratio.
+        padded = replicate_pad(act, self._k_down - 1, 0)
+        down = mx.conv1d(
+            padded, self.down_filter, stride=self.ratio, padding=0, groups=c
+        )
+        return down
+
+
+@dataclass
+class _AMPBlock1:
+    """Anti-aliased multi-periodicity composition block (kernel_size, dilation=(1,3,5)).
+
+    ``x = x + convs2[j](acts2[j](convs1[j](acts1[j](x))))`` for j in 0..2, where
+    acts1 = activations[::2], acts2 = activations[1::2] (6 resamplers total).
+    """
+
+    convs1: list[Conv1d]
+    convs2: list[Conv1d]
+    acts: list[_AliasFreeResampler]  # 6 total
+
+    def __call__(self, x: mx.array) -> mx.array:
+        acts1 = self.acts[0::2]
+        acts2 = self.acts[1::2]
+        for c1, c2, a1, a2 in zip(self.convs1, self.convs2, acts1, acts2):
+            xt = a1(x)
+            xt = c1(xt)
+            xt = a2(xt)
+            xt = c2(xt)
+            x = xt + x
+        return x
+
+
+@dataclass
+class _SLSTM:
+    """Unidirectional residual LSTM (skip=True) over NLC ``[B, T, C]``.
+
+    PyTorch gate order is i, f, g, o. Uses both ``bias_ih`` + ``bias_hh``. Weights
+    per layer are stored in torch layout: ``weight_ih`` ``[4H, in]``, ``weight_hh``
+    ``[4H, H]`` (here in == H). ``y = lstm(x) + x``.
+    """
+
+    weight_ih: list[mx.array]  # per layer, [4H, H]
+    weight_hh: list[mx.array]  # per layer, [4H, H]
+    bias_ih: list[mx.array]  # per layer, [4H]
+    bias_hh: list[mx.array]  # per layer, [4H]
+    num_layers: int
+    hp: bool = False  # true fp32 matmul reduction (encode path; max-abs gated)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        residual = x
+        b, t, h = x.shape
+        mm = hp_matmul if self.hp else (lambda a, w_t: a @ w_t)
+        for layer in range(self.num_layers):
+            w_ih = self.weight_ih[layer]
+            w_hh = self.weight_hh[layer]
+            bias = self.bias_ih[layer] + self.bias_hh[layer]  # [4H]
+            # Precompute the input projection for every timestep: [B, T, 4H].
+            gates_in = mm(x, w_ih.T) + bias
+            hx = mx.zeros((b, h), dtype=x.dtype)
+            cx = mx.zeros((b, h), dtype=x.dtype)
+            outputs = []
+            for ts in range(t):
+                gates = gates_in[:, ts, :] + mm(hx, w_hh.T)
+                i_g, f_g, g_g, o_g = mx.split(gates, 4, axis=-1)
+                i_g = mx.sigmoid(i_g)
+                f_g = mx.sigmoid(f_g)
+                g_g = mx.tanh(g_g)
+                o_g = mx.sigmoid(o_g)
+                cx = f_g * cx + i_g * g_g
+                hx = o_g * mx.tanh(cx)
+                outputs.append(hx)
+            x = mx.stack(outputs, axis=1)
+        return x + residual
+
+
+def _leaky_relu(x: mx.array, slope: float) -> mx.array:
+    """LeakyReLU: ``max(x, 0) + slope * min(x, 0)`` (mirrors ``nn.LeakyReLU``)."""
+    return mx.where(x >= 0, x, x * slope)
+
+
+@dataclass
+class _ResStack:
+    """Causal residual conv stack (upstream ``ResStack``, ``nums`` blocks).
+
+    Each block: ``x = x + conv2(LeakyReLU(conv1(LeakyReLU(x))))`` where conv1 has
+    dilation ``base**i`` (k=3, causal left-pad ``dil*2``) and conv2 has dilation 1
+    (k=3, causal left-pad 2). The two LeakyReLUs use the default slope 0.01.
+    """
+
+    convs1: list[Conv1d]  # dilated, per block
+    convs2: list[Conv1d]  # dilation=1, per block
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for c1, c2 in zip(self.convs1, self.convs2):
+            h = _leaky_relu(x, 0.01)
+            h = c1(h)
+            h = _leaky_relu(h, 0.01)
+            h = c2(h)
+            x = x + h
+        return x
+
+
+@dataclass
+class _Encoder:
+    """AudioVAE waveform encoder (upstream ``Encoder.generator`` Sequential).
+
+    Structure (NLC tensors):
+      pre = Conv1d_S(1->base, k=3, s=1, causal) ; LeakyReLU(0.2)
+      per stage i: Conv1d_S(in->out, k=2*down, s=down, causal) ; ResStack ; LeakyReLU(0.2)
+      post (lookahead=2): Conv1d_S(last->latent_dim, k=5, s=1, NON-causal)
+
+    The lookahead post-conv is non-causal (kernel = 2*lookahead+1 = 5), matching
+    upstream where ``causal=False`` is hard-set for the lookahead branch.
+    """
+
+    pre_conv: Conv1d
+    down_convs: list[Conv1d]
+    res_stacks: list[_ResStack]
+    post_conv: Conv1d
+    act_slope: float = 0.2
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.pre_conv(x)
+        x = _leaky_relu(x, self.act_slope)
+        for dc, rs in zip(self.down_convs, self.res_stacks):
+            x = dc(x)
+            x = rs(x)
+            x = _leaky_relu(x, self.act_slope)
+        x = self.post_conv(x)
+        return x
+
+
+@dataclass
+class _Decoder:
+    """BigVGAN decoder: conv_pre -> [upsample + AMP] x num_stages -> act_post -> conv_post."""
+
+    conv_pre: Conv1d
+    ups: list[ConvTranspose1d]
+    resblocks: list[_AMPBlock1]  # len = num_stages * num_kernels
+    act_post: _AliasFreeResampler
+    conv_post: Conv1d
+    num_kernels: int
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.conv_pre(x)
+        num_upsamples = len(self.ups)
+        for i in range(num_upsamples):
+            x = self.ups[i](x)
+            xs = None
+            for j in range(self.num_kernels):
+                rb = self.resblocks[i * self.num_kernels + j]
+                xs = rb(x) if xs is None else xs + rb(x)
+            x = xs / self.num_kernels
+        x = self.act_post(x)
+        x = self.conv_post(x)
+        x = mx.clip(x, -1.0, 1.0)  # use_tanh_at_final=False
+        return x
+
+
+@dataclass
+class AudioVAE:
+    """AudioVAE encode + decode paths (waveform <-> latent)."""
+
+    config: VocoderConfig
+    post_proj: Conv1d
+    # dec_mi_layer = Sequential(Linear, SLSTM, Linear)
+    mi_lin0_w: mx.array  # [inter, latent]
+    mi_lin0_b: mx.array
+    slstm: _SLSTM
+    mi_lin2_w: mx.array  # [latent, inter]
+    mi_lin2_b: mx.array
+    decoder: _Decoder
+    # Encode path (built only when load_audiovae(with_encoder=True)).
+    encoder: _Encoder | None = None
+    # enc_mi_layer = Sequential(Linear, SLSTM, Linear)
+    enc_lin0_w: mx.array | None = None  # [inter, latent]
+    enc_lin0_b: mx.array | None = None
+    enc_slstm: _SLSTM | None = None
+    enc_lin2_w: mx.array | None = None  # [latent, inter]
+    enc_lin2_b: mx.array | None = None
+    pre_proj: Conv1d | None = None
+    extras: dict = field(default_factory=dict)
+
+    def encode(self, wav: mx.array) -> mx.array:
+        """Encode a waveform ``[B, 1, S]`` into a latent ``[B, 2*latent_dim, T]``.
+
+        Returns the stacked (mean, log_std) pair, i.e. the ``do_sample=False`` output
+        of ``extract_latents``. ``T == S // 1920``.
+        """
+        if self.encoder is None:
+            raise RuntimeError(
+                "encode path not loaded; call load_audiovae(..., with_encoder=True)"
+            )
+        x = wav.astype(mx.float32)
+        # audio_encoder consumes NLC: [B, 1, S] -> [B, S, 1].
+        x = x.transpose(0, 2, 1)
+        x = self.encoder(x)  # [B, T, latent_dim]
+        # enc_mi_layer (already NLC == batch_first layout); HP matmuls for fp32 parity.
+        x = hp_matmul(x, self.enc_lin0_w.T) + self.enc_lin0_b
+        x = self.enc_slstm(x)
+        x = hp_matmul(x, self.enc_lin2_w.T) + self.enc_lin2_b
+        # pre_proj is Conv1d k=1 (hp): a per-frame channel mix on NLC -> [B, T, 256].
+        x = self.pre_proj(x)
+        # Return [B, 2*latent_dim, T] (channel-first), matching the torch latent.
+        return x.transpose(0, 2, 1)
+
+    def decode(self, latent: mx.array) -> mx.array:
+        """Decode a latent ``[B, latent_dim, T]`` into a waveform ``[B, 1, T*1920]``."""
+        x = latent.astype(mx.float32)
+        # post_proj is Conv1d k=1 over [B, C, T]; run it as a channel-mix on NLC.
+        x = x.transpose(0, 2, 1)  # [B, T, C]
+        x = self.post_proj(x)  # k=1 conv == per-frame linear
+        # dec_mi_layer (already NLC == batch_first layout)
+        x = x @ self.mi_lin0_w.T + self.mi_lin0_b
+        x = self.slstm(x)
+        x = x @ self.mi_lin2_w.T + self.mi_lin2_b
+        # Decoder consumes NLC directly.
+        out = self.decoder(x)  # [B, T*1920, 1]
+        return out.transpose(0, 2, 1)  # [B, 1, T*1920]

--- a/mlx_audio/tts/models/dots/chunking.py
+++ b/mlx_audio/tts/models/dots/chunking.py
@@ -1,0 +1,182 @@
+"""Word-safe multilingual text chunking for long-text TTS generation.
+
+Pure stdlib + numpy (NO mlx / torch). The primary split is sentence-level; a
+length-cap *fallback hierarchy* (clause -> word -> grapheme) guarantees no chunk
+exceeds ``max_chars`` while NEVER breaking mid-word or mid-codepoint/grapheme.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+import numpy as np
+
+# Split AFTER a terminal mark, consuming trailing whitespace (the mark stays with the
+# preceding chunk). Latin .!?  CJK 。！？  Devanagari danda ।॥.
+_SENTENCE_RE = re.compile(r"(?<=[.!?。！？।॥])\s*")
+# Clause marks: Latin , ; : —  +  CJK/full-width 、 ， ； ：
+_CLAUSE_RE = re.compile(r"(?<=[,;:—、，；：])\s*")
+
+_MAX_CHARS_DEFAULT = 240  # Latin / unknown
+_MAX_CHARS_CJK = 120  # CJK/Kana/Hangul pack ~2x model-tokens per char
+_MAX_CHARS_DEVANAGARI = 160
+
+_WS_RE = re.compile(r"\s")
+
+
+def _detect_script(text: str) -> str:
+    for ch in text:
+        o = ord(ch)
+        if 0x0900 <= o <= 0x097F:
+            return "devanagari"
+        if (
+            (0x4E00 <= o <= 0x9FFF)
+            or (0x3040 <= o <= 0x30FF)
+            or (0xAC00 <= o <= 0xD7AF)
+        ):
+            return "cjk"
+    return "latin"
+
+
+def resolve_max_chars(text: str, *, language: str | None = None) -> int:
+    """Script-aware safety cap (characters). Sentence split is the primary mechanism;
+    this only bounds unusually long run-on chunks."""
+    code = (language or "").upper()
+    if code in ("ZH", "JA", "YUE", "KO"):
+        return _MAX_CHARS_CJK
+    if code == "HI":
+        return _MAX_CHARS_DEVANAGARI
+    if code:
+        return _MAX_CHARS_DEFAULT
+    return {"cjk": _MAX_CHARS_CJK, "devanagari": _MAX_CHARS_DEVANAGARI}.get(
+        _detect_script(text), _MAX_CHARS_DEFAULT
+    )
+
+
+def _split_keep(text: str, regex: re.Pattern) -> list[str]:
+    return [p for p in (s.strip() for s in regex.split(text)) if p]
+
+
+def _pack_words(s: str, max_chars: int) -> list[str]:
+    out, cur = [], ""
+    for word in s.split():
+        if not cur:
+            cur = word
+        elif len(cur) + 1 + len(word) <= max_chars:
+            cur += " " + word
+        else:
+            out.append(cur)
+            cur = word
+        if len(cur) > max_chars and " " not in cur:
+            if _WS_RE.search(cur) is None and _detect_script(cur) == "cjk":
+                out.extend(_pack_graphemes(cur, max_chars))
+                cur = ""
+    if cur:
+        out.append(cur)
+    return out
+
+
+def _pack_graphemes(s: str, max_chars: int) -> list[str]:
+    """Pack codepoints up to max_chars, never starting a chunk on a combining mark
+    (Unicode category M*) — i.e. keep base+combining clusters intact."""
+    out, cur = [], ""
+    for ch in s:
+        if len(cur) >= max_chars and not unicodedata.category(ch).startswith("M"):
+            out.append(cur)
+            cur = ch
+        else:
+            cur += ch
+    if cur:
+        out.append(cur)
+    return out
+
+
+def _cap(piece: str, max_chars: int) -> list[str]:
+    piece = piece.strip()
+    if not piece:
+        return []
+    if len(piece) <= max_chars:
+        return [piece]
+    out: list[str] = []
+    for clause in _split_keep(piece, _CLAUSE_RE):
+        if len(clause) <= max_chars:
+            out.append(clause)
+        elif _WS_RE.search(clause) is not None:
+            out.extend(_pack_words(clause, max_chars))
+        else:
+            out.extend(_pack_graphemes(clause, max_chars))
+    return out
+
+
+def split_for_generation(
+    text: str, *, max_chars: int, language: str | None = None
+) -> list[str]:
+    """Split ``text`` into TTS-sized chunks: sentence-first, then a word-safe
+    length-cap fallback (clause -> word -> grapheme). Returns non-empty stripped chunks.
+    """
+    text = text.strip()
+    if not text:
+        return []
+    chunks: list[str] = []
+    for sent in _split_keep(text, _SENTENCE_RE):
+        chunks.extend(_cap(sent, max_chars))
+    return [c for c in (c.strip() for c in chunks) if c]
+
+
+def assemble_chunks(
+    wavs: list[np.ndarray], sample_rate: int, gap_ms: int
+) -> np.ndarray:
+    """Concatenate per-chunk mono waveforms with ``gap_ms`` silence BETWEEN chunks
+    (not after the last). Returns float32 1-D."""
+    clean = [np.asarray(w, dtype=np.float32).ravel() for w in wavs]
+    clean = [w for w in clean if w.size]
+    if not clean:
+        return np.zeros(0, dtype=np.float32)
+    gap = np.zeros(int(sample_rate * gap_ms / 1000), dtype=np.float32)
+    pieces: list[np.ndarray] = []
+    for i, w in enumerate(clean):
+        if i:
+            pieces.append(gap)
+        pieces.append(w)
+    return np.concatenate(pieces)
+
+
+# --- degenerate-chunk health check (used by generate_long's retry guard) ---
+_MIN_SILENCE_STD = 0.01  # below this RMS std -> silent/dead chunk
+_MIN_SEC_PER_WORD = 0.18  # truncation floor for spaced scripts (real speech ~0.3-0.5)
+_MIN_SEC_PER_CHAR_CJK = 0.12  # per-char floor for no-space scripts (CJK/Kana/Hangul)
+
+
+def _count_words(text: str) -> int:
+    return len([w for w in _WS_RE.split(text.strip()) if w])
+
+
+def chunk_health(
+    audio: np.ndarray, text: str, sample_rate: int, *, language: str | None = None
+) -> bool:
+    """Cheap, dependency-free heuristic: is this chunk's audio non-degenerate for ``text``?
+
+    Returns False for empty/non-finite/silent audio, or audio far too short for the text
+    (clear truncation). Does NOT detect same-length hallucination -- that needs an ASR
+    validator (see generate_long(validator=...)). Never raises on odd input.
+    """
+    a = np.asarray(audio).ravel()
+    if a.size == 0 or not np.all(np.isfinite(a)):
+        return False
+    if float(np.std(a)) <= _MIN_SILENCE_STD:
+        return False
+    t = (text or "").strip()
+    if not t:
+        return True
+    audio_s = a.size / float(sample_rate)
+    if _detect_script(t) == "cjk":
+        n_chars = sum(
+            1
+            for c in t
+            if not c.isspace() and not unicodedata.category(c).startswith("P")
+        )
+        floor = _MIN_SEC_PER_CHAR_CJK * max(n_chars, 1)
+    else:
+        floor = _MIN_SEC_PER_WORD * max(_count_words(t), 1)
+    return audio_s >= floor

--- a/mlx_audio/tts/models/dots/config.py
+++ b/mlx_audio/tts/models/dots/config.py
@@ -1,0 +1,302 @@
+"""Config dataclasses for the dots.tts MLX port.
+
+Pure stdlib only — NO torch, NO mlx. This module is imported by ``convert.py``
+(which runs under the torch *oracle* venv) as well as by the MLX runtime, so it
+must stay framework-agnostic.
+
+Values are the locked constants derived from the checkpoint's ``config.json`` /
+``llm_config.json`` (Task 0). ``ModelConfig.from_checkpoint`` re-reads those JSON
+files so the runtime config tracks the checkpoint, with these dataclass defaults
+serving as the cross-check.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class DiTConfig:
+    """Velocity-field predictor (flow-matching DiT)."""
+
+    num_layers: int = 18
+    num_heads: int = 16
+    hidden_size: int = 1024
+    ffn_hidden_size: int = 4096
+    head_dim: int = 64
+    modulation: bool = True
+    qkv_bias: bool = False
+    qk_norm: bool = True
+    norm_layer: str = "RMSNorm"
+    alibi_bias: bool = False
+    rotary_bias: bool = True
+    rotary_theta: float = 10000.0
+    attn_dropout: float = 0.0
+    dropout: float = 0.0
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "DiTConfig":
+        hidden = int(d.get("hidden_size", 1024))
+        heads = int(d.get("num_heads", 16))
+        return cls(
+            num_layers=int(d.get("num_layers", 18)),
+            num_heads=heads,
+            hidden_size=hidden,
+            ffn_hidden_size=int(d.get("ffn_hidden_size", 4096)),
+            head_dim=hidden // heads,
+            modulation=bool(d.get("modulation", True)),
+            qkv_bias=bool(d.get("qkv_bias", False)),
+            qk_norm=bool(d.get("qk_norm", True)),
+            norm_layer=str(d.get("norm_layer", "RMSNorm")),
+            alibi_bias=bool(d.get("alibi_bias", False)),
+            rotary_bias=bool(d.get("rotary_bias", True)),
+            rotary_theta=float(d.get("rotary_theta", 10000.0)),
+            attn_dropout=float(d.get("attn_dropout", 0.0)),
+            dropout=float(d.get("dropout", 0.0)),
+        )
+
+
+@dataclass
+class EncoderConfig:
+    """Semantic patch encoder.
+
+    NOTE: the checkpoint's ``config.json`` carries ``qk_norm``/``rotary_*`` flags
+    for the encoder, but the upstream encoder code does NOT consume them — they
+    are forced OFF here (Task 0 finding). ``causal=True``.
+    """
+
+    num_layers: int = 24
+    num_heads: int = 16
+    hidden_size: int = 1024
+    ffn_hidden_size: int = 4096
+    input_dim: int = 128
+    modulation: bool = False
+    qkv_bias: bool = False
+    norm_layer: str = "RMSNorm"
+    causal: bool = True
+    # Flags present in config.json but UNUSED by the encoder code -> OFF.
+    qk_norm: bool = False
+    rotary_bias: bool = False
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "EncoderConfig":
+        return cls(
+            num_layers=int(d.get("num_layers", 24)),
+            num_heads=int(d.get("num_heads", 16)),
+            hidden_size=int(d.get("hidden_size", 1024)),
+            ffn_hidden_size=int(d.get("ffn_hidden_size", 4096)),
+            input_dim=int(d.get("input_dim", 128)),
+            modulation=bool(d.get("modulation", False)),
+            qkv_bias=bool(d.get("qkv_bias", False)),
+            norm_layer=str(d.get("norm_layer", "RMSNorm")),
+            causal=bool(d.get("causal", True)),
+            # Forced OFF regardless of what config.json says.
+            qk_norm=False,
+            rotary_bias=False,
+        )
+
+
+@dataclass
+class VocoderConfig:
+    """AudioVAE vocoder (BigVGAN-style decoder + AudioVAE encoder)."""
+
+    sample_rate: int = 48000
+    causal: bool = True
+    activation: str = "snakebeta"
+    snake_logscale: bool = True
+    latent_dim: int = 128
+    upsample_rates: list[int] = field(default_factory=lambda: [10, 6, 4, 2, 2, 2])
+    upsample_kernel_sizes: list[int] = field(
+        default_factory=lambda: [20, 12, 8, 4, 4, 4]
+    )
+    upsample_initial_channel: int = 1536
+    resblock: str = "1"
+    resblock_kernel_sizes: list[int] = field(default_factory=lambda: [3, 7, 11])
+    resblock_dilation_sizes: list[list[int]] = field(
+        default_factory=lambda: [[1, 3, 5], [1, 3, 5], [1, 3, 5]]
+    )
+    downsample_rates: list[int] = field(default_factory=lambda: [2, 2, 2, 4, 6, 10])
+    downsample_channels: list[int] = field(
+        default_factory=lambda: [12, 24, 48, 96, 192, 384, 768]
+    )
+    use_bias_at_final: bool = False
+    use_tanh_at_final: bool = False
+    mi_num_layers: int = 4
+    num_decoder_lookahead: int = 2
+    # Encode-path (audio_encoder) settings.
+    causal_encoder: bool = True
+    num_encoder_lookahead: int = 2
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "VocoderConfig":
+        return cls(
+            sample_rate=int(d.get("sample_rate", 48000)),
+            causal=bool(d.get("causal", True)),
+            activation=str(d.get("activation", "snakebeta")),
+            snake_logscale=bool(d.get("snake_logscale", True)),
+            latent_dim=int(d.get("latent_dim", 128)),
+            upsample_rates=list(d.get("upsample_rates", [10, 6, 4, 2, 2, 2])),
+            upsample_kernel_sizes=list(
+                d.get("upsample_kernel_sizes", [20, 12, 8, 4, 4, 4])
+            ),
+            upsample_initial_channel=int(d.get("upsample_initial_channel", 1536)),
+            resblock=str(d.get("resblock", "1")),
+            resblock_kernel_sizes=list(d.get("resblock_kernel_sizes", [3, 7, 11])),
+            resblock_dilation_sizes=[
+                list(x) for x in d.get("resblock_dilation_sizes", [[1, 3, 5]] * 3)
+            ],
+            downsample_rates=list(d.get("downsample_rates", [2, 2, 2, 4, 6, 10])),
+            downsample_channels=list(
+                d.get("downsample_channels", [12, 24, 48, 96, 192, 384, 768])
+            ),
+            use_bias_at_final=bool(d.get("use_bias_at_final", False)),
+            use_tanh_at_final=bool(d.get("use_tanh_at_final", False)),
+            mi_num_layers=int(d.get("mi_num_layers", 4)),
+            num_decoder_lookahead=int(d.get("num_decoder_lookahead", 2)),
+            causal_encoder=bool(d.get("causal_encoder", True)),
+            num_encoder_lookahead=int(d.get("num_encoder_lookahead", 2)),
+        )
+
+
+@dataclass
+class LLMConfig:
+    """Qwen2.5 backbone."""
+
+    vocab_size: int = 151672
+    hidden_size: int = 1536
+    intermediate_size: int = 8960
+    num_hidden_layers: int = 28
+    num_attention_heads: int = 12
+    num_key_value_heads: int = 2
+    head_dim: int = 128
+    rope_theta: float = 1e6
+    rms_norm_eps: float = 1e-6
+    hidden_act: str = "silu"
+    tie_word_embeddings: bool = True
+    max_position_embeddings: int = 131072
+    bos_token_id: int = 151643
+    eos_token_id: int = 151643
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "LLMConfig":
+        hidden = int(d.get("hidden_size", 1536))
+        heads = int(d.get("num_attention_heads", 12))
+        return cls(
+            vocab_size=int(d.get("vocab_size", 151672)),
+            hidden_size=hidden,
+            intermediate_size=int(d.get("intermediate_size", 8960)),
+            num_hidden_layers=int(d.get("num_hidden_layers", 28)),
+            num_attention_heads=heads,
+            num_key_value_heads=int(d.get("num_key_value_heads", 2)),
+            head_dim=int(d.get("head_dim", hidden // heads)),
+            rope_theta=float(d.get("rope_theta", 1e6)),
+            rms_norm_eps=float(d.get("rms_norm_eps", 1e-6)),
+            hidden_act=str(d.get("hidden_act", "silu")),
+            tie_word_embeddings=bool(d.get("tie_word_embeddings", True)),
+            max_position_embeddings=int(d.get("max_position_embeddings", 131072)),
+            bos_token_id=int(d.get("bos_token_id", 151643)),
+            eos_token_id=int(d.get("eos_token_id", 151643)),
+        )
+
+
+@dataclass
+class QuantizationConfig:
+    """Records which submodules are quantized + the mlx quant params.
+
+    Absent from config.json ⇒ unquantized (``ModelConfig.quantization is None``).
+    Present ⇒ the loader rebuilds the quantized skeleton (``nn.quantize``) before
+    binding weights. Stage-1 scope: ``components == ["llm"]``.
+    """
+
+    bits: int
+    group_size: int = 64
+    components: list[str] = field(default_factory=lambda: ["llm"])
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "QuantizationConfig":
+        return cls(
+            bits=int(d["bits"]),
+            group_size=int(d.get("group_size", 64)),
+            components=list(d.get("components", ["llm"])),
+        )
+
+
+@dataclass
+class MeanFlowConfig:
+    """MeanFlow distilled-sampler config (the ``mf`` checkpoint).
+
+    Absent from config.json ⇒ flow-matching mode (``ModelConfig.meanflow is None``).
+    Present with ``enabled=True`` ⇒ the DiT carries a ``duration_embedder`` and the
+    decode loop uses the few-step ``meanflow_sample`` solver (NFE, no CFG).
+    """
+
+    enabled: bool = False
+    use_duration_embedding: bool = True
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "MeanFlowConfig":
+        return cls(
+            enabled=bool(d.get("enabled", False)),
+            use_duration_embedding=bool(d.get("use_duration_embedding", True)),
+        )
+
+
+@dataclass
+class ModelConfig:
+    """Top-level dots.tts config holding all submodule configs + shared constants."""
+
+    latent_dim: int = 128
+    patch_size: int = 4
+    campplus_embedding_size: int = 512
+    xvec_max_audio_seconds: float = 10.0
+    fm_sigma: float = 0.0
+    cfg_droprate: float = 0.2
+    xvec_drop_rate: float = 0.2
+    sample_rate: int = 48000
+
+    dit: DiTConfig = field(default_factory=DiTConfig)
+    encoder: EncoderConfig = field(default_factory=EncoderConfig)
+    vocoder: VocoderConfig = field(default_factory=VocoderConfig)
+    llm: LLMConfig = field(default_factory=LLMConfig)
+    quantization: "QuantizationConfig | None" = None
+    meanflow: "MeanFlowConfig | None" = None
+
+    @classmethod
+    def from_checkpoint(cls, path: str | Path) -> "ModelConfig":
+        """Build a ModelConfig from ``<path>/config.json`` + ``<path>/llm_config.json``."""
+        path = Path(path)
+        with open(path / "config.json") as f:
+            cfg = json.load(f)
+        with open(path / "llm_config.json") as f:
+            llm_cfg = json.load(f)
+
+        voc = cfg.get("vocoder", {})
+        q = cfg.get("quantization")
+        mf = cfg.get("meanflow")
+        return cls(
+            latent_dim=int(cfg.get("latent_dim", 128)),
+            patch_size=int(cfg.get("patch_size", 4)),
+            campplus_embedding_size=int(cfg.get("campplus_embedding_size", 512)),
+            xvec_max_audio_seconds=float(cfg.get("xvec_max_audio_seconds", 10.0)),
+            fm_sigma=float(cfg.get("fm_sigma", 0.0)),
+            cfg_droprate=float(cfg.get("cfg_droprate", 0.2)),
+            xvec_drop_rate=float(cfg.get("xvec_drop_rate", 0.2)),
+            sample_rate=int(voc.get("sample_rate", 48000)),
+            dit=DiTConfig.from_dict(cfg.get("DiT", {})),
+            encoder=EncoderConfig.from_dict(cfg.get("PatchEncoder", {})),
+            vocoder=VocoderConfig.from_dict(voc),
+            llm=LLMConfig.from_dict(llm_cfg),
+            quantization=QuantizationConfig.from_dict(q) if q else None,
+            meanflow=MeanFlowConfig.from_dict(mf) if mf else None,
+        )
+
+    @property
+    def mode(self) -> str:
+        """``"meanflow"`` iff a meanflow block is present and enabled, else ``"flow_matching"``."""
+        return (
+            "meanflow"
+            if (self.meanflow is not None and self.meanflow.enabled)
+            else "flow_matching"
+        )

--- a/mlx_audio/tts/models/dots/dit.py
+++ b/mlx_audio/tts/models/dots/dit.py
@@ -1,0 +1,393 @@
+"""Pure-MLX flow-matching DiT acoustic head for dots.tts.
+
+Imports ONLY mlx (+ the package's ``layers.py``) — never torch. Mirrors
+``dots_tts.modules.backbone.dit`` for the shipped checkpoint (``mode="flow_matching"``,
+with an optional ``duration_embedder`` for the meanflow (``mf``) checkpoint): an 18-layer adaLN-zero transformer that predicts a
+denoising velocity for one VAE latent patch.
+
+Convention (M1, matching ``layers.py``): plain classes holding ``mx.array`` weights
+and reused ``layers.py`` primitives — NOT ``mlx.nn.Module``. Tensors flow as
+``[B, L, C]``. The single forward (``DiT.__call__``) is the T6 gate; the euler-ODE
+loop + CFG live in a later task. Weights are bound by ``loader.load_dit``.
+
+Numerics: the per-block attention runs on the FAST (``hp=False``) path — fp32-stored
+weights with MLX's reduced-precision (~tf32) matmul/SDPA, which is viable at DiT
+sequence lengths (the fp32 ``hp`` path OOMs there). The adaLN modulation, layer
+norms, time-embedding sinusoid, and FFN GELU are all computed in fp32. The gate is
+cosine >= 0.9999 (tf32-robust over 18 stacked attention bmms) AND max-abs <= 2e-2.
+"""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+
+from .layers import LayerNorm, Linear, Mlp, MultiHeadAttention, silu
+
+
+def modulate(x: mx.array, shift: mx.array, scale: mx.array) -> mx.array:
+    """adaLN modulation ``x * (1 + scale[:, None, :]) + shift[:, None, :]``.
+
+    ``x`` is ``[B, L, C]``; ``shift`` / ``scale`` are ``[B, C]`` (broadcast over L).
+    Matches the upstream ``modulate`` (``scale.unsqueeze(1)`` / ``shift.unsqueeze(1)``).
+    """
+    return x * (1.0 + scale[:, None, :]) + shift[:, None, :]
+
+
+class TimestepEmbedder:
+    """Sinusoidal timestep embedding -> 2-layer MLP (Linear -> SiLU -> Linear).
+
+    ``timestep_embedding(t, 256)`` builds a 256-dim sinusoid with ``half=128``,
+    ``freqs = exp(-ln(10000) * arange(128) / 128)``, ``args = t[:, None] * freqs[None]``,
+    ``emb = cat([cos(args), sin(args)], -1)`` (**cos FIRST**). ``t`` is the raw
+    timestep in [0, 1] (no 1000x scaling). The MLP maps ``256 -> 1024 -> 1024``.
+    """
+
+    def __init__(
+        self,
+        mlp_fc0: Linear,
+        mlp_fc2: Linear,
+        *,
+        frequency_embedding_size: int = 256,
+        max_period: float = 10000.0,
+    ):
+        self.mlp_fc0 = mlp_fc0
+        self.mlp_fc2 = mlp_fc2
+        self.frequency_embedding_size = frequency_embedding_size
+        self.max_period = max_period
+
+    def _timestep_embedding(self, t: mx.array) -> mx.array:
+        dim = self.frequency_embedding_size
+        half = dim // 2
+        tf = t.astype(mx.float32)
+        freqs = mx.exp(
+            -math.log(self.max_period) * mx.arange(0, half).astype(mx.float32) / half
+        )  # [half]
+        args = tf[:, None] * freqs[None, :]  # [B, half]
+        emb = mx.concatenate([mx.cos(args), mx.sin(args)], axis=-1)  # [B, dim]
+        if dim % 2:
+            emb = mx.concatenate([emb, mx.zeros_like(emb[:, :1])], axis=-1)
+        return emb
+
+    def __call__(self, t: mx.array) -> mx.array:
+        emb = self._timestep_embedding(t)  # [B, 256], fp32
+        x = self.mlp_fc0(emb)
+        x = silu(x)
+        return self.mlp_fc2(x)  # [B, 1024]
+
+
+class FinalLayer:
+    """adaLN-zero output head: ``linear(modulate(norm(x), shift, scale))``.
+
+    ``adaLN_modulation = SiLU -> Linear(1024 -> 2*1024)``; ``shift, scale`` are the
+    2-way chunk. ``norm`` is an affine-free ``LayerNorm(1024, eps=1e-5)`` (no
+    weights). ``linear`` maps ``1024 -> out_dim`` (128).
+    """
+
+    def __init__(self, adaLN_linear: Linear, linear: Linear, hidden_size: int = 1024):
+        self.adaLN_linear = adaLN_linear
+        self.norm = LayerNorm(hidden_size, eps=1e-5)
+        self.linear = linear
+
+    def __call__(self, x: mx.array, c: mx.array) -> mx.array:
+        mod = self.adaLN_linear(silu(c))  # [B, 2*1024]
+        shift, scale = mx.split(mod, 2, axis=-1)
+        x = modulate(self.norm(x), shift, scale)
+        return self.linear(x)
+
+
+class DiTBlock:
+    """adaLN-zero transformer block (modulation=True): gated attn + gated FFN.
+
+    ``adaLN_modulation = SiLU -> Linear(1024 -> 6*1024)`` produces six ``[B, 1024]``
+    chunks ``shift_attn, scale_attn, gate_attn, shift_ffn, scale_ffn, gate_ffn``.
+    ``norm1`` / ``norm2`` are affine-free ``LayerNorm(1024, eps=1e-5)`` (no weights):
+
+        x = x + gate_attn[:, None, :] * attn(modulate(norm1(x), shift_attn, scale_attn))
+        x = x + gate_ffn[:,  None, :] * ffn(modulate(norm2(x),  shift_ffn,  scale_ffn))
+
+    The attention is the shared ``layers.MultiHeadAttention`` (qkv_bias=False,
+    qk_norm=True/RMSNorm, rotary_bias=True, theta=10000), run on the fast (hp=False)
+    path. The FFN is ``layers.Mlp`` with tanh-approx GELU.
+    """
+
+    def __init__(
+        self,
+        attn: MultiHeadAttention,
+        ffn: Mlp,
+        adaLN_linear: Linear,
+        hidden_size: int = 1024,
+    ):
+        self.attn = attn
+        self.ffn = ffn
+        self.adaLN_linear = adaLN_linear
+        self.norm1 = LayerNorm(hidden_size, eps=1e-5)
+        self.norm2 = LayerNorm(hidden_size, eps=1e-5)
+
+    def __call__(
+        self,
+        x: mx.array,
+        c: mx.array,
+        *,
+        mask: mx.array | None = None,
+        pos_ids: mx.array | None = None,
+    ) -> mx.array:
+        mod = self.adaLN_linear(silu(c))  # [B, 6*1024]
+        shift_attn, scale_attn, gate_attn, shift_ffn, scale_ffn, gate_ffn = mx.split(
+            mod, 6, axis=-1
+        )
+        x = x + gate_attn[:, None, :] * self.attn(
+            modulate(self.norm1(x), shift_attn, scale_attn),
+            mask=mask,
+            pos_ids=pos_ids,
+        )
+        x = x + gate_ffn[:, None, :] * self.ffn(
+            modulate(self.norm2(x), shift_ffn, scale_ffn)
+        )
+        return x
+
+
+class DiT:
+    """Flow-matching DiT: predicts a velocity for one VAE latent patch.
+
+    ``__call__(x, timesteps, attn_mask, pos_ids, g_cond, duration)``:
+
+        c = time_embedder(timesteps)        # [B, 1024]
+        c = c + duration_embedder(duration) # optional: c = c + duration_embedder(duration)
+                                            # (meanflow mode only; omitted for flow_matching)
+        c = c + g_cond                      # global conditioning, [B, 1024]
+        x = input_layer(x)                  # Linear(in_dim -> 1024)
+        for block: x = block(x, c, mask=attn_mask, pos_ids=pos_ids)
+        return output_layer(x, c)           # [B, L, out_dim]
+    """
+
+    def __init__(
+        self,
+        input_layer: Linear,
+        time_embedder: TimestepEmbedder,
+        blocks: list[DiTBlock],
+        output_layer: FinalLayer,
+        duration_embedder: TimestepEmbedder | None = None,
+    ):
+        self.input_layer = input_layer
+        self.time_embedder = time_embedder
+        self.duration_embedder = duration_embedder
+        self.blocks = blocks
+        self.output_layer = output_layer
+
+    def __call__(
+        self,
+        x: mx.array,
+        timesteps: mx.array,
+        *,
+        attn_mask: mx.array | None = None,
+        pos_ids: mx.array | None = None,
+        g_cond: mx.array | None = None,
+        duration: mx.array | None = None,
+    ) -> mx.array:
+        c = self.time_embedder(timesteps)  # [B, 1024]
+        if self.duration_embedder is not None and duration is not None:
+            c = c + self.duration_embedder(duration)  # MeanFlow average-velocity signal
+        if g_cond is not None:
+            c = c + g_cond
+        x = self.input_layer(x)  # [B, L, 1024]
+        for block in self.blocks:
+            x = block(x, c, mask=attn_mask, pos_ids=pos_ids)
+        return self.output_layer(x, c)
+
+
+def fm_solver_step(
+    dit: DiT,
+    coordinate_proj: Linear,
+    t: mx.array,
+    z: mx.array,
+    *,
+    input_sequence: mx.array,
+    cfg_sequence: mx.array,
+    attn_mask: mx.array | None,
+    pos_ids: mx.array | None,
+    g_cond: mx.array,
+    guidance_scale: float,
+) -> mx.array:
+    """One flow-matching RHS eval ``v(t, z)`` with classifier-free guidance.
+
+    Mirrors ``DotsTtsCore.fm_solver_step`` (upstream ``core.py``). Projects the noisy
+    latent coordinate, splices it into both the conditional (real ``g_cond``) and the
+    null (``cfg_sequence`` + zeroed ``g_cond``) branches, runs them batched through the
+    DiT in one call, then extrapolates: ``v = vt_c + guidance_scale * (vt_c - vt_u)``.
+
+    Args:
+        dit: the flow-matching ``DiT`` velocity predictor.
+        coordinate_proj: ``Linear(latent_dim, hidden_size)`` projecting ``z`` (the
+            ``coordinate_proj.*`` weight from ``core.safetensors``).
+        t: scalar timestep ``[1]`` (or any 1-D), broadcast to the 2-way batch.
+        z: the noisy latent coordinate ``[1, patch_size, latent_dim]``.
+        input_sequence: the conditional sequence ``[1, L, hidden_size]``; its last
+            ``patch_size`` slots are overwritten by the projected ``z``.
+        cfg_sequence: the null/history-only sequence ``[1, L, hidden_size]`` (same
+            splice, but paired with a zeroed ``g_cond``).
+        attn_mask / pos_ids: the ``[1, L, L]`` mask / ``[1, L]`` positions (broadcast
+            across the batch by the DiT).
+        g_cond: the (already-scaled) global conditioning ``[1, hidden_size]``.
+        guidance_scale: CFG scale (the extrapolation coefficient).
+
+    Returns:
+        the velocity ``v`` for the latent block, ``[1, patch_size, latent_dim]``.
+    """
+    batch_size = input_sequence.shape[0]
+    patch_size = z.shape[1]
+    latent_start = input_sequence.shape[1] - patch_size
+
+    # Project the noisy coordinate [1, patch_size, latent_dim] -> [1, patch_size, H].
+    z_proj = coordinate_proj(z)
+    rdtype = input_sequence.dtype
+    z_proj = z_proj.astype(rdtype)
+
+    # COND branch: real g_cond, projected z spliced into the latent slots.
+    z_c = mx.concatenate([input_sequence[:, :latent_start], z_proj], axis=1)
+    # UNCOND branch: null sequence + zeroed g_cond, SAME projected z.
+    z_u = mx.concatenate([cfg_sequence[:, :latent_start], z_proj], axis=1)
+
+    z_z = mx.concatenate([z_c, z_u], axis=0)  # [2, L, H]
+    t_t = mx.broadcast_to(t.reshape(1), (2,))
+    g = g_cond.astype(rdtype)
+    g_cond_t = mx.concatenate([g, mx.zeros_like(g)], axis=0)  # [2, H]
+
+    vt = dit(z_z, t_t, attn_mask=attn_mask, pos_ids=pos_ids, g_cond=g_cond_t)
+    vt = vt[:, latent_start:]  # [2, patch_size, latent_dim]
+    vt_c = vt[:batch_size]
+    vt_u = vt[batch_size:]
+    return vt_c + guidance_scale * (vt_c - vt_u)
+
+
+class FlowSolver:
+    """Flow-matching euler-ODE solver (replacing torchdiffeq) + CFG.
+
+    Convention (sigma=0): ``t=0`` is pure noise ``x0``, ``t=1`` is data ``x1``;
+    the DiT predicts the velocity ``u = x1 - x0``. The euler loop integrates
+    ``t: 0 -> 1`` in ``num_steps`` fixed left-endpoint steps:
+
+        dt = 1 / num_steps
+        z = noise
+        for k in 0 .. num_steps-1:  z = z + dt * v(k*dt, z)
+
+    matching the upstream ``odeint(method="euler", t=[0, 1],
+    options={"step_size": 1/num_steps})``. Each ``v`` is one CFG-guided
+    ``fm_solver_step`` (a batched cond+uncond DiT call). The final ``z`` (at t=1)
+    is the denoised normalized latent patch.
+
+    Numerics (T9, measured): the euler ODE AMPLIFIES the per-step DiT bmm precision
+    error. With INJECTED identical noise, the shippable tf32-bmm path drives the
+    denoised patch to ~0.033 max-abs vs the torch oracle, while a true-fp32 reduction
+    collapses it to ~1.4e-4 — i.e. the math is structurally correct and the residual
+    is a tf32 numerical floor, NOT a bug. Direction (cosine) stays >= 0.999 and the
+    downstream VAE decode is robust to this magnitude drift, so end-to-end parity is
+    gated on BEHAVIOR (intelligible clone), not sample-exact PSNR.
+    """
+
+    def __init__(self, dit: DiT, coordinate_proj: Linear, *, latent_dim: int = 128):
+        self.dit = dit
+        self.coordinate_proj = coordinate_proj
+        self.latent_dim = latent_dim
+
+    def denoise(
+        self,
+        *,
+        input_sequence: mx.array,
+        cfg_sequence: mx.array,
+        attn_mask: mx.array | None,
+        pos_ids: mx.array | None,
+        g_cond: mx.array,
+        guidance_scale: float = 3.0,
+        num_steps: int = 10,
+        patch_size: int = 4,
+        noise: mx.array | None = None,
+    ) -> mx.array:
+        """Denoise one latent patch from ``noise`` (or a fresh draw) via euler + CFG.
+
+        Args:
+            input_sequence / cfg_sequence: cond / null sequences ``[1, L, hidden]``.
+            attn_mask / pos_ids: the ``[1, L, L]`` mask / ``[1, L]`` positions.
+            g_cond: global conditioning ``[1, hidden]`` (already scaled upstream).
+            guidance_scale: CFG scale.
+            num_steps: euler step count (NFE).
+            patch_size: number of latent slots to denoise.
+            noise: the injected initial coordinate ``[1, patch_size, latent_dim]``;
+                ``None`` draws a fresh ``mx.random.normal``.
+
+        Returns:
+            the denoised latent patch ``[1, patch_size, latent_dim]`` (at t=1).
+        """
+        rdtype = input_sequence.dtype
+        if noise is None:
+            z = mx.random.normal((1, patch_size, self.latent_dim)).astype(rdtype)
+        else:
+            z = noise.astype(rdtype)
+
+        dt = 1.0 / num_steps
+        for k in range(num_steps):
+            t = mx.array([k * dt], dtype=rdtype)
+            v = fm_solver_step(
+                self.dit,
+                self.coordinate_proj,
+                t,
+                z,
+                input_sequence=input_sequence,
+                cfg_sequence=cfg_sequence,
+                attn_mask=attn_mask,
+                pos_ids=pos_ids,
+                g_cond=g_cond,
+                guidance_scale=guidance_scale,
+            )
+            z = z + dt * v
+        return z
+
+    def meanflow_sample(
+        self,
+        *,
+        input_sequence: mx.array,
+        attn_mask: mx.array | None,
+        pos_ids: mx.array | None,
+        g_cond: mx.array,
+        num_steps: int = 4,
+        patch_size: int = 4,
+        noise: mx.array,
+    ) -> mx.array:
+        """Distilled MeanFlow few-step sampler (NFE = ``num_steps``, NO CFG).
+
+        Mirrors upstream ``_meanflow_step_fm`` / ``meanflow_solver_step``: the DiT
+        predicts the AVERAGE velocity over the interval ``[t, t+dt]`` (it receives both
+        ``t`` and ``dt`` as ``duration``), so a single forward per step advances the full
+        ``dt``. No classifier-free guidance — one conditional branch with the real
+        ``g_cond`` (guidance is fused into the distilled student). Uniform schedule on
+        ``[0, 1]``: ``t_k = k/nfe``, ``dt = 1/nfe``.
+
+        Args:
+            input_sequence: the conditional sequence ``[1, L, hidden]``; its last
+                ``patch_size`` slots are overwritten by the projected ``z`` each step.
+            attn_mask / pos_ids: the ``[1, L, L]`` mask / ``[1, L]`` positions.
+            g_cond: global conditioning ``[1, hidden]`` (already scaled upstream).
+            num_steps: NFE (number of DiT forwards). Distilled to work at 2-4.
+            patch_size: number of latent slots to denoise.
+            noise: the injected initial coordinate ``[1, patch_size, latent_dim]``.
+
+        Returns:
+            the denoised latent patch ``[1, patch_size, latent_dim]`` (at t=1).
+        """
+        rdtype = input_sequence.dtype
+        z = noise.astype(rdtype)
+        latent_start = input_sequence.shape[1] - patch_size
+        g = g_cond.astype(rdtype)
+        inv = 1.0 / num_steps
+        for k in range(num_steps):
+            t = mx.array([k * inv], dtype=rdtype)
+            dt = mx.array([inv], dtype=rdtype)
+            z_proj = self.coordinate_proj(z).astype(rdtype)
+            seq = mx.concatenate([input_sequence[:, :latent_start], z_proj], axis=1)
+            v = self.dit(
+                seq, t, attn_mask=attn_mask, pos_ids=pos_ids, g_cond=g, duration=dt
+            )
+            v = v[:, latent_start:]  # [1, patch_size, latent_dim]
+            z = z + v * inv
+        return z

--- a/mlx_audio/tts/models/dots/io_helper.py
+++ b/mlx_audio/tts/models/dots/io_helper.py
@@ -1,0 +1,63 @@
+"""Latent normalization + sampling helper for the dots.tts MLX runtime.
+
+Imports ONLY mlx / numpy — never torch. Ports ``dots_tts.models.dots_tts.core.IOHelper``:
+
+  * ``normalize(x)``    = ``(x - mean) / sqrt(var)``   (x is ``[B, T, 128]``)
+  * ``denormalize(x)``  = ``x * sqrt(var) + mean``
+  * ``sample_from_latent(latent, noise)`` : ``latent`` is ``[B, 256, T]`` (the
+    mean/log_std pair stacked on the channel axis); returns
+    ``z = mean + noise * exp(log_std)`` transposed to ``[B, T, 128]``.
+
+``mean`` / ``var`` are per-channel ``[128]`` stats loaded from ``latent_stats.npz``
+(keys ``mean`` / ``var``). They broadcast over the last (channel) dim of the
+normalize/denormalize inputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlx.core as mx
+
+
+class IOHelper:
+    """Per-channel latent normalize / denormalize / sample (mirrors torch IOHelper)."""
+
+    def __init__(self, latent_stats_path: str | Path | None = None):
+        if latent_stats_path is not None:
+            stats = mx.load(str(latent_stats_path))
+            if "mean" not in stats or "var" not in stats:
+                raise ValueError(f"latent_stats missing mean/var keys: {sorted(stats)}")
+            # fp32 throughout: parity oracle is fp32 and the stats are tiny.
+            self.global_mean = stats["mean"].astype(mx.float32)
+            self.global_var = stats["var"].astype(mx.float32)
+        else:
+            self.global_mean = None
+            self.global_var = None
+
+    def normalize(self, x: mx.array) -> mx.array:
+        """``(x - mean) / sqrt(var)`` over the last dim; identity if stats absent."""
+        if self.global_mean is not None and self.global_var is not None:
+            x = (x - self.global_mean) / mx.sqrt(self.global_var)
+        return x
+
+    def denormalize(self, x: mx.array) -> mx.array:
+        """``x * sqrt(var) + mean`` over the last dim; identity if stats absent."""
+        if self.global_mean is not None and self.global_var is not None:
+            x = x * mx.sqrt(self.global_var) + self.global_mean
+        return x
+
+    @staticmethod
+    def sample_from_latent(latent: mx.array, noise: mx.array | None = None) -> mx.array:
+        """Sample ``z`` from a ``[B, 256, T]`` latent and return it as ``[B, T, 128]``.
+
+        ``mean, log_std = split(latent, 2, axis=1)`` (channel); ``z = mean +
+        noise * exp(log_std)``; then transpose ``[B, 128, T] -> [B, T, 128]``.
+        ``noise`` is injectable for parity (default = a fresh standard-normal draw
+        the shape of ``mean``).
+        """
+        mean, log_std = mx.split(latent, 2, axis=1)
+        if noise is None:
+            noise = mx.random.normal(mean.shape)
+        z = mean + noise * mx.exp(log_std)
+        return z.transpose(0, 2, 1)

--- a/mlx_audio/tts/models/dots/layers.py
+++ b/mlx_audio/tts/models/dots/layers.py
@@ -1,0 +1,589 @@
+"""Pure-MLX 1-D conv primitives for the dots.tts AudioVAE encode + decode paths.
+
+Imports ONLY mlx — never torch, never numpy. These mirror the upstream causal
+``Conv1d`` / ``ConvTranspose1d`` from ``dots_tts.modules.backbone.layers`` (and the
+strided causal ``Conv1d_S`` used by the encoder) plus a replicate (edge-clamp) pad
+helper used by the alias-free resamplers.
+
+Tensor convention: tensors flow as NLC ``[B, T, C]`` (MLX-native channels-last).
+Weight tensors are stored in torch layout and transposed to MLX layout at load
+time by ``loader.py`` (Conv1d: ``[out, in, k]`` -> ``[out, k, in]``;
+ConvTranspose1d: ``[in, out, k]`` -> ``[out, k, in]``).
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+
+def hp_matmul(x: mx.array, w_t: mx.array) -> mx.array:
+    """High-precision ``x @ w_t`` accumulated in true fp32 (contraction over last axis).
+
+    MLX's ``mx.matmul`` / ``mx.conv1d`` on Apple Silicon round each fp32 operand to a
+    reduced-precision (~tf32) mantissa before the multiply-accumulate, which costs up
+    to ~1e-1 absolute on large-magnitude inputs. Computing the contraction as an
+    explicit elementwise multiply + ``mx.sum`` keeps the reduction in genuine fp32
+    (matches the torch oracle to ~1e-6). Used on the *encode* path, whose deep stack
+    is gated by a tight max-abs tolerance; the decode path keeps the faster
+    ``mx.matmul`` (it is PSNR-gated, not max-abs).
+
+    CAVEAT (I1): ``w_t`` MUST be a 2-D right operand ``[K, N]`` and the call
+    materializes the broadcast product ``[..., K, N]`` before reducing — i.e.
+    ``O(M·N·K)`` peak memory for an ``[M, K]`` left operand. It is therefore
+    suitable only for the activation@2-D-weight projections (q/k/v/o, fc1/fc2),
+    NOT for the batched attention bmm (``QKᵀ`` / ``attn·V``, whose right operand
+    is itself batched) and NOT for large-``N`` projections without chunking. The
+    attention parity path computes its (tiny-``L``) bmm with a separate explicit
+    fp32 reduction; the runtime path uses fast SDPA.
+
+    Args:
+        x: ``[..., K]``.
+        w_t: ``[K, N]`` (already transposed; i.e. for a torch ``Linear`` weight
+            ``W`` of shape ``[N, K]`` pass ``W.T``).
+
+    Returns:
+        ``[..., N]`` in fp32.
+    """
+    x = x.astype(mx.float32)
+    w_t = w_t.astype(mx.float32)
+    return mx.sum(x[..., :, None] * w_t, axis=-2)
+
+
+def replicate_pad(x: mx.array, left: int, right: int) -> mx.array:
+    """Edge-clamp pad the time axis of an NLC tensor (mirrors ``F.pad(mode="replicate")``).
+
+    ``mx.pad`` only supports constant padding, so the edge frames are repeated and
+    concatenated manually. ``x`` is ``[B, T, C]``; padding is applied along T.
+    """
+    if left == 0 and right == 0:
+        return x
+    pieces = []
+    if left > 0:
+        pieces.append(mx.broadcast_to(x[:, :1, :], (x.shape[0], left, x.shape[2])))
+    pieces.append(x)
+    if right > 0:
+        pieces.append(mx.broadcast_to(x[:, -1:, :], (x.shape[0], right, x.shape[2])))
+    return mx.concatenate(pieces, axis=1)
+
+
+class Conv1d:
+    """Causal / "same"-padded (optionally strided) 1-D convolution over NLC tensors.
+
+    Mirrors both ``dots_tts.modules.backbone.layers.Conv1d`` (decode path, stride=1)
+    and the encoder's ``Conv1d_S`` (which adds a stride for downsampling):
+      * ``causal=True``  -> left-pad ``dilation * (kernel - 1)`` zeros, conv with
+        padding=0. For ``Conv1d_S`` the dilation is always 1, so the left pad is
+        ``kernel - 1`` (== its ``causal_pad``).
+      * ``causal=False`` -> symmetric "same" pad ``(kernel*dilation - dilation)//2``
+        (handled by ``mx.conv1d``'s ``padding`` arg). ``Conv1d_S``'s post-projection
+        (lookahead) conv uses this non-causal path.
+
+    ``weight`` is the MLX-layout kernel ``[out, k, in]``; ``bias`` is ``[out]`` or None.
+
+    ``hp=True`` runs the conv as a tap-loop of fp32 elementwise-multiply + ``mx.sum``
+    reductions (see ``hp_matmul``) instead of ``mx.conv1d``, matching the torch oracle
+    to ~1e-6. The encode path sets this (it is max-abs gated and its deep, large-
+    magnitude conv stack otherwise drifts ~1e0); ``groups != 1`` is not supported in
+    the HP path (only the channel-mixing encode convs use it, all groups=1).
+    """
+
+    def __init__(
+        self,
+        weight: mx.array,
+        bias: mx.array | None,
+        *,
+        causal: bool,
+        stride: int = 1,
+        dilation: int = 1,
+        groups: int = 1,
+        hp: bool = False,
+    ):
+        self.weight = weight
+        self.bias = bias
+        self.causal = causal
+        self.stride = stride
+        self.dilation = dilation
+        self.groups = groups
+        self.hp = hp
+        self.kernel_size = weight.shape[1]
+        if causal:
+            self.left_padding = dilation * (self.kernel_size - 1)
+            self.padding = 0
+        else:
+            self.left_padding = 0
+            self.padding = (self.kernel_size * dilation - dilation) // 2
+
+    def __call__(self, x: mx.array) -> mx.array:
+        if self.hp:
+            return self._call_hp(x)
+        if self.causal and self.left_padding > 0:
+            x = mx.pad(x, [(0, 0), (self.left_padding, 0), (0, 0)])
+        y = mx.conv1d(
+            x,
+            self.weight,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+        if self.bias is not None:
+            y = y + self.bias
+        return y
+
+    def _call_hp(self, x: mx.array) -> mx.array:
+        """fp32 tap-loop conv: out[t,o] = sum_j sum_i x_padded[t*s + j*d, i] * W[o,j,i]."""
+        x = x.astype(mx.float32)
+        if self.causal:
+            x = mx.pad(x, [(0, 0), (self.left_padding, 0), (0, 0)])
+        elif self.padding > 0:
+            x = mx.pad(x, [(0, 0), (self.padding, self.padding), (0, 0)])
+        w = self.weight.astype(mx.float32)  # [Cout, k, Cin]
+        cout, k, _ = w.shape
+        s, d = self.stride, self.dilation
+        t_pad = x.shape[1]
+        t_out = (t_pad - d * (k - 1) - 1) // s + 1
+        acc = None
+        for j in range(k):
+            # gather the j-th tap at the strided output positions: [B, t_out, Cin]
+            seg = x[:, j * d : j * d + s * t_out : s, :]
+            # contract over Cin in fp32: [B, t_out, 1, Cin] * [Cout, Cin] -> [B, t_out, Cout]
+            contrib = mx.sum(seg[:, :, None, :] * w[None, None, :, j, :], axis=3)
+            acc = contrib if acc is None else acc + contrib
+        if self.bias is not None:
+            acc = acc + self.bias.astype(mx.float32)
+        return acc
+
+
+class ConvTranspose1d:
+    """Causal / non-causal transposed 1-D convolution over NLC tensors.
+
+    Mirrors ``dots_tts.modules.backbone.layers.ConvTranspose1d``: run the standard
+    transposed conv, then if ``causal`` trim the last ``stride`` time samples.
+    For the decoder upsamplers ``padding=0`` (causal) always.
+
+    ``weight`` is the MLX-layout kernel ``[out, k, in]``; ``bias`` is ``[out]`` or None.
+    """
+
+    def __init__(
+        self,
+        weight: mx.array,
+        bias: mx.array | None,
+        *,
+        stride: int,
+        causal: bool,
+    ):
+        self.weight = weight
+        self.bias = bias
+        self.stride = stride
+        self.causal = causal
+
+    def __call__(self, x: mx.array) -> mx.array:
+        y = mx.conv_transpose1d(x, self.weight, stride=self.stride, padding=0)
+        if self.bias is not None:
+            y = y + self.bias
+        if self.causal:
+            y = y[:, : -self.stride, :]
+        return y
+
+
+# --------------------------------------------------------------------------- #
+# Shared transformer primitives (reused by the DiT (T6) and semantic encoder (T7)).
+#
+# Convention (M1): plain classes holding ``mx.array`` weights — NOT ``mlx.nn.Module``.
+# Weights are stored in torch layout (``Linear.weight`` is ``[out, in]``) and applied
+# as ``x @ W.T``. The ``hp`` flag routes the activation@2-D-weight matmuls through the
+# fp32 ``hp_matmul`` reduction (tight max-abs parity vs the torch oracle); ``hp=False``
+# uses MLX's fast (~tf32) matmul / SDPA for the runtime path.
+# --------------------------------------------------------------------------- #
+
+
+class Linear:
+    """Affine map ``x @ W.T (+ b)`` with a torch-layout weight ``[out, in]``.
+
+    ``hp=True`` contracts through ``hp_matmul`` (true fp32); ``hp=False`` uses the
+    fast ``mx.matmul`` (rounds fp32 -> ~tf32 on Apple Silicon).
+    """
+
+    def __init__(self, weight: mx.array, bias: mx.array | None = None):
+        self.weight = weight  # [out, in] (torch layout)
+        self.bias = bias  # [out] or None
+
+    def __call__(self, x: mx.array, *, hp: bool = False) -> mx.array:
+        if hp:
+            y = hp_matmul(x, self.weight.T)
+            if self.bias is not None:
+                y = y + self.bias.astype(mx.float32)
+            return y
+        y = x @ self.weight.T
+        if self.bias is not None:
+            y = y + self.bias
+        return y
+
+
+class RMSNorm:
+    """Root-mean-square layer norm with a learned per-feature ``weight`` (gamma).
+
+    Mirrors ``torch.nn.RMSNorm`` (eps=None default -> ``finfo(fp32).eps``): the
+    rms reduction is computed in fp32, then scaled by ``weight``. Used for the
+    attention qk-norm (``RMSNorm(head_dim)``) and the semantic-encoder norms.
+    """
+
+    # torch's nn.RMSNorm(dim) is constructed with eps=None, which it resolves to
+    # ``torch.finfo(x.dtype).eps`` (fp32 -> 1.1920928955078125e-07). Confirmed
+    # against the oracle: using 1e-5 here drifts ~1.3e-5 max-abs.
+    DEFAULT_EPS = 1.1920928955078125e-07
+
+    def __init__(
+        self, dim: int, eps: float | None = None, weight: mx.array | None = None
+    ):
+        self.dim = dim
+        self.eps = self.DEFAULT_EPS if eps is None else eps
+        # weight defaults to ones (the torch init) until load_weights overrides it.
+        self.weight = weight if weight is not None else mx.ones((dim,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        in_dtype = x.dtype
+        xf = x.astype(mx.float32)
+        var = mx.mean(xf * xf, axis=-1, keepdims=True)
+        xf = xf * mx.rsqrt(var + self.eps)
+        out = xf * self.weight.astype(mx.float32)
+        return out.astype(in_dtype)
+
+
+class LayerNorm:
+    """Affine-free layer norm (``elementwise_affine=False``, eps 1e-5).
+
+    Mirrors ``nn.LayerNorm(dim, elementwise_affine=False, eps=1e-5)`` used by the
+    DiT adaLN path (T6): normalize over the last axis, no learned scale/shift.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-5):
+        self.dim = dim
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        in_dtype = x.dtype
+        xf = x.astype(mx.float32)
+        mean = mx.mean(xf, axis=-1, keepdims=True)
+        var = mx.mean((xf - mean) ** 2, axis=-1, keepdims=True)
+        out = (xf - mean) * mx.rsqrt(var + self.eps)
+        return out.astype(in_dtype)
+
+
+class _Identity:
+    """No-op stand-in for qk-norm=False (mirrors ``nn.Identity``)."""
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x
+
+
+def rotate_half(x: mx.array) -> mx.array:
+    """GPT-NeoX half-half rotation: ``cat([-x[..., d/2:], x[..., :d/2]], -1)``."""
+    d = x.shape[-1] // 2
+    x1 = x[..., :d]
+    x2 = x[..., d:]
+    return mx.concatenate([-x2, x1], axis=-1)
+
+
+def apply_rotary_pos_emb(emb: mx.array, t: mx.array) -> mx.array:
+    """Apply rotary embedding ``emb`` (the ``[B, L, dim]`` freqs) to heads ``t``.
+
+    ``emb`` is the duplicated freqs ``cat([freqs, freqs], -1)`` from
+    ``RotaryEmbedding.forward``; here we take its cos/sin directly (NOT of a
+    further-transformed tensor). A 3-D ``emb`` is unsqueezed to ``[B, 1, L, dim]``
+    to broadcast over the head axis of ``t`` (``[B, H, L, dim]``). Computed in fp32.
+    """
+    emb = emb.astype(mx.float32)
+    if emb.ndim == 3:
+        emb = emb[:, None, :, :]
+    tf = t.astype(mx.float32)
+    out = tf * mx.cos(emb) + rotate_half(tf) * mx.sin(emb)
+    return out.astype(t.dtype)
+
+
+class RotaryEmbedding:
+    """GPT-NeoX rotary position embedding (half-half, fp32).
+
+    ``inv_freq[j] = theta^(-2j/dim)`` for ``j = 0..dim/2-1``. ``forward(pos)`` takes
+    float positions ``[B, L]`` (or ``[L]``), computes ``freqs = pos ⊗ inv_freq``
+    ``[B, L, dim/2]``, and returns ``cat([freqs, freqs], -1)`` ``[B, L, dim]``. All
+    arithmetic is forced to fp32 (upstream disables autocast + keeps inv_freq fp32).
+    """
+
+    def __init__(self, dim: int, theta: float = 10000.0):
+        self.dim = dim
+        self.theta = float(theta)
+        j = mx.arange(0, dim, 2).astype(mx.float32)  # [dim/2]
+        self.inv_freq = 1.0 / (self.theta ** (j / dim))  # [dim/2], fp32
+
+    def __call__(self, pos: mx.array) -> mx.array:
+        pos = pos.astype(mx.float32)
+        if pos.ndim == 1:
+            # [L] ⊗ [dim/2] -> [L, dim/2]
+            freqs = pos[:, None] * self.inv_freq[None, :]
+        else:
+            # [B, L] ⊗ [dim/2] -> [B, L, dim/2]
+            freqs = pos[..., None] * self.inv_freq
+        return mx.concatenate([freqs, freqs], axis=-1)
+
+
+class Mlp:
+    """Two-layer FFN: ``fc2(act(fc1(x)))`` with bias on both projections.
+
+    The activation is supplied by the caller: DiT uses tanh-approx GELU, the
+    semantic encoder (T7) uses SiLU. ``hp`` routes both Linear layers through the
+    fp32 ``hp_matmul`` path; the activation runs in fp32 under ``hp`` too.
+    """
+
+    def __init__(self, fc1: Linear, fc2: Linear, act):
+        self.fc1 = fc1
+        self.fc2 = fc2
+        self.act = act
+
+    def __call__(self, x: mx.array, *, hp: bool = False) -> mx.array:
+        x = self.fc1(x, hp=hp)
+        x = self.act(x)
+        return self.fc2(x, hp=hp)
+
+
+def gelu_tanh(x: mx.array) -> mx.array:
+    """Tanh-approx GELU (matches ``nn.GELU(approximate="tanh")``), used by the DiT FFN."""
+    xf = x.astype(mx.float32)
+    inner = 0.7978845608028654 * (xf + 0.044715 * xf * xf * xf)  # sqrt(2/pi)
+    out = 0.5 * xf * (1.0 + mx.tanh(inner))
+    return out.astype(x.dtype)
+
+
+def silu(x: mx.array) -> mx.array:
+    """SiLU / swish (``x * sigmoid(x)``), used by the semantic-encoder FFN."""
+    return x * mx.sigmoid(x)
+
+
+def _sdpa_manual_fp32(q, k, v, attn_bias, scale):
+    """Explicit fp32 scaled-dot-product-attention for the tight parity path.
+
+    The batched ``QKᵀ`` / ``attn·V`` bmms are computed with ``mx.matmul`` but with
+    fp32 operands and an fp32 softmax; at the tiny fixture ``L`` the cost is
+    negligible. ``hp_matmul`` is deliberately NOT used here (its right operand is
+    batched, violating the 2-D-right-operand contract — see ``hp_matmul`` caveat).
+
+    NOTE: ``mx.matmul`` still rounds fp32 -> ~tf32 on Apple Silicon, so the bmm
+    contributes ~1e-3 max-abs even here (the projections/qk-norm/rotary are exact
+    to ~1e-6). A true-fp32 sum-reduction bmm closes that to ~1.7e-6 but costs
+    ``O(B·H·L·S·D)`` peak memory — fine at fixture ``L`` but NOT at DiT seq lengths,
+    so the runtime/T6 path should rely on the structural-equivalence + ~tf32
+    cosine gate rather than a tight hp max-abs at large ``L``.
+    """
+    q = q.astype(mx.float32)
+    k = k.astype(mx.float32)
+    v = v.astype(mx.float32)
+    scores = mx.matmul(q, mx.swapaxes(k, -1, -2)) * scale  # [B, H, L, S]
+    if attn_bias is not None:
+        scores = scores + attn_bias.astype(mx.float32)
+    weights = mx.softmax(scores, axis=-1)
+    return mx.matmul(weights, v)  # [B, H, L, D]
+
+
+class MultiHeadAttention:
+    """Multi-head attention with optional qk-norm + GPT-NeoX rotary.
+
+    Mirrors ``dots_tts.modules.backbone.layers.MultiHeadAttention``. Separate
+    q/k/v projections (bias=``qkv_bias``); ``o_proj`` ALWAYS has bias (upstream
+    asymmetry). ``qk_norm`` applies ``norm_layer(head_dim)`` per head AFTER the
+    head split and BEFORE rotary. Rotary (when ``rotary_bias``) uses ``pos_ids``.
+    The bool mask (True=attend) becomes an additive bias (0 / -inf). SDPA scale is
+    ``head_dim**-0.5`` applied once.
+
+    ``hp=True`` -> fp32 projections (``hp_matmul``) + explicit fp32 SDPA (tight
+    max-abs parity). ``hp=False`` -> fast projections + ``mx.fast.scaled_dot_product_
+    attention`` (the runtime path; structurally identical, ~tf32 numerics).
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        *,
+        qkv_bias: bool = False,
+        qk_norm: bool = False,
+        norm_layer: str = "LayerNorm",
+        rotary_bias: bool = False,
+        rotary_theta: float = 10000.0,
+    ):
+        assert (
+            hidden_size % num_heads == 0
+        ), "hidden_size must be divisible by num_heads"
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.scale = self.head_dim**-0.5
+        self.qkv_bias = qkv_bias
+        self.qk_norm = qk_norm
+        self.norm_layer = norm_layer
+        self.rotary_bias = rotary_bias
+
+        # Projections start as zero-weight placeholders; load_weights fills them.
+        self.q_proj = Linear(mx.zeros((hidden_size, hidden_size)))
+        self.k_proj = Linear(mx.zeros((hidden_size, hidden_size)))
+        self.v_proj = Linear(mx.zeros((hidden_size, hidden_size)))
+        self.o_proj = Linear(
+            mx.zeros((hidden_size, hidden_size)), mx.zeros((hidden_size,))
+        )
+
+        if qk_norm:
+            self.q_norm = self._make_norm(norm_layer, self.head_dim)
+            self.k_norm = self._make_norm(norm_layer, self.head_dim)
+        else:
+            self.q_norm = _Identity()
+            self.k_norm = _Identity()
+
+        self.rotary = (
+            RotaryEmbedding(self.head_dim, theta=rotary_theta) if rotary_bias else None
+        )
+
+    @staticmethod
+    def _make_norm(norm_layer: str, dim: int):
+        if norm_layer == "RMSNorm":
+            return RMSNorm(dim)
+        if norm_layer == "LayerNorm":
+            # qk-norm LayerNorm in upstream IS affine (has weight+bias); not used by
+            # the checkpoint (it's RMSNorm), so the affine-free LayerNorm suffices for
+            # parity only if weights happen to be ones — kept explicit for clarity.
+            return LayerNorm(dim)
+        raise ValueError(f"unsupported norm_layer {norm_layer!r}")
+
+    def load_weights(self, weights: dict) -> None:
+        """Load the upstream state_dict (npz-key-safe ``w_<dotted>`` scheme).
+
+        Keys: ``w_q_proj_weight``, ``w_k_proj_weight``, ``w_v_proj_weight``,
+        ``w_o_proj_weight``, ``w_o_proj_bias``, and (if qk_norm) ``w_q_norm_weight``,
+        ``w_k_norm_weight``. Weights are stored in torch ``[out, in]`` layout.
+        """
+
+        def g(name):
+            return weights["w_" + name]
+
+        self.q_proj.weight = g("q_proj_weight")
+        self.k_proj.weight = g("k_proj_weight")
+        self.v_proj.weight = g("v_proj_weight")
+        self.o_proj.weight = g("o_proj_weight")
+        self.o_proj.bias = g("o_proj_bias")
+        if self.qkv_bias:
+            self.q_proj.bias = g("q_proj_bias")
+            self.k_proj.bias = g("k_proj_bias")
+            self.v_proj.bias = g("v_proj_bias")
+        if self.qk_norm:
+            self.q_norm.weight = g("q_norm_weight")
+            self.k_norm.weight = g("k_norm_weight")
+
+    def _split_heads(self, x: mx.array) -> mx.array:
+        """``[B, N, H*D] -> [B, H, N, D]``."""
+        b, n, _ = x.shape
+        x = x.reshape(b, n, self.num_heads, self.head_dim)
+        return mx.transpose(x, (0, 2, 1, 3))
+
+    def _merge_heads(self, x: mx.array) -> mx.array:
+        """``[B, H, N, D] -> [B, N, H*D]``."""
+        b, h, n, d = x.shape
+        x = mx.transpose(x, (0, 2, 1, 3))
+        return x.reshape(b, n, h * d)
+
+    def __call__(
+        self,
+        q: mx.array,
+        k: mx.array | None = None,
+        v: mx.array | None = None,
+        *,
+        mask: mx.array | None = None,
+        pos_ids: mx.array | None = None,
+        hp: bool = False,
+    ) -> mx.array:
+        if k is None:
+            k = q
+        if v is None:
+            v = q
+
+        qp = self.q_proj(q, hp=hp)
+        kp = self.k_proj(k, hp=hp)
+        vp = self.v_proj(v, hp=hp)
+
+        qh = self._split_heads(qp)  # [B, H, N, D]
+        kh = self._split_heads(kp)
+        vh = self._split_heads(vp)
+
+        qh = self.q_norm(qh)
+        kh = self.k_norm(kh)
+
+        if self.rotary is not None:
+            b, _, length, _ = qh.shape
+            _, _, slen, _ = kh.shape
+            if pos_ids is None:
+                pos_ids = mx.arange(length).astype(mx.float32)[None]
+            if length == slen:
+                emb = self.rotary(pos_ids)
+                qh = apply_rotary_pos_emb(emb, qh)
+                kh = apply_rotary_pos_emb(emb, kh)
+            else:
+                q_emb = self.rotary(mx.arange(length).astype(mx.float32))
+                k_emb = self.rotary(mx.arange(slen).astype(mx.float32))
+                qh = apply_rotary_pos_emb(q_emb, qh)
+                kh = apply_rotary_pos_emb(k_emb, kh)
+
+        # Bool mask (True=attend) -> additive bias [B, 1, L, S] broadcasting over heads.
+        attn_bias = None
+        if mask is not None:
+            if mask.ndim == 2:  # [B, S] -> [B, 1, 1, S]
+                m = mask[:, None, None, :]
+            elif mask.ndim == 3:  # [B, L, S] -> [B, 1, L, S]
+                m = mask[:, None, :, :]
+            else:
+                m = mask  # already [B, H, L, S]
+            attn_bias = mx.where(
+                m, mx.array(0.0, dtype=mx.float32), mx.array(-mx.inf, dtype=mx.float32)
+            )
+
+        if hp:
+            out = _sdpa_manual_fp32(qh, kh, vh, attn_bias, self.scale)
+        else:
+            # mx.fast.sdpa requires the additive mask to promote to the output
+            # (query) dtype; a fp32 bias does NOT promote to bf16, so cast it down.
+            if attn_bias is not None and attn_bias.dtype != qh.dtype:
+                attn_bias = attn_bias.astype(qh.dtype)
+            out = mx.fast.scaled_dot_product_attention(
+                qh, kh, vh, scale=self.scale, mask=attn_bias
+            )
+
+        out = self._merge_heads(out)
+        return self.o_proj(out, hp=hp)
+
+    def step(self, x_new, kv_cache, mask, *, hp: bool = False):
+        """Streaming self-attention: new tokens attend to a growing KV cache.
+
+        Projects ``x_new`` [1, n, hidden], appends its K/V to ``kv_cache``
+        (mlx_lm KVCache; returns the full [1, H, T, D] tensors), and runs SDPA under the
+        bool ``mask`` [n, T] (True=attend). No rotary / qk-norm (the patch encoder uses
+        neither) — position enters only through ``mask``, so no positions are tracked.
+        """
+        assert self.rotary is None, "streaming step() does not support rotary"
+        qh = self._split_heads(self.q_proj(x_new, hp=hp))  # [1, H, n, D]
+        kh = self._split_heads(self.k_proj(x_new, hp=hp))
+        vh = self._split_heads(self.v_proj(x_new, hp=hp))
+        qh = self.q_norm(qh)  # _Identity for the encoder
+        kh = self.k_norm(kh)
+        k_full, v_full = kv_cache.update_and_fetch(kh, vh)  # [1, H, T, D]
+
+        attn_bias = None
+        if mask is not None:
+            m = mask[None, None, :, :]  # [1, 1, n, T]
+            attn_bias = mx.where(
+                m, mx.array(0.0, dtype=mx.float32), mx.array(-mx.inf, dtype=mx.float32)
+            )
+        if hp:
+            out = _sdpa_manual_fp32(qh, k_full, v_full, attn_bias, self.scale)
+        else:
+            if attn_bias is not None and attn_bias.dtype != qh.dtype:
+                attn_bias = attn_bias.astype(qh.dtype)
+            out = mx.fast.scaled_dot_product_attention(
+                qh, k_full, v_full, scale=self.scale, mask=attn_bias
+            )
+        return self.o_proj(self._merge_heads(out), hp=hp)

--- a/mlx_audio/tts/models/dots/llm.py
+++ b/mlx_audio/tts/models/dots/llm.py
@@ -1,0 +1,186 @@
+"""Pure-MLX Qwen2.5 LLM trunk for dots.tts (``llm.*`` + ``eos_proj.*``).
+
+Mirrors ``DotsTtsCore.step_llm``: the dots.tts decode is schedule-driven, so the
+LLM is a *contextual encoder* (+ an EOS signal), NOT a logit sampler. Each step we
+want the **last-layer hidden state** — i.e. HF Qwen2's ``outputs.hidden_states[-1]``,
+which is the output of the final RMSNorm (``model.norm``). mlx-lm's ``Qwen2Model``
+returns exactly that: ``self.norm(h)`` (the trunk, pre-``lm_head``). We never compute
+logits, so the tied ``lm_head`` (= ``embed_tokens``) is irrelevant to ``step``.
+
+``step`` accepts EITHER token ids (embedded via ``embed_tokens``) OR ``inputs_embeds``
+directly (re-encoded audio embeddings), matching the two ``step_llm`` entry points.
+mlx-lm's ``Qwen2Model.__call__(inputs, cache=None, input_embeddings=None)`` supports
+both natively — when ``input_embeddings`` is given it skips the embedding lookup.
+
+The KV cache is incremental: ``make_cache()`` returns mlx-lm's per-layer
+``KVCache`` list (via ``make_prompt_cache``); feeding one token at a time with the
+cache equals a single full-sequence forward (mlx-lm's RoPE offsets off ``cache.offset``).
+
+``eos_proj`` is a tiny ``Linear(1536,1536) -> SiLU -> Linear(1536,2)`` head; the decode
+uses ``softmax(eos_proj(hidden))[..., 1] > 0.8`` for EOS.
+
+Imports mlx + mlx_lm and makes no torch calls. (Importing mlx_lm pulls in
+torch + transformers transitively for its tokenizer utilities; this module never
+calls into them.) The Qwen2.5 config (vocab 151672, hidden
+1536, 28 layers, 12 heads, 2 kv-heads/GQA, rope_theta 1e6, rms_norm_eps 1e-6, tied
+embeddings) is read verbatim from the saved ``llm_config.json``; mlx-lm handles the
+GQA / RoPE / norm details from those args. Loaded fp32 for parity (MLX fast matmul
+rounds to ~tf32, but cosine over the 28 layers stays >= 0.9999 vs the torch oracle).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.cache import make_prompt_cache
+from mlx_lm.models.qwen2 import Model as Qwen2Model
+from mlx_lm.models.qwen2 import ModelArgs as Qwen2Args
+
+_LLM_PREFIX = "llm."
+
+
+class _EosProj(nn.Module):
+    """``Linear(H, H) -> SiLU -> Linear(H, 2)`` (the ``eos_proj`` Sequential).
+
+    Submodule names ``0`` / ``2`` match the checkpoint keys (``eos_proj.0.*`` is the
+    first Linear, index 1 is the SiLU, ``eos_proj.2.*`` is the output Linear).
+    """
+
+    def __init__(self, hidden: int):
+        super().__init__()
+        self.layers = [nn.Linear(hidden, hidden), nn.SiLU(), nn.Linear(hidden, 2)]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+class DotsLLM:
+    """Qwen2.5 trunk (hidden + KV cache) + the ``eos_proj`` head.
+
+    Use ``DotsLLM.from_core(...)`` to build from the converted ``core.safetensors``.
+    """
+
+    def __init__(self, model: Qwen2Model, eos: _EosProj):
+        self._model = model
+        self._eos = eos
+
+    # region construction
+    @classmethod
+    def from_core(
+        cls,
+        core_safetensors: str,
+        llm_config_json: str,
+        dtype: mx.Dtype = mx.float32,
+        quantization: "object | None" = None,  # QuantizationConfig | None
+    ) -> "DotsLLM":
+        """Build the Qwen2.5 trunk + eos head and bind ``core.safetensors`` weights.
+
+        Reads the Qwen2.5 config from ``llm_config_json`` (the same config the
+        trained checkpoint was built with), instantiates mlx-lm's Qwen2 ``Model``,
+        then loads the ``llm.model.*`` weights (stripped of the ``llm.`` prefix) and
+        the ``eos_proj.*`` weights. Embeddings are tied, so there is no separate
+        ``lm_head`` to load (we never compute logits anyway).
+        """
+        cfg = json.loads(Path(llm_config_json).read_text())
+        args = Qwen2Args(
+            model_type=cfg.get("model_type", "qwen2"),
+            hidden_size=cfg["hidden_size"],
+            num_hidden_layers=cfg["num_hidden_layers"],
+            intermediate_size=cfg["intermediate_size"],
+            num_attention_heads=cfg["num_attention_heads"],
+            rms_norm_eps=cfg["rms_norm_eps"],
+            vocab_size=cfg["vocab_size"],
+            num_key_value_heads=cfg["num_key_value_heads"],
+            max_position_embeddings=cfg.get("max_position_embeddings", 32768),
+            rope_theta=cfg.get("rope_theta", 1000000.0),
+            rope_traditional=cfg.get("rope_traditional", False),
+            rope_scaling=cfg.get("rope_scaling"),
+            tie_word_embeddings=cfg.get("tie_word_embeddings", True),
+        )
+        model = Qwen2Model(args)
+
+        raw = mx.load(str(core_safetensors))
+        llm_weights = {
+            k[len(_LLM_PREFIX) :]: (v if v.dtype == mx.uint32 else v.astype(dtype))
+            for k, v in raw.items()
+            if k.startswith(_LLM_PREFIX)
+        }
+        if quantization is not None and "llm" in quantization.components:
+            has_scales = any(k.endswith(".scales") for k in llm_weights)
+            if not has_scales:
+                raise ValueError(
+                    "config.json declares the llm is quantized, but core.safetensors "
+                    "has no '.scales' tensors — the weights and the quantization block "
+                    "disagree. Re-run `python -m dots_tts_mlx.quantize`."
+                )
+            nn.quantize(
+                model, group_size=quantization.group_size, bits=quantization.bits
+            )
+        # ``sanitize`` drops a tied ``lm_head.weight`` if present and any unused
+        # rotary buffers; our keys have neither, so it is a no-op safeguard.
+        llm_weights = model.sanitize(llm_weights)
+        model.load_weights(list(llm_weights.items()))
+        model.set_dtype(dtype)
+        model.eval()
+
+        eos = _EosProj(args.hidden_size)
+        eos.update(
+            {
+                "layers": [
+                    {
+                        "weight": raw["eos_proj.0.weight"].astype(dtype),
+                        "bias": raw["eos_proj.0.bias"].astype(dtype),
+                    },
+                    {},  # SiLU — no parameters
+                    {
+                        "weight": raw["eos_proj.2.weight"].astype(dtype),
+                        "bias": raw["eos_proj.2.bias"].astype(dtype),
+                    },
+                ]
+            }
+        )
+        eos.eval()
+
+        return cls(model, eos)
+
+    # endregion construction
+
+    def make_cache(self) -> list:
+        """Fresh incremental per-layer KV cache for a decode (mlx-lm ``KVCache``)."""
+        return make_prompt_cache(self._model)
+
+    def step(
+        self,
+        input_ids: mx.array | None = None,
+        inputs_embeds: mx.array | None = None,
+        cache: list | None = None,
+    ) -> tuple[mx.array, list | None]:
+        """One LLM step -> ``(last_hidden, cache)``.
+
+        Provide exactly one of ``input_ids`` ``[B, L]`` (token path) or
+        ``inputs_embeds`` ``[B, L, H]`` (re-encoded-embedding path). ``last_hidden``
+        is ``[B, L, H]`` = the final-RMSNorm output (HF ``hidden_states[-1]``). When
+        ``cache`` is given it is updated in place and returned for the next step.
+        """
+        provided = int(input_ids is not None) + int(inputs_embeds is not None)
+        if provided != 1:
+            raise ValueError(
+                "Exactly one of input_ids or inputs_embeds must be provided to step()."
+            )
+
+        if inputs_embeds is not None:
+            hidden = self._model.model(
+                inputs=None, cache=cache, input_embeddings=inputs_embeds
+            )
+        else:
+            hidden = self._model.model(input_ids, cache=cache)
+        return hidden, cache
+
+    def eos_logits(self, hidden: mx.array) -> mx.array:
+        """EOS head: ``eos_proj(hidden)`` -> ``[..., 2]`` logits."""
+        return self._eos(hidden)

--- a/mlx_audio/tts/models/dots/loader.py
+++ b/mlx_audio/tts/models/dots/loader.py
@@ -1,0 +1,939 @@
+"""MLX runtime loader for dots.tts.
+
+Sets a conservative MLX memory ceiling at import as a safety guard, then provides a
+``DotsTts`` container + ``from_pretrained`` that loads the config,
+latent stats, tokenizer dir, and validates the three converted safetensors.
+
+Submodule wiring (instantiating the DiT / encoder / vocoder / speaker / LLM and
+binding weights) is filled in by later tasks; for now ``load_weights`` only
+validates presence and surfaces the loaded raw weight dicts.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import mlx.core as mx
+
+# Memory-ceiling safety guard: set BEFORE any heavy allocation.
+_DOTS_MEMORY_LIMIT_GB = int(os.environ.get("MLX_AUDIO_DOTS_MEMORY_LIMIT_GB", "20"))
+if _DOTS_MEMORY_LIMIT_GB > 0:
+    mx.set_memory_limit(int(_DOTS_MEMORY_LIMIT_GB * (1 << 30)))
+
+from .audiovae import (  # noqa: E402  (must follow the memory guard)
+    _SLSTM,
+    AudioVAE,
+    _AliasFreeResampler,
+    _AMPBlock1,
+    _Decoder,
+    _Encoder,
+    _ResStack,
+)
+from .config import ModelConfig, VocoderConfig  # noqa: E402
+from .dit import DiT, DiTBlock, FinalLayer, TimestepEmbedder  # noqa: E402
+from .layers import (  # noqa: E402
+    Conv1d,
+    ConvTranspose1d,
+    Linear,
+    Mlp,
+    MultiHeadAttention,
+    RMSNorm,
+    gelu_tanh,
+    silu,
+)
+from .semantic_encoder import (  # noqa: E402
+    SuperviseEncoder,
+    TransformerEncoderLayer,
+    VAESemanticEncoder,
+)
+from .speaker import (  # noqa: E402
+    _BN,
+    FCM,
+    CAMPPlus,
+    _BasicResBlock,
+    _CAMDenseTDNNBlock,
+    _CAMDenseTDNNLayer,
+    _CAMLayer,
+    _Conv1d,
+    _Conv2d,
+    _TDNNLayer,
+    _TransitLayer,
+)
+
+_SAFETENSORS = ("core.safetensors", "vocoder.safetensors", "speaker.safetensors")
+
+
+@dataclass
+class DotsTts:
+    """Container for the loaded dots.tts model + assets.
+
+    Attributes:
+        config: the resolved ``ModelConfig`` (from the checkpoint JSON).
+        dtype: the runtime cast dtype (bf16 default; parity tests pass fp32).
+        path: the ``weights/dots_tts_mlx`` directory the assets were loaded from.
+        latent_mean / latent_var: per-channel latent normalization stats, shape (128,).
+        tokenizer_dir: path to the copied tokenizer files.
+        weights: raw weight dicts keyed by submodule file stem
+            (``core`` / ``vocoder`` / ``speaker``), populated by ``load_weights``.
+        model: the fully-wired ``DotsTtsModel`` AR runtime (populated by
+            ``from_pretrained``); ``None`` until wired.
+    """
+
+    config: ModelConfig
+    dtype: mx.Dtype
+    path: Path
+    latent_mean: mx.array
+    latent_var: mx.array
+    tokenizer_dir: Path
+    weights: dict[str, dict[str, mx.array]] = field(default_factory=dict)
+    model: object | None = None
+
+    def load_weights(self) -> "DotsTts":
+        """Validate the three safetensors load and stash the raw weight dicts.
+
+        Submodule construction + weight binding is deferred to later tasks. This
+        only confirms the converted artifacts are present and parseable, casting
+        each tensor to ``self.dtype``.
+        """
+        for name in _SAFETENSORS:
+            fpath = self.path / name
+            if not fpath.exists():
+                raise FileNotFoundError(
+                    f"missing converted weight file: {fpath} "
+                    "(run `python -m dots_tts_mlx.convert` under the oracle venv first)"
+                )
+            raw = mx.load(str(fpath))
+            if not raw:
+                raise ValueError(f"{name} loaded empty")
+            stem = name.split(".")[0]
+            self.weights[stem] = {k: v.astype(self.dtype) for k, v in raw.items()}
+        return self
+
+
+def _conv1d_weight(w: mx.array, dtype: mx.Dtype) -> mx.array:
+    """torch Conv1d ``[out, in, k]`` -> MLX ``[out, k, in]``."""
+    return w.transpose(0, 2, 1).astype(dtype)
+
+
+def _convtranspose1d_weight(w: mx.array, dtype: mx.Dtype) -> mx.array:
+    """torch ConvTranspose1d ``[in, out, k]`` -> MLX ``[out, k, in]``."""
+    return w.transpose(1, 2, 0).astype(dtype)
+
+
+def _filter_weight(f: mx.array, channels: int) -> mx.array:
+    """Alias-free filter -> depthwise MLX kernel ``[C, k, 1]``, kept fp32.
+
+    Checkpoint filters are ``[1, 1, k]`` (fixed_filter=True) or ``[C, 1, k]``
+    (fixed_filter=False, per-channel). Broadcast the fixed case to ``C`` channels,
+    then transpose ``[C, 1, k]`` -> ``[C, k, 1]``.
+
+    The taps are forced fp32 regardless of the runtime ``dtype`` (they are tiny and
+    the alias-free resampler runs its conv in fp32 — see ``audiovae._AliasFreeResampler``).
+    """
+    if f.shape[0] == 1 and channels != 1:
+        f = mx.broadcast_to(f, (channels, 1, f.shape[2]))
+    return f.transpose(0, 2, 1).astype(mx.float32)
+
+
+def load_audiovae(
+    path_to_vocoder_safetensors: str | Path,
+    dtype: mx.Dtype = mx.bfloat16,
+    *,
+    with_encoder: bool = False,
+) -> AudioVAE:
+    """Build the AudioVAE decode (and optionally encode) path + bind vocoder weights.
+
+    Args:
+        path_to_vocoder_safetensors: path to ``vocoder.safetensors`` (un-prefixed,
+            weight_norm-folded, torch-layout fp32 weights from ``convert.py``).
+        dtype: runtime dtype. ``mx.float32`` for parity tests, ``mx.bfloat16``
+            for inference. Snake math + alias-free filter taps are fp32 regardless.
+        with_encoder: also build + bind the encode path (``audio_encoder`` /
+            ``enc_mi_layer`` / ``pre_proj``), enabling ``AudioVAE.encode``.
+
+    Returns:
+        an ``AudioVAE`` whose ``decode(latent)`` (and, if ``with_encoder``,
+        ``encode(wav)``) reproduces the torch oracle.
+    """
+    path = Path(path_to_vocoder_safetensors)
+    if not path.exists():
+        raise FileNotFoundError(f"vocoder weights not found: {path}")
+    cfg_dir = path.parent
+    config = (
+        ModelConfig.from_checkpoint(cfg_dir).vocoder
+        if ((cfg_dir / "config.json").exists())
+        else VocoderConfig()
+    )
+
+    w = mx.load(str(path))
+
+    # --- post_proj: Conv1d k=1 (128 -> 128) ---
+    post_proj = Conv1d(
+        _conv1d_weight(w["post_proj.weight"], dtype),
+        w["post_proj.bias"].astype(dtype),
+        causal=False,
+    )
+
+    # --- dec_mi_layer = Sequential(Linear, SLSTM, Linear) ---
+    mi_num_layers = config.mi_num_layers
+    slstm = _SLSTM(
+        weight_ih=[
+            w[f"dec_mi_layer.1.lstm.weight_ih_l{n}"].astype(dtype)
+            for n in range(mi_num_layers)
+        ],
+        weight_hh=[
+            w[f"dec_mi_layer.1.lstm.weight_hh_l{n}"].astype(dtype)
+            for n in range(mi_num_layers)
+        ],
+        bias_ih=[
+            w[f"dec_mi_layer.1.lstm.bias_ih_l{n}"].astype(dtype)
+            for n in range(mi_num_layers)
+        ],
+        bias_hh=[
+            w[f"dec_mi_layer.1.lstm.bias_hh_l{n}"].astype(dtype)
+            for n in range(mi_num_layers)
+        ],
+        num_layers=mi_num_layers,
+    )
+
+    # --- Decoder ---
+    causal = config.causal
+    num_kernels = len(config.resblock_kernel_sizes)
+    initial = config.upsample_initial_channel
+
+    conv_pre = Conv1d(
+        _conv1d_weight(w["decoder.conv_pre.weight"], dtype),
+        w["decoder.conv_pre.bias"].astype(dtype),
+        causal=False,  # upstream exception: conv_pre is non-causal even in causal decoder
+    )
+
+    ups = []
+    for i, (u, _k) in enumerate(
+        zip(config.upsample_rates, config.upsample_kernel_sizes)
+    ):
+        ups.append(
+            ConvTranspose1d(
+                _convtranspose1d_weight(w[f"decoder.ups.{i}.0.weight"], dtype),
+                w[f"decoder.ups.{i}.0.bias"].astype(dtype),
+                stride=u,
+                causal=causal,
+            )
+        )
+
+    def _resampler(prefix: str, channels: int) -> _AliasFreeResampler:
+        return _AliasFreeResampler(
+            up_filter=_filter_weight(w[f"{prefix}.upsample.filter"], channels),
+            down_filter=_filter_weight(
+                w[f"{prefix}.downsample.lowpass.filter"], channels
+            ),
+            alpha=w[f"{prefix}.act.alpha"].astype(dtype),
+            beta=w[f"{prefix}.act.beta"].astype(dtype),
+            ratio=2,
+        )
+
+    resblocks = []
+    for i in range(len(ups)):
+        ch = initial // (2 ** (i + 1))
+        for j, (k_size, dils) in enumerate(
+            zip(config.resblock_kernel_sizes, config.resblock_dilation_sizes)
+        ):
+            rb_idx = i * num_kernels + j
+            prefix = f"decoder.resblocks.{rb_idx}"
+            convs1 = [
+                Conv1d(
+                    _conv1d_weight(w[f"{prefix}.convs1.{d}.weight"], dtype),
+                    w[f"{prefix}.convs1.{d}.bias"].astype(dtype),
+                    causal=causal,
+                    dilation=dils[d],
+                )
+                for d in range(num_kernels)
+            ]
+            convs2 = [
+                Conv1d(
+                    _conv1d_weight(w[f"{prefix}.convs2.{d}.weight"], dtype),
+                    w[f"{prefix}.convs2.{d}.bias"].astype(dtype),
+                    causal=causal,
+                    dilation=1,
+                )
+                for d in range(num_kernels)
+            ]
+            acts = [_resampler(f"{prefix}.activations.{a}", ch) for a in range(6)]
+            resblocks.append(_AMPBlock1(convs1=convs1, convs2=convs2, acts=acts))
+
+    final_ch = initial // (2 ** len(ups))
+    act_post = _resampler("decoder.activation_post", final_ch)
+
+    conv_post = Conv1d(
+        _conv1d_weight(w["decoder.conv_post.weight"], dtype),
+        None,  # use_bias_at_final=False
+        causal=causal,
+    )
+
+    decoder = _Decoder(
+        conv_pre=conv_pre,
+        ups=ups,
+        resblocks=resblocks,
+        act_post=act_post,
+        conv_post=conv_post,
+        num_kernels=num_kernels,
+    )
+
+    encoder = None
+    enc_lin0_w = enc_lin0_b = enc_lin2_w = enc_lin2_b = None
+    enc_slstm = None
+    pre_proj = None
+    if with_encoder:
+        (
+            encoder,
+            enc_lin0_w,
+            enc_lin0_b,
+            enc_slstm,
+            enc_lin2_w,
+            enc_lin2_b,
+            pre_proj,
+        ) = _build_encoder(w, config, dtype)
+
+    return AudioVAE(
+        config=config,
+        post_proj=post_proj,
+        mi_lin0_w=w["dec_mi_layer.0.weight"].astype(dtype),
+        mi_lin0_b=w["dec_mi_layer.0.bias"].astype(dtype),
+        slstm=slstm,
+        mi_lin2_w=w["dec_mi_layer.2.weight"].astype(dtype),
+        mi_lin2_b=w["dec_mi_layer.2.bias"].astype(dtype),
+        decoder=decoder,
+        encoder=encoder,
+        enc_lin0_w=enc_lin0_w,
+        enc_lin0_b=enc_lin0_b,
+        enc_slstm=enc_slstm,
+        enc_lin2_w=enc_lin2_w,
+        enc_lin2_b=enc_lin2_b,
+        pre_proj=pre_proj,
+    )
+
+
+def _build_encoder(w, config, dtype):
+    """Build the AudioVAE encode submodules from ``vocoder.safetensors`` weights.
+
+    Mirrors the upstream ``Encoder.generator`` Sequential index layout:
+      generator.0   Conv1d_S(1 -> base, k=3, s=1, causal)   [pre]
+      generator.1   LeakyReLU (no params)
+      per stage i in 0..5 at base index ``2 + 3*i``:
+        +0  Conv1d_S(in -> out, k=2*down, s=down, causal)    [downsample]
+        +1  ResStack(out, k=3, base=2, nums=6, causal)
+        +2  LeakyReLU
+      generator.20  Conv1d_S(768 -> latent_dim, k=5, s=1, NON-causal)  [lookahead post]
+    """
+    causal = config.causal_encoder
+    down_rates = config.downsample_rates  # [2, 2, 2, 4, 6, 10]
+    g = "audio_encoder.generator"
+
+    # All encode convs run in high-precision (hp=True) mode: the encoder is a deep,
+    # large-magnitude stack gated by a tight max-abs tolerance, and MLX's reduced-
+    # precision fp32 matmul/conv otherwise drifts ~1e0 (see layers.hp_matmul).
+
+    # pre proj conv (causal, stride 1, k=3)
+    pre_conv = Conv1d(
+        _conv1d_weight(w[f"{g}.0.layer.weight"], dtype),
+        w[f"{g}.0.layer.bias"].astype(dtype),
+        causal=causal,
+        hp=True,
+    )
+
+    down_convs = []
+    res_stacks = []
+    n_blocks = 6  # ResStack nums (Encoder stacks=6)
+    dil_base = 2  # stack_dilation_base
+    for i, down in enumerate(down_rates):
+        base_idx = 2 + 3 * i
+        # downsample Conv1d_S: kernel = 2*down, stride = down, causal
+        down_convs.append(
+            Conv1d(
+                _conv1d_weight(w[f"{g}.{base_idx}.layer.weight"], dtype),
+                w[f"{g}.{base_idx}.layer.bias"].astype(dtype),
+                causal=causal,
+                stride=down,
+                hp=True,
+            )
+        )
+        rs_idx = base_idx + 1
+        convs1 = []  # dilated (k=3), block-index .2
+        convs2 = []  # dilation=1 (k=3), block-index .5
+        for b in range(n_blocks):
+            dil = dil_base**b
+            convs1.append(
+                Conv1d(
+                    _conv1d_weight(w[f"{g}.{rs_idx}.layers.{b}.2.weight"], dtype),
+                    w[f"{g}.{rs_idx}.layers.{b}.2.bias"].astype(dtype),
+                    causal=causal,
+                    dilation=dil,
+                    hp=True,
+                )
+            )
+            convs2.append(
+                Conv1d(
+                    _conv1d_weight(w[f"{g}.{rs_idx}.layers.{b}.5.weight"], dtype),
+                    w[f"{g}.{rs_idx}.layers.{b}.5.bias"].astype(dtype),
+                    causal=causal,
+                    dilation=1,
+                    hp=True,
+                )
+            )
+        res_stacks.append(_ResStack(convs1=convs1, convs2=convs2))
+
+    # lookahead post conv: NON-causal (kernel = 2*lookahead + 1 = 5), stride 1
+    post_idx = 2 + 3 * len(down_rates)
+    post_conv = Conv1d(
+        _conv1d_weight(w[f"{g}.{post_idx}.layer.weight"], dtype),
+        w[f"{g}.{post_idx}.layer.bias"].astype(dtype),
+        causal=False,
+        hp=True,
+    )
+
+    encoder = _Encoder(
+        pre_conv=pre_conv,
+        down_convs=down_convs,
+        res_stacks=res_stacks,
+        post_conv=post_conv,
+    )
+
+    # enc_mi_layer = Sequential(Linear, SLSTM, Linear)
+    mi_num_layers = config.mi_num_layers
+    enc_slstm = _SLSTM(
+        weight_ih=[
+            w[f"enc_mi_layer.1.lstm.weight_ih_l{n}"].astype(dtype)
+            for n in range(mi_num_layers)
+        ],
+        weight_hh=[
+            w[f"enc_mi_layer.1.lstm.weight_hh_l{n}"].astype(dtype)
+            for n in range(mi_num_layers)
+        ],
+        bias_ih=[
+            w[f"enc_mi_layer.1.lstm.bias_ih_l{n}"].astype(dtype)
+            for n in range(mi_num_layers)
+        ],
+        bias_hh=[
+            w[f"enc_mi_layer.1.lstm.bias_hh_l{n}"].astype(dtype)
+            for n in range(mi_num_layers)
+        ],
+        num_layers=mi_num_layers,
+        hp=True,
+    )
+
+    # pre_proj: Conv1d k=1 (latent_dim -> 2*latent_dim)
+    pre_proj = Conv1d(
+        _conv1d_weight(w["pre_proj.weight"], dtype),
+        w["pre_proj.bias"].astype(dtype),
+        causal=False,
+        hp=True,
+    )
+
+    return (
+        encoder,
+        w["enc_mi_layer.0.weight"].astype(dtype),
+        w["enc_mi_layer.0.bias"].astype(dtype),
+        enc_slstm,
+        w["enc_mi_layer.2.weight"].astype(dtype),
+        w["enc_mi_layer.2.bias"].astype(dtype),
+        pre_proj,
+    )
+
+
+def _conv2d_weight(w: mx.array, dtype: mx.Dtype) -> mx.array:
+    """torch Conv2d ``[out, in, kh, kw]`` -> MLX ``[out, kh, kw, in]``."""
+    return w.transpose(0, 2, 3, 1).astype(dtype)
+
+
+def _fold_bn(
+    w: dict[str, mx.array], prefix: str, dtype: mx.Dtype, *, affine: bool = True
+) -> _BN:
+    """Fold a frozen BatchNorm to an affine ``(scale, shift)`` over the channel axis.
+
+    ``y = (x - rm)/sqrt(rv + eps)*gamma + beta`` (eps 1e-5). For affine-free BN
+    (config ``batchnorm_``, the final dense), gamma=1 / beta=0 so it reduces to
+    ``(x - rm)/sqrt(rv + eps)``. Keys live at ``<prefix>.{running_mean,running_var,
+    weight,bias}``; the result broadcasts against channels-last activations.
+    """
+    eps = 1e-5
+    rm = w[f"{prefix}.running_mean"].astype(mx.float32)
+    rv = w[f"{prefix}.running_var"].astype(mx.float32)
+    inv = mx.rsqrt(rv + eps)
+    if affine:
+        gamma = w[f"{prefix}.weight"].astype(mx.float32)
+        beta = w[f"{prefix}.bias"].astype(mx.float32)
+    else:
+        gamma = mx.ones_like(rm)
+        beta = mx.zeros_like(rm)
+    scale = (gamma * inv).astype(dtype)
+    shift = (beta - rm * gamma * inv).astype(dtype)
+    return _BN(scale, shift)
+
+
+def load_speaker(
+    path_to_speaker_safetensors: str | Path, dtype: mx.Dtype = mx.float32
+) -> CAMPPlus:
+    """Build the pure-MLX CAM++ x-vector encoder + bind ``speaker.safetensors`` weights.
+
+    The converted ``speaker.safetensors`` preserves the upstream keys verbatim:
+    a ``model.`` prefix (the wrapping ``SpeakerXVectorFeatures`` held the CAMPPlus as
+    ``self.model``), torch-layout conv weights, raw BatchNorm running stats, and a
+    wrapper-only ``resample.kernel`` buffer. This loader strips the prefix, transposes
+    conv weights to MLX layout, and folds every BN to a frozen affine.
+
+    Args:
+        path_to_speaker_safetensors: path to ``speaker.safetensors``.
+        dtype: runtime dtype (``mx.float32`` for the parity gate).
+
+    Returns:
+        a ``CAMPPlus`` whose ``model(fbank[B, T, 80]) -> [B, 512]`` reproduces the
+        torch oracle (cosine >= 0.9995).
+    """
+    path = Path(path_to_speaker_safetensors)
+    if not path.exists():
+        raise FileNotFoundError(f"speaker weights not found: {path}")
+    raw = mx.load(str(path))
+    # Strip the wrapper ``model.`` prefix; drop the wrapper-only resample buffer.
+    w = {k[len("model.") :]: v for k, v in raw.items() if k.startswith("model.")}
+
+    def conv2d(name, stride, padding):
+        return _Conv2d(
+            _conv2d_weight(w[f"{name}.weight"], dtype),
+            None,  # all FCM convs are bias=False
+            stride=stride,
+            padding=padding,
+        )
+
+    def res_block(name, stride):
+        # conv1: k3 stride (stride,1) p1 ; conv2: k3 s1 p1 ; shortcut k1 (stride,1) p0
+        shortcut_conv = shortcut_bn = None
+        if f"{name}.shortcut.0.weight" in w:
+            shortcut_conv = _Conv2d(
+                _conv2d_weight(w[f"{name}.shortcut.0.weight"], dtype),
+                None,
+                stride=(stride, 1),
+                padding=(0, 0),
+            )
+            shortcut_bn = _fold_bn(w, f"{name}.shortcut.1", dtype)
+        return _BasicResBlock(
+            conv1=conv2d(f"{name}.conv1", (stride, 1), (1, 1)),
+            bn1=_fold_bn(w, f"{name}.bn1", dtype),
+            conv2=conv2d(f"{name}.conv2", (1, 1), (1, 1)),
+            bn2=_fold_bn(w, f"{name}.bn2", dtype),
+            shortcut_conv=shortcut_conv,
+            shortcut_bn=shortcut_bn,
+        )
+
+    head = FCM(
+        conv1=conv2d("head.conv1", (1, 1), (1, 1)),
+        bn1=_fold_bn(w, "head.bn1", dtype),
+        layer1=[res_block("head.layer1.0", 2), res_block("head.layer1.1", 1)],
+        layer2=[res_block("head.layer2.0", 2), res_block("head.layer2.1", 1)],
+        conv2=conv2d("head.conv2", (2, 1), (1, 1)),
+        bn2=_fold_bn(w, "head.bn2", dtype),
+        out_channels=320,
+    )
+
+    # --- xvector.tdnn: Conv1d 320->128 k5 s2 dil1 pad2, BN-ReLU
+    tdnn = _TDNNLayer(
+        conv=_Conv1d(
+            _conv1d_weight(w["xvector.tdnn.linear.weight"], dtype),
+            None,
+            stride=2,
+            padding=2,
+            dilation=1,
+        ),
+        bn=_fold_bn(w, "xvector.tdnn.nonlinear.batchnorm", dtype),
+    )
+
+    def dense_block(block_name, num_layers, dilation):
+        layers = []
+        for i in range(num_layers):
+            ln = f"xvector.{block_name}.tdnnd{i + 1}"
+            cam = _CAMLayer(
+                linear_local=_Conv1d(
+                    _conv1d_weight(w[f"{ln}.cam_layer.linear_local.weight"], dtype),
+                    None,  # cam_layer.linear_local bias=False
+                    stride=1,
+                    padding=dilation,  # (k-1)//2 * dilation, k=3
+                    dilation=dilation,
+                ),
+                linear1=_Conv1d(
+                    _conv1d_weight(w[f"{ln}.cam_layer.linear1.weight"], dtype),
+                    w[f"{ln}.cam_layer.linear1.bias"].astype(dtype),
+                ),
+                linear2=_Conv1d(
+                    _conv1d_weight(w[f"{ln}.cam_layer.linear2.weight"], dtype),
+                    w[f"{ln}.cam_layer.linear2.bias"].astype(dtype),
+                ),
+            )
+            layers.append(
+                _CAMDenseTDNNLayer(
+                    bn1=_fold_bn(w, f"{ln}.nonlinear1.batchnorm", dtype),
+                    relu1=None,
+                    linear1=_Conv1d(
+                        _conv1d_weight(w[f"{ln}.linear1.weight"], dtype),
+                        None,  # linear1 bias=False
+                    ),
+                    bn2=_fold_bn(w, f"{ln}.nonlinear2.batchnorm", dtype),
+                    relu2=None,
+                    cam_layer=cam,
+                )
+            )
+        return _CAMDenseTDNNBlock(layers)
+
+    def transit(name):
+        return _TransitLayer(
+            bn=_fold_bn(w, f"xvector.{name}.nonlinear.batchnorm", dtype),
+            linear=_Conv1d(
+                _conv1d_weight(w[f"xvector.{name}.linear.weight"], dtype),
+                None,  # transit bias=False
+            ),
+        )
+
+    block1 = dense_block("block1", 12, 1)
+    block2 = dense_block("block2", 24, 2)
+    block3 = dense_block("block3", 16, 2)
+
+    out_nonlinear = _fold_bn(w, "xvector.out_nonlinear.batchnorm", dtype)
+    dense_linear = _Conv1d(
+        _conv1d_weight(w["xvector.dense.linear.weight"], dtype),
+        None,  # DenseLayer bias=False
+    )
+    dense_bn = _fold_bn(w, "xvector.dense.nonlinear.batchnorm", dtype, affine=False)
+
+    return CAMPPlus(
+        head=head,
+        tdnn=tdnn,
+        block1=block1,
+        transit1=transit("transit1"),
+        block2=block2,
+        transit2=transit("transit2"),
+        block3=block3,
+        transit3=transit("transit3"),
+        out_nonlinear=out_nonlinear,
+        dense_linear=dense_linear,
+        dense_bn=dense_bn,
+    )
+
+
+def _linear(w: dict, prefix: str, dtype: mx.Dtype, *, bias: bool = True) -> Linear:
+    """Build a ``Linear`` from torch-layout ``<prefix>.weight`` (+ optional bias)."""
+    weight = w[f"{prefix}.weight"].astype(dtype)
+    b = w[f"{prefix}.bias"].astype(dtype) if bias else None
+    return Linear(weight, b)
+
+
+def load_dit(path_to_core_safetensors: str | Path, dtype: mx.Dtype = mx.float32) -> DiT:
+    """Build the pure-MLX flow-matching DiT + bind ``velocity_field_predictor.*`` weights.
+
+    The converted ``core.safetensors`` keeps the upstream keys verbatim (un-prefixed
+    torch-layout fp32). This loader maps the 244 ``velocity_field_predictor.*`` keys
+    onto the MLX ``DiT``:
+
+      * Linear weights stay torch-layout ``[out, in]`` (``layers.Linear`` applies
+        ``x @ W.T``) — no transpose.
+      * ``attn.{q,k,v}_proj`` (no bias) / ``attn.o_proj`` (has bias) / ``attn.{q,k}_norm``
+        (RMSNorm weight) are bound via ``MultiHeadAttention.load_weights`` (the
+        npz-key-safe ``w_<dotted>`` scheme).
+      * ``norm1`` / ``norm2`` / ``output_layer.norm`` are affine-free (no stored
+        weights) — skipped.
+      * attn rotary has no stored params (recomputed in ``layers``).
+
+    The block attention runs on the fast (hp=False) path; see ``dit`` for numerics.
+
+    In meanflow mode (``config.json`` carries an enabled ``meanflow`` block) the
+    checkpoint additionally carries 4 ``velocity_field_predictor.duration_embedder.mlp.{0,2}.{weight,bias}``
+    keys; this loader binds them onto ``DiT.duration_embedder`` (a ``TimestepEmbedder``)
+    using the same ``_linear`` machinery as ``time_embedder``. In flow-matching mode
+    that submodule is ``None`` and those keys are absent.
+
+    Args:
+        path_to_core_safetensors: path to ``core.safetensors``.
+        dtype: runtime dtype (``mx.float32`` for the parity gate).
+
+    Returns:
+        a ``DiT`` whose ``__call__`` reproduces the torch oracle (cosine >= 0.9999).
+    """
+    path = Path(path_to_core_safetensors)
+    if not path.exists():
+        raise FileNotFoundError(f"core weights not found: {path}")
+    raw = mx.load(str(path))
+    p = "velocity_field_predictor."
+    w = {k[len(p) :]: v for k, v in raw.items() if k.startswith(p)}
+
+    cfg_dir = path.parent
+    config = ModelConfig.from_checkpoint(cfg_dir)
+    dit_cfg = config.dit
+    hidden = dit_cfg.hidden_size
+    num_layers = dit_cfg.num_layers
+
+    input_layer = _linear(w, "input_layer", dtype)
+
+    time_embedder = TimestepEmbedder(
+        _linear(w, "time_embedder.mlp.0", dtype),
+        _linear(w, "time_embedder.mlp.2", dtype),
+    )
+
+    duration_embedder = None
+    if config.mode == "meanflow":
+        if "duration_embedder.mlp.0.weight" not in w:
+            raise ValueError(
+                "config declares meanflow mode but core.safetensors has no "
+                "duration_embedder.* keys (wrong checkpoint?)."
+            )
+        duration_embedder = TimestepEmbedder(
+            _linear(w, "duration_embedder.mlp.0", dtype),
+            _linear(w, "duration_embedder.mlp.2", dtype),
+        )
+
+    blocks: list[DiTBlock] = []
+    for i in range(num_layers):
+        bp = f"blocks.{i}"
+        attn = MultiHeadAttention(
+            hidden,
+            dit_cfg.num_heads,
+            qkv_bias=dit_cfg.qkv_bias,
+            qk_norm=dit_cfg.qk_norm,
+            norm_layer=dit_cfg.norm_layer,
+            rotary_bias=dit_cfg.rotary_bias,
+            rotary_theta=dit_cfg.rotary_theta,
+        )
+        attn.load_weights(
+            {
+                "w_q_proj_weight": w[f"{bp}.attn.q_proj.weight"].astype(dtype),
+                "w_k_proj_weight": w[f"{bp}.attn.k_proj.weight"].astype(dtype),
+                "w_v_proj_weight": w[f"{bp}.attn.v_proj.weight"].astype(dtype),
+                "w_o_proj_weight": w[f"{bp}.attn.o_proj.weight"].astype(dtype),
+                "w_o_proj_bias": w[f"{bp}.attn.o_proj.bias"].astype(dtype),
+                "w_q_norm_weight": w[f"{bp}.attn.q_norm.weight"].astype(dtype),
+                "w_k_norm_weight": w[f"{bp}.attn.k_norm.weight"].astype(dtype),
+            }
+        )
+        ffn = Mlp(
+            _linear(w, f"{bp}.ffn.fc1", dtype),
+            _linear(w, f"{bp}.ffn.fc2", dtype),
+            gelu_tanh,
+        )
+        adaLN = _linear(w, f"{bp}.adaLN_modulation.1", dtype)
+        blocks.append(DiTBlock(attn, ffn, adaLN, hidden_size=hidden))
+
+    output_layer = FinalLayer(
+        _linear(w, "output_layer.adaLN_modulation.1", dtype),
+        _linear(w, "output_layer.linear", dtype),
+        hidden_size=hidden,
+    )
+
+    return DiT(
+        input_layer,
+        time_embedder,
+        blocks,
+        output_layer,
+        duration_embedder=duration_embedder,
+    )
+
+
+def load_coordinate_proj(
+    path_to_core_safetensors: str | Path, dtype: mx.Dtype = mx.float32
+) -> Linear:
+    """Build the flow-matching ``coordinate_proj`` ``Linear(latent_dim, hidden_size)``.
+
+    The noisy-latent projection used by the euler/CFG solver lives at
+    ``coordinate_proj.{weight,bias}`` in ``core.safetensors`` (un-prefixed,
+    torch-layout ``[hidden_size, latent_dim]`` = ``[1024, 128]``). It is NOT under the
+    ``velocity_field_predictor.`` prefix, so ``load_dit`` does not pick it up.
+
+    Args:
+        path_to_core_safetensors: path to ``core.safetensors``.
+        dtype: runtime dtype (``mx.float32`` for the parity gate).
+
+    Returns:
+        a ``layers.Linear`` mapping ``[..., latent_dim] -> [..., hidden_size]``.
+    """
+    path = Path(path_to_core_safetensors)
+    if not path.exists():
+        raise FileNotFoundError(f"core weights not found: {path}")
+    raw = mx.load(str(path))
+    if "coordinate_proj.weight" not in raw:
+        raise ValueError(f"no coordinate_proj.* keys in {path}")
+    return Linear(
+        raw["coordinate_proj.weight"].astype(dtype),
+        raw["coordinate_proj.bias"].astype(dtype),
+    )
+
+
+def load_semantic_encoder(
+    path_to_core_safetensors: str | Path, dtype: mx.Dtype = mx.float32
+) -> VAESemanticEncoder:
+    """Build the pure-MLX VAE semantic encoder + bind ``patch_encoder.*`` weights.
+
+    Maps the un-prefixed ``patch_encoder.*`` keys from ``core.safetensors`` onto the
+    MLX ``VAESemanticEncoder`` (in_dim=128, out_dim=1536, patch_size=4):
+
+      * ``ds_proj`` — causal stride-2 ``Conv1d(128, 128, k=2)`` (torch ``[out, in, k]``
+        -> MLX ``[out, k, in]``); ``causal=True`` left-pads ``dilation*(k-1)=1``.
+      * ``in_proj`` — ``Linear(128 -> 1024)``; ``out_proj`` — ``Linear(2048 -> 1536)``.
+      * 24 ``TransformerEncoderLayer``: ``attn_norm`` / ``ffn_norm`` are affine
+        ``RMSNorm(1024)``; ``attn`` is ``MultiHeadAttention(1024, 16)`` with
+        **NO qk_norm / NO rotary / NO qkv_bias** (config says otherwise but the
+        upstream ``SuperviseEncoder`` does not forward those — see module docstring);
+        ``ffn`` is a SiLU ``Mlp(1024 -> 4096 -> 1024)``.
+
+    CONFIG-VS-CODE GUARD: asserts the checkpoint has NO ``patch_encoder.encoder.
+    layers.*.attn.q_norm`` / ``k_norm`` / ``rotary`` keys before wiring — this proves
+    the encoder runs without qk-norm / rotary regardless of the config block.
+
+    Args:
+        path_to_core_safetensors: path to ``core.safetensors``.
+        dtype: runtime dtype (``mx.float32`` for the parity gate).
+
+    Returns:
+        a ``VAESemanticEncoder`` whose ``__call__([B, T, 128]) -> [B, T/4, 1536]``
+        reproduces the torch oracle (cosine >= 0.9999).
+    """
+    path = Path(path_to_core_safetensors)
+    if not path.exists():
+        raise FileNotFoundError(f"core weights not found: {path}")
+    raw = mx.load(str(path))
+    p = "patch_encoder."
+    w = {k[len(p) :]: v for k, v in raw.items() if k.startswith(p)}
+    if not w:
+        raise ValueError(f"no patch_encoder.* keys in {path}")
+
+    # CONFIG-VS-CODE GUARD: the trained encoder has no qk-norm / rotary params,
+    # despite config.PatchEncoder.{qk_norm,rotary_bias}=True (SuperviseEncoder does
+    # not forward those flags into the layers). Fail loudly if that ever changes.
+    forbidden = [
+        k
+        for k in w
+        if (".q_norm" in k or ".k_norm" in k or "rotary" in k or "inv_freq" in k)
+    ]
+    assert not forbidden, (
+        "patch_encoder unexpectedly carries qk-norm / rotary weights "
+        f"(config-vs-code resolution broken): {forbidden}"
+    )
+
+    cfg_dir = path.parent
+    config = ModelConfig.from_checkpoint(cfg_dir)
+    enc_cfg = config.encoder
+    hidden = enc_cfg.hidden_size  # 1024
+    num_layers = enc_cfg.num_layers  # 24
+    num_heads = enc_cfg.num_heads  # 16
+    # The MLX EncoderConfig already forces qk_norm / rotary OFF (Task 0 finding);
+    # assert here so a config-schema regression can't silently re-enable them.
+    assert (
+        not enc_cfg.qk_norm and not enc_cfg.rotary_bias
+    ), "EncoderConfig must force qk_norm / rotary OFF for the patch encoder"
+
+    # ds_proj: causal stride-2 Conv1d(128, 128, k=2). torch [out, in, k] -> MLX [out, k, in].
+    ds_proj = Conv1d(
+        _conv1d_weight(w["ds_proj.weight"], dtype),
+        w["ds_proj.bias"].astype(dtype),
+        causal=True,
+        stride=2,
+    )
+
+    in_proj = _linear(w, "in_proj", dtype)
+    out_proj = _linear(w, "out_proj", dtype)
+
+    layers: list[TransformerEncoderLayer] = []
+    for i in range(num_layers):
+        lp = f"encoder.layers.{i}"
+        attn_norm = RMSNorm(hidden, weight=w[f"{lp}.attn_norm.weight"].astype(dtype))
+        ffn_norm = RMSNorm(hidden, weight=w[f"{lp}.ffn_norm.weight"].astype(dtype))
+        attn = MultiHeadAttention(
+            hidden,
+            num_heads,
+            qkv_bias=False,
+            qk_norm=False,
+            rotary_bias=False,
+        )
+        attn.load_weights(
+            {
+                "w_q_proj_weight": w[f"{lp}.attn.q_proj.weight"].astype(dtype),
+                "w_k_proj_weight": w[f"{lp}.attn.k_proj.weight"].astype(dtype),
+                "w_v_proj_weight": w[f"{lp}.attn.v_proj.weight"].astype(dtype),
+                "w_o_proj_weight": w[f"{lp}.attn.o_proj.weight"].astype(dtype),
+                "w_o_proj_bias": w[f"{lp}.attn.o_proj.bias"].astype(dtype),
+            }
+        )
+        ffn = Mlp(
+            _linear(w, f"{lp}.ffn.fc1", dtype),
+            _linear(w, f"{lp}.ffn.fc2", dtype),
+            silu,
+        )
+        layers.append(TransformerEncoderLayer(attn_norm, attn, ffn_norm, ffn))
+
+    encoder = SuperviseEncoder(layers, causal=enc_cfg.causal)
+
+    return VAESemanticEncoder(
+        ds_proj=ds_proj,
+        in_proj=in_proj,
+        encoder=encoder,
+        out_proj=out_proj,
+        out_ds_rate=config.patch_size // 2,
+        patch_size=config.patch_size,
+    )
+
+
+def _load_container(path: Path, dtype: mx.Dtype) -> DotsTts:
+    """Validate the converted assets + build the bare ``DotsTts`` container.
+
+    Confirms ``config.json`` / ``llm_config.json`` / ``latent_stats.npz`` /
+    ``tokenizer/`` / the three safetensors are present and parseable, and stashes the
+    raw weight dicts. Does NOT wire the AR runtime (that is ``from_pretrained``).
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"model directory not found: {path}")
+
+    config = ModelConfig.from_checkpoint(path)
+
+    stats_path = path / "latent_stats.npz"
+    if not stats_path.exists():
+        raise FileNotFoundError(f"missing latent_stats.npz: {stats_path}")
+    stats = mx.load(str(stats_path))
+    if "mean" not in stats or "var" not in stats:
+        raise ValueError(f"latent_stats.npz missing mean/var keys: {sorted(stats)}")
+
+    tokenizer_dir = path / "tokenizer"
+    if not tokenizer_dir.exists():
+        raise FileNotFoundError(f"missing tokenizer dir: {tokenizer_dir}")
+
+    container = DotsTts(
+        config=config,
+        dtype=dtype,
+        path=path,
+        latent_mean=stats["mean"].astype(mx.float32),
+        latent_var=stats["var"].astype(mx.float32),
+        tokenizer_dir=tokenizer_dir,
+    )
+    return container.load_weights()
+
+
+def from_pretrained(path: str | Path, dtype: mx.Dtype = mx.bfloat16) -> DotsTts:
+    """Load + FULLY WIRE a converted dots.tts model from ``path``.
+
+    Builds the bare ``DotsTts`` container (validating + loading assets), then wires
+    the complete AR runtime — tokenizer, Qwen2.5 LLM + eos head, AudioVAE
+    encode+decode, CAM++ x-vector, flow-matching ``FlowSolver`` (DiT +
+    coordinate_proj), the semantic patch encoder, and the hidden / latent / xvec
+    projections — attaching the resulting ``DotsTtsModel`` as ``container.model``.
+
+    Args:
+        path: directory containing ``{core,vocoder,speaker}.safetensors``,
+            ``latent_stats.npz``, ``config.json`` + ``llm_config.json``, and ``tokenizer/``.
+        dtype: runtime cast dtype. ``mx.bfloat16`` for inference, ``mx.float32`` for
+            parity / behavioral tests.
+
+    Returns:
+        a ``DotsTts`` with assets loaded, safetensors validated, and ``.model`` set to
+        the fully-wired ``DotsTtsModel`` (call ``container.model.generate(...)``).
+    """
+    path = Path(path)
+    container = _load_container(path, dtype)
+    # Lazy import to avoid a circular import (model.py imports loader.py).
+    from .model import DotsTtsModel
+
+    container.model = DotsTtsModel.from_pretrained(path, dtype=dtype)
+    return container

--- a/mlx_audio/tts/models/dots/model.py
+++ b/mlx_audio/tts/models/dots/model.py
@@ -1,0 +1,1105 @@
+"""AR orchestration for the dots.tts MLX runtime — ``DotsTtsModel.generate``.
+
+Imports mlx / numpy / stdlib (+ this package) and makes no torch calls. (torch +
+transformers are pulled in transitively via mlx-lm; the math here is pure MLX.)
+Audio I/O is WAV via stdlib ``wave`` + numpy; resampling is a numpy
+Kaiser-windowed-sinc that mirrors
+torchaudio ``sinc_interp_kaiser`` (lowpass_filter_width=64, rolloff=0.95) to ~1e-6.
+
+Ties every pure-MLX submodule (LLM trunk + eos head, AudioVAE encode/decode,
+CAM++ x-vector, flow-matching DiT + coordinate_proj, patch encoder, the
+hidden/latent/xvec projections) into the schedule-driven autoregressive decode that
+upstream ``DotsTtsModel`` implements across ``_prepare_prompt_conditioning`` ->
+``_prefill`` -> ``_decode`` -> vocode.
+
+Distilled control flow (authoritative upstream refs in model.py / core.py):
+
+  hidden_patch_size = 1, latent_patch_size = patch_size = 4, fm_hidden = 1024,
+  llm_hidden = 1536, latent_dim = 128, hop_size = 1920.
+
+  * prompt conditioning: load+resample prompt audio to 48 kHz mono, trim, pad to a
+    multiple of patch_size*hop (=7680); x-vector from a 16 kHz fbank ->
+    g_cond = xvec_proj(xvec * speaker_scale); prompt_latents =
+    sample_from_latent(vae.encode(48k))[:, :-patch_size]; prompt_patches =
+    normalize(prompt_latents).reshape(1, S, patch_size, 128).
+  * prefill: embed schedule[:prefill_end], scatter patch_encoder(prompt_patches)
+    into the prompt-span slots, one LLM forward; walk the prompt spans appending
+    hidden (hidden_proj) + history (latent_proj) chunks to fm_sequence/fm_cfg_sequence.
+  * decode: text runs -> LLM step + hidden chunk; audio spans -> EOS check (deferred
+    stop), build attn_mask/pos_ids, FlowSolver.denoise one patch, append history,
+    re-encode the new patch via patch_encoder over the FULL denormalized latent history
+    (recompute-full; causal-equivalent to upstream's streaming decode_patch) -> take the
+    last token -> LLM step, emit denorm patch.
+  * vocode: concat emitted patches, AudioVAE.decode -> 48 kHz waveform.
+
+The fm_sequence layout is ``[history... | latent_block(patch_size)]``: history is
+causal, the latent block attends to all history + itself (``_build_fm_attn_mask``);
+pos_ids run 0..fm_len-1 for history then fm_len..fm_len+patch_size-1 for the block
+(``_build_fm_pos_ids``).
+"""
+
+from __future__ import annotations
+
+import bisect
+import gc
+import math
+import os
+import wave
+from pathlib import Path
+from typing import Callable
+
+import mlx.core as mx
+import numpy as np
+
+# Memory-ceiling safety guard: set BEFORE any heavy allocation.
+_DOTS_MEMORY_LIMIT_GB = int(os.environ.get("MLX_AUDIO_DOTS_MEMORY_LIMIT_GB", "20"))
+if _DOTS_MEMORY_LIMIT_GB > 0:
+    mx.set_memory_limit(int(_DOTS_MEMORY_LIMIT_GB * (1 << 30)))
+
+from .dit import FlowSolver  # noqa: E402
+from .io_helper import IOHelper  # noqa: E402
+from .layers import Linear  # noqa: E402
+from .llm import DotsLLM  # noqa: E402
+from .loader import (  # noqa: E402
+    load_audiovae,
+    load_coordinate_proj,
+    load_dit,
+    load_semantic_encoder,
+    load_speaker,
+)
+from .speaker import kaldi_fbank  # noqa: E402
+from .text import DotsTokenizer  # noqa: E402
+
+_SPEAKER_FBANK_SAMPLE_RATE = 16000
+
+
+def _resolve_num_steps(num_steps: int | None, mode: str) -> int:
+    """Per-mode default for the solver step count.
+
+    ``None`` resolves to 4 in meanflow mode (the published distilled NFE) and 10 in
+    flow-matching mode (the existing default). An explicit value is always honored.
+    """
+    if num_steps is not None:
+        return int(num_steps)
+    return 4 if mode == "meanflow" else 10
+
+
+# ---------------------------------------------------------------------------
+# Audio I/O + resampling (pure numpy; no torch / torchaudio / librosa).
+# ---------------------------------------------------------------------------
+def _load_wav_mono(path: str | Path) -> tuple[np.ndarray, int]:
+    """Load a PCM WAV file to a mono float32 ndarray in [-1, 1] + its sample rate."""
+    with wave.open(str(path), "rb") as wf:
+        n_ch = wf.getnchannels()
+        sr = wf.getframerate()
+        sw = wf.getsampwidth()
+        n = wf.getnframes()
+        raw = wf.readframes(n)
+    if sw == 2:
+        data = np.frombuffer(raw, dtype="<i2").astype(np.float32) / 32768.0
+    elif sw == 4:
+        data = np.frombuffer(raw, dtype="<i4").astype(np.float32) / 2147483648.0
+    elif sw == 1:
+        data = (np.frombuffer(raw, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+    else:
+        raise ValueError(f"unsupported WAV sample width: {sw} bytes")
+    if n_ch > 1:
+        data = data.reshape(-1, n_ch).mean(axis=1)
+    return data.astype(np.float32), sr
+
+
+def _kaiser_sinc_kernel(
+    orig_freq: int,
+    new_freq: int,
+    *,
+    lowpass_filter_width: int = 64,
+    rolloff: float = 0.95,
+    beta: float = 14.769656459379492,
+) -> tuple[np.ndarray, int, int, int]:
+    """Replicate torchaudio ``_get_sinc_resample_kernel`` (sinc_interp_kaiser).
+
+    Returns ``(kernel[new_freq, K], width, orig_freq//gcd, new_freq//gcd)``.
+    """
+    g = math.gcd(int(orig_freq), int(new_freq))
+    of = int(orig_freq) // g
+    nf = int(new_freq) // g
+    base_freq = min(of, nf) * rolloff
+    width = math.ceil(lowpass_filter_width * of / base_freq)
+    idx = np.arange(-width, width + of, dtype=np.float64)[None, None] / of
+    t = np.arange(0, -nf, -1, dtype=np.float64)[:, None, None] / nf + idx
+    t *= base_freq
+    t = np.clip(t, -lowpass_filter_width, lowpass_filter_width)
+    inside = np.clip(1.0 - (t / lowpass_filter_width) ** 2, 0.0, None)
+    window = np.i0(beta * np.sqrt(inside)) / np.i0(beta)
+    t *= math.pi
+    scale = base_freq / of
+    with np.errstate(invalid="ignore", divide="ignore"):
+        sinc = np.where(t == 0, 1.0, np.sin(t) / t)
+    kernels = sinc * window * scale
+    return kernels[:, 0, :].astype(np.float32), width, of, nf
+
+
+def _resample(x: np.ndarray, orig_freq: int, new_freq: int, **kw) -> np.ndarray:
+    """High-quality Kaiser-sinc resample (mirrors torchaudio.functional.resample)."""
+    if orig_freq == new_freq:
+        return x.astype(np.float32)
+    kernel, width, of, nf = _kaiser_sinc_kernel(orig_freq, new_freq, **kw)
+    length = x.shape[-1]
+    xp = np.pad(x, (width, width + of))
+    k = kernel.shape[-1]
+    out_positions = (len(xp) - k) // of + 1
+    starts = np.arange(out_positions) * of
+    win = xp[starts[:, None] + np.arange(k)[None, :]]  # [out_positions, K]
+    res = (win @ kernel.T).reshape(-1)  # interleave the nf phases
+    target_length = math.ceil(nf * length / of)
+    return res[:target_length].astype(np.float32)
+
+
+def _trim_silence(x: np.ndarray, top_db: float = 30.0) -> np.ndarray:
+    """Trim leading/trailing silence below ``top_db`` dB of peak (librosa-style).
+
+    Frame-energy gate over 2048-sample frames (512 hop), matching librosa.effects.trim
+    defaults closely enough for prompt conditioning.
+    """
+    if x.size == 0:
+        return x
+    frame_length, hop = 2048, 512
+    n = x.size
+    n_frames = 1 + max(0, (n - frame_length) // hop)
+    if n_frames <= 0:
+        return x
+    ref = np.max(np.abs(x)) + 1e-9
+    threshold = ref * (10.0 ** (-top_db / 20.0))
+    nonsilent = []
+    for i in range(n_frames):
+        s = i * hop
+        frame = x[s : s + frame_length]
+        rms = np.sqrt(np.mean(frame**2) + 1e-12)
+        nonsilent.append(rms > threshold)
+    nonsilent = np.asarray(nonsilent)
+    if not nonsilent.any():
+        return x
+    first = int(np.argmax(nonsilent))
+    last = int(len(nonsilent) - 1 - np.argmax(nonsilent[::-1]))
+    start = first * hop
+    end = min(n, (last + 1) * hop + frame_length)
+    return x[start:end]
+
+
+def _load_prompt_audio48k(
+    prompt_audio: str | Path | mx.array | np.ndarray, sample_rate: int
+) -> np.ndarray:
+    """Load + trim a prompt clip to mono 48 kHz for prompt conditioning.
+
+    Path inputs follow the runtime's native WAV path (load, trim, resample). Predecoded
+    arrays are assumed to already be mono at ``sample_rate`` and are only trimmed.
+    """
+    if isinstance(prompt_audio, (str, Path)):
+        raw, sr = _load_wav_mono(prompt_audio)
+        raw = _trim_silence(raw, top_db=30.0)
+        return _resample(raw, sr, sample_rate)
+
+    raw = np.asarray(prompt_audio, dtype=np.float32)
+    raw = np.squeeze(raw)
+    if raw.ndim == 0:
+        raise ValueError("prompt_audio array must contain at least one sample")
+    if raw.ndim > 1:
+        raw = raw.mean(axis=0)
+    return _trim_silence(raw.astype(np.float32), top_db=30.0)
+
+
+def _clean_onset(wav: np.ndarray, sr: int) -> np.ndarray:
+    """Trim the fixed BigVGAN vocoder onset transient off the start of a dots.tts clip.
+
+    dots.tts (via its BigVGAN vocoder) emits a deterministic ~50-150 ms low-level burst (a soft
+    "hhh"/breath, byte-identical across clips) at sample 0, followed by a short silence gap before
+    the real speech. It's a fixed ~-26 dBFS transient — on quiet dubs (peaks ~-20 dBFS) it's audible.
+
+    Mirrors ``clean_tts_audio._speech_bounds`` (smoothed-RMS gate + sustained-run requirement) to find
+    the *real* speech onset, then keeps ``[onset - lead_pad, end]``. Differences vs the MisoTTS cleaner:
+    a tighter ``rel_db`` (12, not 16) and lighter smoothing (40 ms, not 150) so the threshold sits
+    cleanly *between* the low transient and the louder speech body — the wide 16 dB / 150 ms gate would
+    flag the transient itself as "speech" (it's within 16 dB of the body) and trim nothing. The lead-pad
+    is kept small (30 ms) so a soft real onset consonant is never clipped; the transient + dead-air gap
+    that precede the speech are both removed. A 10 ms fade-in suppresses the cut click.
+
+    Pure numpy (no torch/MLX). Returns the trimmed-and-faded mono float32 array.
+    """
+    rel_db, hop_ms, smooth_ms, run_ms = 12.0, 10.0, 40.0, 60.0
+    lead_pad_ms, fade_ms = 30.0, 10.0
+    x = wav.astype(np.float32)
+    if x.ndim > 1:
+        x = x.mean(1)
+    hop = max(1, int(sr * hop_ms / 1000))
+    n = max(1, (len(x) - hop) // hop)
+    rms = np.array(
+        [np.sqrt((x[i * hop : i * hop + hop] ** 2).mean() + 1e-12) for i in range(n)]
+    )
+    db = 20 * np.log10(rms + 1e-9)
+    k = max(1, int(smooth_ms / hop_ms))
+    sm = np.convolve(
+        db, np.ones(k) / k, mode="same"
+    )  # light smooth — keep transient/speech distinct
+    above = sm > (sm.max() - rel_db)
+    run = max(1, int(run_ms / hop_ms))  # require a sustained run (not the burst's edge)
+    ok = np.convolve(above.astype(int), np.ones(run, dtype=int), mode="valid") == run
+    starts = np.where(ok)[0]
+    if len(starts) == 0:  # nothing looked like speech -> leave untouched
+        return x
+    s0 = int(starts[0] * hop)
+    i0 = max(
+        0, s0 - int(lead_pad_ms / 1000 * sr)
+    )  # small lead-pad: never clip the first phoneme
+    y = x[i0:].copy()
+    nf = min(int(sr * fade_ms / 1000), len(y) // 2)  # anti-click fade-in at the cut
+    if nf > 0:
+        y[:nf] *= np.linspace(0.0, 1.0, nf, dtype=y.dtype)
+    return y
+
+
+# ---------------------------------------------------------------------------
+# xvec_proj = Linear(512 -> 1024) -> affine LayerNorm(1024).
+# ---------------------------------------------------------------------------
+class _AffineLayerNorm:
+    """``nn.LayerNorm(dim, elementwise_affine=True, eps=1e-5)`` (weight + bias)."""
+
+    def __init__(self, weight: mx.array, bias: mx.array, eps: float = 1e-5):
+        self.weight = weight
+        self.bias = bias
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        in_dtype = x.dtype
+        xf = x.astype(mx.float32)
+        mean = mx.mean(xf, axis=-1, keepdims=True)
+        var = mx.mean((xf - mean) ** 2, axis=-1, keepdims=True)
+        out = (xf - mean) * mx.rsqrt(var + self.eps)
+        out = out * self.weight.astype(mx.float32) + self.bias.astype(mx.float32)
+        return out.astype(in_dtype)
+
+
+class _XvecProj:
+    """``Sequential(Linear(512, 1024), LayerNorm(1024))`` (the ``xvec_proj.*``)."""
+
+    def __init__(self, linear: Linear, norm: _AffineLayerNorm):
+        self.linear = linear
+        self.norm = norm
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.norm(self.linear(x))
+
+
+class DotsTtsModel:
+    """Full pure-MLX dots.tts TTS model: ``generate(text, prompt_audio, ...) -> wav``.
+
+    Construct via ``DotsTtsModel.from_pretrained(path, dtype)``. Holds every wired
+    submodule + the schedule helpers; runs the schedule-driven AR decode end to end.
+    """
+
+    def __init__(
+        self,
+        *,
+        tokenizer: DotsTokenizer,
+        llm: DotsLLM,
+        vae,
+        speaker,
+        flow_solver: FlowSolver,
+        patch_encoder,
+        io_helper: IOHelper,
+        hidden_proj: Linear,
+        latent_proj: Linear,
+        xvec_proj: _XvecProj,
+        patch_size: int = 4,
+        hop_size: int = 1920,
+        latent_dim: int = 128,
+        dtype: mx.Dtype = mx.float32,
+        mode: str = "flow_matching",
+    ):
+        self.tokenizer = tokenizer
+        self.llm = llm
+        self.vae = vae
+        self.speaker = speaker
+        self.flow_solver = flow_solver
+        self.patch_encoder = patch_encoder
+        self.io = io_helper
+        self.hidden_proj = hidden_proj
+        self.latent_proj = latent_proj
+        self.xvec_proj = xvec_proj
+        self.patch_size = patch_size  # latent_patch_size
+        self.hidden_patch_size = 1
+        self.hop_size = hop_size
+        self.fm_hidden = 1024
+        self.latent_dim = latent_dim
+        self.dtype = dtype
+        self.mode = mode
+        self.sample_rate = 48000
+        self._model_dir: Path | None = None
+        self._compat_hash: str | None = None
+
+    # region construction
+    @classmethod
+    def from_pretrained(
+        cls, path: str | Path, dtype: mx.Dtype = mx.float32
+    ) -> "DotsTtsModel":
+        """Load + wire every submodule from a converted ``weights/dots_tts_mlx`` dir."""
+        from .loader import ModelConfig
+
+        path = Path(path)
+        config = ModelConfig.from_checkpoint(path)
+
+        core = str(path / "core.safetensors")
+        vocoder = str(path / "vocoder.safetensors")
+        speaker_st = str(path / "speaker.safetensors")
+        llm_config_json = str(path / "llm_config.json")
+        latent_stats = str(path / "latent_stats.npz")
+
+        tokenizer = DotsTokenizer.from_pretrained(path / "tokenizer")
+        llm = DotsLLM.from_core(
+            core, llm_config_json, dtype=dtype, quantization=config.quantization
+        )
+        vae = load_audiovae(vocoder, dtype=dtype, with_encoder=True)
+        speaker = load_speaker(speaker_st, dtype=dtype)
+        dit = load_dit(core, dtype=dtype)
+        coord = load_coordinate_proj(core, dtype=dtype)
+        flow_solver = FlowSolver(dit, coord, latent_dim=config.latent_dim)
+        patch_encoder = load_semantic_encoder(core, dtype=dtype)
+        io_helper = IOHelper(latent_stats)
+
+        raw = mx.load(core)
+        hidden_proj = Linear(
+            raw["hidden_proj.weight"].astype(dtype),
+            raw["hidden_proj.bias"].astype(dtype),
+        )
+        latent_proj = Linear(
+            raw["latent_proj.weight"].astype(dtype),
+            raw["latent_proj.bias"].astype(dtype),
+        )
+        xvec_proj = _XvecProj(
+            Linear(
+                raw["xvec_proj.0.weight"].astype(dtype),
+                raw["xvec_proj.0.bias"].astype(dtype),
+            ),
+            _AffineLayerNorm(
+                raw["xvec_proj.1.weight"].astype(dtype),
+                raw["xvec_proj.1.bias"].astype(dtype),
+            ),
+        )
+
+        # hop_size = total vocoder upsample factor (= 1920 for this checkpoint); the
+        # pad-multiple is patch_size * hop_size (= 7680). latent_dim from config.
+        hop_size = math.prod(config.vocoder.upsample_rates)
+
+        model = cls(
+            tokenizer=tokenizer,
+            llm=llm,
+            vae=vae,
+            speaker=speaker,
+            flow_solver=flow_solver,
+            patch_encoder=patch_encoder,
+            io_helper=io_helper,
+            hidden_proj=hidden_proj,
+            latent_proj=latent_proj,
+            xvec_proj=xvec_proj,
+            patch_size=config.patch_size,
+            hop_size=hop_size,
+            latent_dim=config.latent_dim,
+            dtype=dtype,
+            mode=config.mode,
+        )
+        from .profile import model_compat_hash
+
+        model._model_dir = path
+        model._compat_hash = model_compat_hash(path)
+        return model
+
+    # endregion construction
+
+    # region prompt conditioning
+    def _xvector_from_audio48k(self, audio48k: np.ndarray) -> mx.array:
+        """CAM++ x-vector from a 48 kHz mono waveform: resample to 16 kHz -> fbank."""
+        audio16k = _resample(audio48k, 48000, _SPEAKER_FBANK_SAMPLE_RATE)
+        # Crop to max_audio_seconds (10s) — start=0 deterministically (upstream).
+        max_len = _SPEAKER_FBANK_SAMPLE_RATE * 10
+        if audio16k.shape[-1] > max_len:
+            audio16k = audio16k[:max_len]
+        fbank = kaldi_fbank(audio16k, sample_rate=_SPEAKER_FBANK_SAMPLE_RATE)  # [T, 80]
+        fbank_mx = mx.array(np.asarray(fbank), dtype=mx.float32)[None]  # [1, T, 80]
+        xvec = self.speaker(fbank_mx)  # [1, 512]
+        return xvec
+
+    def _prepare_prompt_conditioning(
+        self,
+        prompt_audio48k: np.ndarray | None,
+        *,
+        speaker_scale: float,
+    ) -> tuple[mx.array | None, mx.array | None, mx.array | None]:
+        """Return ``(g_cond [1, 1024], prompt_patches [1, S, patch_size, 128] | None,
+        prompt_denorm_latents [1, S*patch_size, 128] | None)``.
+
+        For a reference clone (``prompt_audio48k`` given) this always builds the full
+        **in-context** prompt: the speaker ``g_cond`` plus the prefill latents.
+        ``prompt_patches`` is the NORMALIZED, reshaped prompt latent (FM history +
+        prefill scatter); ``prompt_denorm_latents`` is the matching DENORMALIZED stream
+        that seeds the patch-encoder recompute-full history (upstream feeds the
+        denormalized ``prompt_latents_sampled`` into ``patch_encoder.prefill``). With no
+        reference audio (plain text-to-speech) it returns ``(None, None, None)``.
+        """
+        if prompt_audio48k is None:
+            return None, None, None
+
+        # Pad to a multiple of patch_size * hop_size (= 7680).
+        chunk = self.patch_size * self.hop_size
+        n = prompt_audio48k.shape[-1]
+        target = math.ceil(n / chunk) * chunk
+        if target > n:
+            prompt_audio48k = np.pad(prompt_audio48k, (0, target - n))
+
+        xvec = self._xvector_from_audio48k(prompt_audio48k)  # [1, 512] fp32
+        speaker_embedding = xvec * float(speaker_scale)
+        g_cond = self.xvec_proj(speaker_embedding.astype(self.dtype))  # [1, 1024]
+        g_cond = g_cond.astype(self.dtype)
+
+        wav = mx.array(prompt_audio48k, dtype=mx.float32)[None, None]  # [1, 1, S]
+        latent = self.vae.encode(wav)  # [1, 256, T]
+        sampled = self.io.sample_from_latent(latent)  # [1, T, 128] (denormalized)
+        sampled = sampled[:, : -self.patch_size]  # drop the trailing patch
+        normalized = self.io.normalize(sampled)  # [1, S*patch_size, 128]
+        s = normalized.shape[1] // self.patch_size
+        keep = s * self.patch_size
+        prompt_patches = normalized[:, :keep].reshape(
+            1, s, self.patch_size, self.latent_dim
+        )
+        # Denormalized stream (same time span as prompt_patches) for the recompute-full
+        # patch-encoder history; upstream patch_encoder operates on denormalized latents.
+        prompt_denorm_latents = sampled[:, :keep]  # [1, S*patch_size, 128]
+        return (
+            g_cond,
+            prompt_patches.astype(self.dtype),
+            prompt_denorm_latents.astype(self.dtype),
+        )
+
+    # endregion prompt conditioning
+
+    # region fm-sequence builders
+    def _build_fm_attn_mask(self, fm_seq_len: int) -> mx.array:
+        """``[1, L, L]`` bool mask; history causal, latent block attends to all + self.
+
+        L = fm_seq_len + patch_size. Mirrors upstream ``_build_fm_attn_mask`` for the
+        simple (non-bucketed) case where ``latent_start == fm_seq_len``.
+        """
+        p = self.patch_size
+        h = self.hidden_patch_size
+        latent_start = fm_seq_len  # total_len - patch_size == fm_seq_len here
+        total = fm_seq_len + p
+        mask = np.zeros((total, total), dtype=bool)
+        block_start = fm_seq_len - h
+        if block_start > 0:
+            causal = ~np.triu(np.ones((block_start, block_start), dtype=bool), k=1)
+            mask[:block_start, :block_start] = causal
+        # The last hidden token (block_start..fm_seq_len) attends to all history + block.
+        mask[block_start:fm_seq_len, :fm_seq_len] = True
+        mask[block_start:fm_seq_len, latent_start:] = True
+        # The latent block attends to all history + itself.
+        mask[latent_start:, :fm_seq_len] = True
+        mask[latent_start:, latent_start:] = True
+        return mx.array(mask)[None]  # [1, L, L]
+
+    def _build_fm_pos_ids(self, fm_seq_len: int) -> mx.array:
+        """``[1, L]`` positions: 0..fm_len-1 (history), fm_len..fm_len+p-1 (block)."""
+        p = self.patch_size
+        total = fm_seq_len + p
+        pos = np.zeros((total,), dtype=np.float32)
+        pos[:fm_seq_len] = np.arange(fm_seq_len, dtype=np.float32)
+        pos[fm_seq_len:] = np.arange(fm_seq_len, fm_seq_len + p, dtype=np.float32)
+        return mx.array(pos)[None]  # [1, L]
+
+    # endregion fm-sequence builders
+
+    # region generate
+    def generate(
+        self,
+        text: str,
+        *,
+        prompt_audio: str | Path | mx.array | np.ndarray | None = None,
+        prompt_text: str | None = None,
+        profile: "SpeakerProfile | None" = None,  # noqa: F821
+        num_steps: int | None = None,
+        guidance_scale: float = 1.2,
+        speaker_scale: float = 1.5,
+        language: str | None = None,
+        seed: int = 42,
+        max_generate_length: int = 500,
+        eos_threshold: float = 0.8,
+        trim_onset: bool = True,
+        streaming_decode: bool = True,
+    ) -> dict:
+        """Synthesize ``text`` (optionally cloning ``prompt_audio``) -> 48 kHz wav.
+
+        Returns ``{"audio": mx.array [1, T], "sample_rate": 48000,
+        "num_patches": int}``.
+
+        ``trim_onset`` (default on) removes the fixed ~50-150 ms BigVGAN vocoder onset
+        transient (a soft "hhh"/breath at sample 0) via an energy gate + 10 ms fade. It
+        is applied here — not bolted onto the CLI — so EVERY caller (Python API, the
+        persistent service, the CLI) gets clean audio by default. Pass ``trim_onset=False``
+        for the raw vocoder output.
+
+        ``streaming_decode`` (default on) re-encodes each generated patch incrementally
+        through a maintained conv_tail + per-layer KV caches (O(n) over the clip).
+        ``streaming_decode=False`` selects the legacy recompute-full path (re-encodes the
+        full history every patch, O(n^3)) — kept as a fallback and the on-device parity
+        oracle. Both paths are numerically identical (the encoder is fully causal, no
+        rotary/qk-norm).
+        """
+        mx.random.seed(int(seed))
+        np.random.seed(int(seed))
+        num_steps = _resolve_num_steps(num_steps, self.mode)
+
+        # --- prompt conditioning: from a saved profile, or computed from prompt_audio. ---
+        patch_emb_override = None
+        if profile is not None:
+            if prompt_audio is not None or prompt_text is not None:
+                raise ValueError(
+                    "generate(profile=…) is mutually exclusive with prompt_audio/prompt_text."
+                )
+            if self._compat_hash is not None:
+                profile.check_compat(self._compat_hash)
+            # integrity: the cached arrays must line up with prompt_patch_count.
+            if (
+                int(profile.prompt_patches.shape[1]) != profile.prompt_patch_count
+                or int(profile.patch_emb.shape[1]) != profile.prompt_patch_count
+                or int(profile.prompt_denorm_latents.shape[1])
+                != profile.prompt_patch_count * self.patch_size
+            ):
+                raise ValueError(
+                    "corrupt speaker profile: prompt_patch_count mismatch."
+                )
+            g_cond = profile.g_cond.astype(self.dtype)
+            prompt_patches = profile.prompt_patches.astype(self.dtype)
+            prompt_denorm_latents = profile.prompt_denorm_latents.astype(self.dtype)
+            patch_emb_override = profile.patch_emb.astype(self.dtype)
+            prompt_text = profile.prompt_text  # rebuild the identical schedule
+            use_prompt_prefill = True
+            # speaker_scale is already baked into profile.g_cond; the arg is ignored here.
+            # RNG sync: the ref-audio path consumes exactly one mx.random.normal draw in
+            # io.sample_from_latent (the VAE-latent sampling) before the decode loop. The
+            # profile path skips that encode, so replicate the single RNG advance here —
+            # MLX's global RNG advances per-call (shape-independent), so the decode-loop
+            # noise then matches one-shot generate exactly (byte-parity). Do NOT remove:
+            # the round-trip parity gate (test_profile_generate_matches_one_shot) depends on it.
+            mx.random.normal((1,))
+        else:
+            prompt_audio48k = None
+            if prompt_audio is not None:
+                prompt_audio48k = _load_prompt_audio48k(prompt_audio, self.sample_rate)
+            if prompt_audio48k is not None and not prompt_text:
+                raise ValueError(
+                    "Reference cloning requires the reference transcript "
+                    "(prompt_text / --ref-text). The x-vector-only (no-transcript) clone "
+                    "mode has been removed — it drifted on longer utterances. Pass the "
+                    "transcript, or omit the reference audio for plain text-to-speech."
+                )
+            # cloning => always in-context prefill; no reference => plain TTS.
+            use_prompt_prefill = prompt_audio48k is not None
+            g_cond, prompt_patches, prompt_denorm_latents = (
+                self._prepare_prompt_conditioning(
+                    prompt_audio48k,
+                    speaker_scale=speaker_scale,
+                )
+            )
+        prompt_patch_count = (
+            0 if prompt_patches is None else int(prompt_patches.shape[1])
+        )
+
+        # --- build the generation schedule. ---
+        schedule_ids = self.tokenizer.build_generation_schedule(
+            text,
+            prompt_text=prompt_text,
+            language=language,
+            max_audio_tokens=max_generate_length,
+        )
+        schedule = mx.array(schedule_ids, dtype=mx.int32)[None]  # [1, N]
+        span_id = self.tokenizer.audio_gen_span_id
+        comp_id = self.tokenizer.audio_comp_span_id
+        audio_ids = {span_id, comp_id}
+        span_positions = [i for i, t in enumerate(schedule_ids) if t in audio_ids]
+        if len(span_positions) < prompt_patch_count + 1:
+            raise ValueError(
+                f"schedule has {len(span_positions)} spans, need "
+                f"{prompt_patch_count + 1} (prompt + >=1 decode)."
+            )
+
+        # --- FM sequence buffers (grown incrementally as lists of [1, n, 1024]). ---
+        self._fm_chunks: list[mx.array] = []
+        self._fm_cfg_chunks: list[mx.array] = []
+        self._fm_seq_len = 0
+        # All DENORMALIZED latent patches seen so far (each [1, patch_size, 128]); the
+        # patch re-encode runs the patch_encoder over this full history every step so
+        # the causal context (prior patches + ds_proj left-context) is preserved. Seed
+        # with the prompt's denormalized latents (upstream feeds these into
+        # patch_encoder.prefill) so the FIRST generated patch already has left-context.
+        self._denorm_patch_history: list[mx.array] = []
+        if prompt_denorm_latents is not None and prompt_patch_count > 0:
+            for i in range(prompt_patch_count):
+                start = i * self.patch_size
+                self._denorm_patch_history.append(
+                    prompt_denorm_latents[:, start : start + self.patch_size]
+                )
+
+        cache = self.llm.make_cache()
+
+        # Streaming patch-decode state (default path). Prefill it from the SAME
+        # denormalized prompt stream that seeds the recompute-full history above, so the
+        # KV caches reflect recompute-full's prompt view. No RNG is drawn here (prefill is
+        # deterministic) -> streaming vs recompute-full stay in RNG lock-step.
+        self._streaming_decode = bool(streaming_decode)
+        self._patch_encoder_state = None
+        if self._streaming_decode:
+            self._patch_encoder_state = self.patch_encoder.init_decode_state(
+                dtype=self.dtype
+            )
+            if prompt_denorm_latents is not None and prompt_patch_count > 0:
+                self.patch_encoder.prefill(
+                    prompt_denorm_latents[:, : prompt_patch_count * self.patch_size],
+                    self._patch_encoder_state,
+                )
+
+        llm_hiddens: mx.array | None = None
+
+        # --- prefill. ---
+        position = self._prefill(
+            schedule_ids,
+            schedule,
+            span_positions=span_positions,
+            prompt_patches=prompt_patches,
+            prompt_denorm_latents=prompt_denorm_latents,
+            cache=cache,
+            patch_emb=patch_emb_override,
+        )
+        llm_hiddens = self._last_prefill_hidden
+
+        # --- decode loop. ---
+        g_cond_run = None if g_cond is None else g_cond.astype(self.dtype)
+        null_g_cond = mx.zeros((1, self.fm_hidden), dtype=self.dtype)
+
+        emitted: list[mx.array] = []
+        should_drop_regenerated = use_prompt_prefill  # drop the first regenerated patch
+        n_sched = len(schedule_ids)
+        # span_cursor: index into span_positions for the NEXT audio span.
+        span_cursor = bisect.bisect_left(span_positions, position)
+        end_flag = False
+
+        while position < n_sched and not end_flag:
+            token_id = schedule_ids[position]
+            if token_id in audio_ids:
+                stop_after = self._should_stop_after_current_audio(
+                    llm_hiddens, eos_threshold=eos_threshold
+                )
+                # build FM inputs + denoise one patch
+                fm_seq = mx.concatenate(self._fm_chunks, axis=1)
+                fm_cfg = mx.concatenate(self._fm_cfg_chunks, axis=1)
+                fm_seq_len = self._fm_seq_len
+                attn_mask = self._build_fm_attn_mask(fm_seq_len)
+                pos_ids = self._build_fm_pos_ids(fm_seq_len)
+                # pad both sequences with a zero latent block (placeholder slots).
+                pad = mx.zeros((1, self.patch_size, self.fm_hidden), dtype=self.dtype)
+                input_seq = mx.concatenate([fm_seq, pad], axis=1)
+                cfg_seq = mx.concatenate([fm_cfg, pad], axis=1)
+                noise = mx.random.normal((1, self.patch_size, self.latent_dim)).astype(
+                    self.dtype
+                )
+                if self.mode == "meanflow":
+                    patch = self.flow_solver.meanflow_sample(
+                        input_sequence=input_seq,
+                        attn_mask=attn_mask,
+                        pos_ids=pos_ids,
+                        g_cond=g_cond_run if g_cond_run is not None else null_g_cond,
+                        num_steps=num_steps,
+                        patch_size=self.patch_size,
+                        noise=noise,
+                    )  # normalized latent [1, patch_size, 128]
+                else:
+                    patch = self.flow_solver.denoise(
+                        input_sequence=input_seq,
+                        cfg_sequence=cfg_seq,
+                        attn_mask=attn_mask,
+                        pos_ids=pos_ids,
+                        g_cond=g_cond_run if g_cond_run is not None else null_g_cond,
+                        guidance_scale=guidance_scale,
+                        num_steps=num_steps,
+                        patch_size=self.patch_size,
+                        noise=noise,
+                    )  # normalized latent [1, patch_size, 128]
+                mx.eval(patch)
+
+                # consume the patch: append history + re-encode for the LLM.
+                self._append_history_chunk(patch)
+                denorm = self.io.denormalize(patch)  # [1, patch_size, 128]
+                llm_hiddens, cache = self._reencode_and_step(cache, denorm)
+
+                # if the next token is also an audio span, append a hidden chunk.
+                if position + 1 < n_sched and schedule_ids[position + 1] in audio_ids:
+                    self._append_hidden_chunk(llm_hiddens)
+
+                position += 1
+                span_cursor += 1
+
+                if should_drop_regenerated:
+                    should_drop_regenerated = False  # discard the prompt-tail patch
+                else:
+                    emitted.append(denorm)
+
+                if stop_after:
+                    end_flag = True
+                continue
+
+            # TEXT run: consume schedule[position:next_audio_position] in one LLM step.
+            next_audio_position = (
+                span_positions[span_cursor]
+                if span_cursor < len(span_positions)
+                else n_sched
+            )
+            text_chunk = schedule[:, position:next_audio_position]
+            llm_hiddens, cache = self.llm.step(input_ids=text_chunk, cache=cache)
+            self._append_hidden_chunk(llm_hiddens)
+            position = next_audio_position
+
+        if not emitted:
+            raise RuntimeError(
+                "Generation produced no payload latents (EOS fired immediately or "
+                "the schedule provided no effective decode span)."
+            )
+
+        # --- vocode. ---
+        latents = mx.concatenate(emitted, axis=1)  # [1, T_patches*patch_size, 128]
+        wav = self.vae.decode(latents.transpose(0, 2, 1))  # [1, 1, T*1920]
+        wav = wav[:, 0, :]  # [1, T*1920]
+        mx.eval(wav)
+        if trim_onset:
+            cleaned = _clean_onset(
+                np.asarray(wav[0].astype(mx.float32)), self.sample_rate
+            )
+            wav = mx.array(cleaned)[None]  # [1, T']
+        return {
+            "audio": wav,
+            "sample_rate": self.sample_rate,
+            "num_patches": len(emitted),
+        }
+
+    def generate_long(
+        self,
+        text: str,
+        *,
+        prompt_audio: str | Path | mx.array | np.ndarray | None = None,
+        prompt_text: str | None = None,
+        profile: "SpeakerProfile | None" = None,  # noqa: F821
+        num_steps: int | None = None,
+        guidance_scale: float = 1.2,
+        speaker_scale: float = 1.5,
+        language: str | None = None,
+        seed: int = 42,
+        max_generate_length: int = 500,
+        eos_threshold: float = 0.8,
+        trim_onset: bool = True,
+        streaming_decode: bool = True,
+        gap_ms: int = 80,
+        max_chars: int | None = None,
+        retry_degenerate: bool = True,
+        max_retries: int = 2,
+        validator: "Callable[[np.ndarray, str, int], bool] | None" = None,  # noqa: F821
+    ) -> dict:
+        """Render long/multilingual text by sentence-chunking.
+
+        Splits ``text`` into TTS-sized chunks (sentence-first, word-safe length-cap
+        fallback), generates each chunk INDEPENDENTLY via ``generate()`` (short context ->
+        EOS fires correctly per sentence -> no truncation/drift; no O(n^2) growth), drains
+        Metal between chunks, and concatenates with ``gap_ms`` silence between sentences.
+        Numerically just N independent ``generate()`` calls -- no model/parity change.
+
+        Conditioning/sampling args mirror ``generate``; ``profile`` is mutually exclusive
+        with ``prompt_audio``/``prompt_text`` (enforced inside ``generate``). ``streaming_decode``
+        (default on) is forwarded to each per-chunk ``generate`` call. Returns
+        ``{"audio": [1, T], "sample_rate", "num_chunks", "num_patches"}``. (Speed is a CLI
+        post-process, matching ``generate``.)
+
+        ``num_steps=None`` (default) resolves per-mode in ``generate`` (4 meanflow / 10
+        flow-matching).
+        """
+        from .chunking import (
+            assemble_chunks,
+            chunk_health,
+            resolve_max_chars,
+            split_for_generation,
+        )
+
+        cap = (
+            int(max_chars) if max_chars else resolve_max_chars(text, language=language)
+        )
+        chunks = split_for_generation(text, max_chars=cap, language=language)
+        if not chunks:
+            raise ValueError("generate_long: text is empty after splitting.")
+
+        max_retries = max(0, int(max_retries))
+        pieces: list[np.ndarray] = []
+        total_patches = 0
+        total_retries = 0
+        unrecovered = 0
+
+        def _gen_once(chunk: str, chunk_seed: int):
+            out = self.generate(
+                chunk,
+                prompt_audio=prompt_audio,
+                prompt_text=prompt_text,
+                profile=profile,
+                num_steps=num_steps,
+                guidance_scale=guidance_scale,
+                speaker_scale=speaker_scale,
+                language=language,
+                seed=chunk_seed,
+                max_generate_length=max_generate_length,
+                eos_threshold=eos_threshold,
+                trim_onset=trim_onset,
+                streaming_decode=streaming_decode,
+            )
+            return np.asarray(out["audio"][0].astype(mx.float32)), int(
+                out["num_patches"]
+            )
+
+        def _accept(audio_np: np.ndarray, chunk: str) -> bool:
+            if not chunk_health(audio_np, chunk, self.sample_rate, language=language):
+                return False
+            if validator is not None:
+                try:
+                    return bool(validator(audio_np, chunk, self.sample_rate))
+                except (
+                    Exception
+                ):  # noqa: BLE001 -- a flaky validator must not crash the render
+                    return False
+            return True
+
+        for i, chunk in enumerate(chunks):
+            best_audio, best_patches = _gen_once(
+                chunk, seed
+            )  # attempt 0 = current seed
+            accepted = _accept(best_audio, chunk)
+            attempt = 0
+            while not accepted and retry_degenerate and attempt < max_retries:
+                attempt += 1
+                total_retries += 1
+                mx.synchronize()
+                mx.clear_cache()
+                gc.collect()
+                chunk_seed = int(seed) + 1_000_003 * (i + 1) + 101 * attempt
+                cand_audio, cand_patches = _gen_once(chunk, chunk_seed)
+                if _accept(cand_audio, chunk):
+                    best_audio, best_patches, accepted = cand_audio, cand_patches, True
+                elif cand_audio.size > best_audio.size:
+                    best_audio, best_patches = cand_audio, cand_patches
+            if not accepted:
+                unrecovered += 1
+            pieces.append(best_audio)
+            total_patches += best_patches
+            mx.synchronize()
+            mx.clear_cache()
+            gc.collect()
+
+        full = assemble_chunks(pieces, self.sample_rate, gap_ms)
+        return {
+            "audio": mx.array(full)[None],
+            "sample_rate": self.sample_rate,
+            "num_chunks": len(chunks),
+            "num_patches": total_patches,
+            "retries": total_retries,
+            "unrecovered": unrecovered,
+        }
+
+    # endregion generate
+
+    # region decode helpers
+    def _append_hidden_chunk(self, hidden_chunk: mx.array) -> None:
+        """Project the last hidden token -> fm_sequence; zeros -> fm_cfg_sequence."""
+        last_hidden = hidden_chunk[:, -self.hidden_patch_size :, :]  # [1, 1, 1536]
+        projected = self.hidden_proj(last_hidden).astype(self.dtype)  # [1, 1, 1024]
+        null_projected = self.hidden_proj(mx.zeros_like(last_hidden)).astype(self.dtype)
+        self._fm_chunks.append(projected)
+        self._fm_cfg_chunks.append(null_projected)
+        self._fm_seq_len += projected.shape[1]
+
+    def _append_history_chunk(self, latent_chunk: mx.array) -> None:
+        """Project a latent patch [1, patch_size, 128] -> BOTH fm sequences."""
+        history_latent = self.latent_proj(latent_chunk).astype(
+            self.dtype
+        )  # [1, p, 1024]
+        self._fm_chunks.append(history_latent)
+        self._fm_cfg_chunks.append(history_latent)
+        self._fm_seq_len += history_latent.shape[1]
+
+    def _reencode_and_step(self, cache, denorm_patch: mx.array):
+        """Re-encode the new denormalized patch (with full causal context) -> one LLM step.
+
+        RECOMPUTE-FULL: upstream ``_consume_audio_patch`` -> ``patch_encoder.decode_patch``
+        re-encodes the new patch against a PERSISTENT per-layer KV cache (all prior
+        patches) + a ``conv_tail`` (so the causal stride-2 ``ds_proj`` conv sees the
+        previous patch's last frame, not a zero left-pad). Rather than port that
+        incremental KV-cache/conv_tail streaming, we run ``patch_encoder`` over the FULL
+        denormalized history every step: the encoder is fully causal (causal ds_proj
+        conv with left-padding + causal transformer mask), so a recompute over
+        ``[1, 4n, 128]`` is NUMERICALLY IDENTICAL to the streaming decode_patch — token n
+        only ever attends to tokens 0..n and the conv's left-context is the natural
+        prefix of the full sequence. The patch_encoder maps each 4-frame patch -> 1 LLM
+        token (out_ds_rate=2 downsampled tokens grouped back by _project_embeddings), so
+        n patches -> [1, n, 1536]; we take the LAST token as the new patch's embedding.
+        O(n^2) over patches — fine for short clips; the faithful alternative to
+        upstream's incremental decode_patch.
+        """
+        if getattr(self, "_streaming_decode", False):
+            emb = self.patch_encoder.decode_patch(
+                denorm_patch, self._patch_encoder_state
+            ).astype(self.dtype)
+            return self.llm.step(inputs_embeds=emb, cache=cache)
+        # --- recompute-full fallback / parity oracle (kept verbatim, O(n^3)) ---
+        self._denorm_patch_history.append(denorm_patch)
+        history = mx.concatenate(self._denorm_patch_history, axis=1)  # [1, 4n, 128]
+        emb_full = self.patch_encoder(history)  # [1, n, 1536]
+        emb = emb_full[:, -1:, :].astype(self.dtype)  # newest patch -> [1, 1, 1536]
+        return self.llm.step(inputs_embeds=emb, cache=cache)
+
+    def _should_stop_after_current_audio(
+        self, llm_hiddens: mx.array | None, *, eos_threshold: float
+    ) -> bool:
+        if llm_hiddens is None:
+            return False
+        logits = self.llm.eos_logits(llm_hiddens)  # [1, L, 2]
+        probs = mx.softmax(logits.astype(mx.float32), axis=-1)
+        eos_p = float(probs[0, -1, 1])
+        return eos_p > eos_threshold
+
+    def enroll(
+        self,
+        prompt_audio: str | Path,
+        prompt_text: str,
+        *,
+        speaker_scale: float = 1.5,
+    ) -> "SpeakerProfile":  # noqa: F821
+        """Compute + return a reusable SpeakerProfile for ``prompt_audio``.
+
+        Caches the target-independent reference artifacts (g_cond, the AudioVAE-encoded
+        prompt latents, and the patch-encoder embeddings). ``prompt_text`` is REQUIRED —
+        it is stored so a later ``generate(profile=…)`` rebuilds the identical schedule.
+        """
+        from .profile import SpeakerProfile
+
+        if not prompt_text:
+            raise ValueError(
+                "enroll() requires a non-empty prompt_text (the reference transcript)."
+            )
+        if self._compat_hash is None:
+            raise ValueError(
+                "enroll() requires a model built via from_pretrained (no compat hash)."
+            )
+
+        prompt_audio48k = _load_prompt_audio48k(prompt_audio, self.sample_rate)
+        g_cond, prompt_patches, prompt_denorm_latents = (
+            self._prepare_prompt_conditioning(
+                prompt_audio48k, speaker_scale=speaker_scale
+            )
+        )
+        s = int(prompt_patches.shape[1])
+        flat = prompt_denorm_latents[:, : s * self.patch_size]  # denormalized
+        patch_emb = self.patch_encoder(flat).astype(self.dtype)
+        mx.eval(g_cond, prompt_patches, prompt_denorm_latents, patch_emb)
+
+        return SpeakerProfile(
+            g_cond=g_cond,
+            prompt_patches=prompt_patches,
+            prompt_denorm_latents=prompt_denorm_latents,
+            patch_emb=patch_emb,
+            prompt_text=prompt_text,
+            prompt_patch_count=s,
+            speaker_scale=float(speaker_scale),
+            latent_dim=self.latent_dim,
+            patch_size=self.patch_size,
+            hop_size=self.hop_size,
+            sample_rate=self.sample_rate,
+            dtype=str(self.dtype).split(".")[-1],
+            compat_hash=self._compat_hash,
+        )
+
+    def _prefill(
+        self,
+        schedule_ids: list[int],
+        schedule: mx.array,
+        *,
+        span_positions: list[int],
+        prompt_patches: mx.array | None,
+        prompt_denorm_latents: mx.array | None = None,
+        cache,
+        patch_emb: mx.array | None = None,
+    ) -> int:
+        """Run the prefill forward + walk the prompt spans. Returns ``prefill_end``.
+
+        Stores the last LLM hidden in ``self._last_prefill_hidden``.
+        """
+        prompt_patch_count = (
+            0 if prompt_patches is None else int(prompt_patches.shape[1])
+        )
+        prefill_end = span_positions[prompt_patch_count]
+        prompt_span_positions = span_positions[:prompt_patch_count]
+
+        if prefill_end == 0:
+            self._last_prefill_hidden = None
+            return 0
+
+        # embed schedule[:prefill_end]; scatter prompt patch embeddings into spans.
+        head_ids = schedule[:, :prefill_end]  # [1, prefill_end]
+        inputs_embeds = self.llm._model.model.embed_tokens(head_ids)
+        inputs_embeds = inputs_embeds.astype(self.dtype)
+        if prompt_span_positions:
+            # patch_encoder over the full prompt latents -> [1, S, 1536].
+            # The prompt_patches reshape is [1, S, patch_size, 128]; flatten the time
+            # axis back to [1, S*patch_size, 128] for the encoder, which downsamples
+            # by patch_size to [1, S, 1536].
+            # patch_emb is supplied by the profile path (precomputed at enroll); else
+            # recompute it here — numerically identical, so the ref-audio path is unchanged.
+            if patch_emb is None:
+                # The patch encoder operates on DENORMALIZED latents (matches upstream's
+                # patch_encoder.prefill(prompt_latents) and our streaming-state prefill).
+                # prompt_patches (normalized) is the FM-history input only -- NOT this.
+                if prompt_denorm_latents is None:
+                    raise ValueError(
+                        "_prefill requires prompt_denorm_latents to recompute patch_emb "
+                        "when patch_emb is not supplied (the profile path)."
+                    )
+                flat = prompt_denorm_latents[
+                    :, : prompt_patch_count * self.patch_size
+                ]  # [1, S*patch_size, 128] denormalized
+                patch_emb = self.patch_encoder(flat)
+            patch_emb = patch_emb.astype(inputs_embeds.dtype)  # [1, S, 1536]
+            # scatter into the prompt span slots.
+            idx = mx.array(prompt_span_positions, dtype=mx.int32)
+            inputs_embeds[:, idx, :] = patch_emb[:, :prompt_patch_count, :]
+
+        llm_hiddens, _ = self.llm.step(inputs_embeds=inputs_embeds, cache=cache)
+        self._last_prefill_hidden = llm_hiddens[:, -1:, :]
+
+        # walk the prompt spans appending hidden + history chunks.
+        cursor = 0
+        for prompt_index, span_position in enumerate(prompt_span_positions):
+            if span_position > cursor:
+                self._append_hidden_chunk(
+                    llm_hiddens[:, span_position - 1 : span_position, :]
+                )
+            self._append_history_chunk(prompt_patches[:, prompt_index])  # [1, p, 128]
+            next_is_span = span_position + 1 < len(schedule_ids) and schedule_ids[
+                span_position + 1
+            ] in (self.tokenizer.audio_gen_span_id, self.tokenizer.audio_comp_span_id)
+            if next_is_span:
+                self._append_hidden_chunk(
+                    llm_hiddens[:, span_position : span_position + 1, :]
+                )
+            cursor = span_position + 1
+        if prefill_end > cursor:
+            self._append_hidden_chunk(llm_hiddens[:, prefill_end - 1 : prefill_end, :])
+        return prefill_end
+
+    # endregion decode helpers

--- a/mlx_audio/tts/models/dots/profile.py
+++ b/mlx_audio/tts/models/dots/profile.py
@@ -1,0 +1,142 @@
+"""Speaker-enrollment profile: cached, target-independent reference-encode artifacts.
+
+A SpeakerProfile holds the four arrays produced once at enrollment (g_cond, the
+AudioVAE-encoded prompt latents, and the patch-encoder embeddings) plus the metadata
+needed to reconstruct the identical generation schedule. Saved as a ``.dtprofile``
+directory: ``cond.safetensors`` (arrays) + ``profile.json`` (metadata). Pure MLX +
+stdlib; no torch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import mlx.core as mx
+
+SCHEMA_VERSION = 2  # bumped from 1: in-context patch_emb now derived from denormalized
+# latents; v1 profiles cached the wrong (normalized-derived) patch_emb.
+_ARRAY_FIELDS = ("g_cond", "prompt_patches", "prompt_denorm_latents", "patch_emb")
+_META_FIELDS = (
+    "prompt_text",
+    "prompt_patch_count",
+    "speaker_scale",
+    "latent_dim",
+    "patch_size",
+    "hop_size",
+    "sample_rate",
+    "dtype",
+    "compat_hash",
+    "schema_version",
+)
+
+
+@dataclass
+class SpeakerProfile:
+    g_cond: mx.array
+    prompt_patches: mx.array
+    prompt_denorm_latents: mx.array
+    patch_emb: mx.array
+    prompt_text: str
+    prompt_patch_count: int
+    speaker_scale: float
+    latent_dim: int
+    patch_size: int
+    hop_size: int
+    sample_rate: int
+    dtype: str
+    compat_hash: str
+    schema_version: int = SCHEMA_VERSION
+
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+        arrays = {f: getattr(self, f) for f in _ARRAY_FIELDS}
+        mx.eval(*arrays.values())
+        mx.save_safetensors(str(path / "cond.safetensors"), arrays)
+        meta = {f: getattr(self, f) for f in _META_FIELDS}
+        (path / "profile.json").write_text(json.dumps(meta, indent=2, sort_keys=True))
+
+    @classmethod
+    def load(cls, path: str | Path) -> "SpeakerProfile":
+        path = Path(path)
+        cond = path / "cond.safetensors"
+        meta_path = path / "profile.json"
+        if not cond.exists() or not meta_path.exists():
+            raise FileNotFoundError(
+                f"{path} is not a valid .dtprofile (need cond.safetensors + profile.json)."
+            )
+        arrays = mx.load(str(cond))
+        missing = [f for f in _ARRAY_FIELDS if f not in arrays]
+        if missing:
+            raise ValueError(f"profile {path} missing arrays: {missing}")
+        meta = json.loads(meta_path.read_text())
+        if meta.get("schema_version") != SCHEMA_VERSION:
+            raise ValueError(
+                f"profile schema_version {meta.get('schema_version')} != {SCHEMA_VERSION}"
+            )
+        return cls(
+            **{f: arrays[f] for f in _ARRAY_FIELDS},
+            **{f: meta[f] for f in _META_FIELDS},
+        )
+
+    def check_compat(self, model_hash: str) -> None:
+        if self.compat_hash != model_hash:
+            raise ValueError(
+                "this speaker profile was enrolled on a different model "
+                f"(profile hash {self.compat_hash[:12]}…, current model {model_hash[:12]}…) — "
+                "re-enroll the voice on the current model."
+            )
+
+
+def _safetensors_signature(
+    path: str | Path, exclude_prefixes: tuple[str, ...] = ()
+) -> list:
+    """Sorted ``[(name, shape)]`` from a safetensors header — metadata only, no
+    tensor reads. ``exclude_prefixes`` drops e.g. the quantized ``llm.`` tensors."""
+    path = Path(path)
+    with open(path, "rb") as f:
+        n = int.from_bytes(f.read(8), "little")
+        header = json.loads(f.read(n).decode("utf-8"))
+    sig = []
+    for name, meta in sorted(header.items()):
+        if name == "__metadata__":
+            continue
+        if any(name.startswith(p) for p in exclude_prefixes):
+            continue
+        # NB: dtype is intentionally excluded — non-LLM float components are stored at
+        # different on-disk dtypes across variants (bf16 dir: F32; int4/int8 dirs: BF16)
+        # but load+cast to the same runtime dtype, yielding identical artifacts. Keying on
+        # (name, shape) keeps profiles portable across quant variants while still pinning
+        # the model architecture; config.json + latent_stats values pin the rest.
+        sig.append((name, tuple(meta["shape"])))
+    return sig
+
+
+def model_compat_hash(model_dir: str | Path) -> str:
+    """Hash the artifact-producing components of a converted model dir.
+
+    Pins config dims + latent-stats normalization + the AudioVAE / CAM++ / patch-encoder
+    / projection tensor signatures (the bf16 components that produce profile artifacts).
+    EXCLUDES the ``quantization`` config block and all ``llm.`` tensors, so a profile is
+    portable across int4 / int8 / bf16.
+    """
+    model_dir = Path(model_dir)
+    h = hashlib.sha256()
+
+    cfg = json.loads((model_dir / "config.json").read_text())
+    cfg.pop("quantization", None)  # quant-independent
+    h.update(json.dumps(cfg, sort_keys=True).encode("utf-8"))
+    h.update((model_dir / "latent_stats.npz").read_bytes())
+
+    sigs = {
+        "core": _safetensors_signature(
+            model_dir / "core.safetensors", exclude_prefixes=("llm.",)
+        ),
+        "speaker": _safetensors_signature(model_dir / "speaker.safetensors"),
+        "vocoder": _safetensors_signature(model_dir / "vocoder.safetensors"),
+    }
+    h.update(json.dumps(sigs, sort_keys=True, default=list).encode("utf-8"))
+    return h.hexdigest()

--- a/mlx_audio/tts/models/dots/quantize.py
+++ b/mlx_audio/tts/models/dots/quantize.py
@@ -1,0 +1,146 @@
+"""Offline quantizer: convert an MLX fp32 dots.tts weights dir to a bf16/int8/int4 variant.
+
+Stage-1 scope: quantize ONLY the ``llm.*`` (Qwen2.5) tensors via mlx-lm's ``nn.quantize``;
+keep DiT (``velocity_field_predictor``), ``patch_encoder``, the projections, the vocoder,
+and the speaker at bf16. Writes a self-contained output dir
+(``{core,vocoder,speaker}.safetensors`` + ``config.json`` [with a ``quantization`` block for
+int8/int4] + ``llm_config.json`` + ``latent_stats.npz`` + ``tokenizer/``).
+
+Dev-only build tool, mirroring ``convert.py``. Pure MLX (``mlx`` + ``mlx_lm``); no torch.
+Run: ``python -m dots_tts_mlx.quantize --src weights/dots_tts_mlx --out weights/dots_tts_mlx_int4 --bits 4``
+LOCAL artifacts only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+from mlx_lm.models.qwen2 import Model as Qwen2Model
+from mlx_lm.models.qwen2 import ModelArgs as Qwen2Args
+
+_DOTS_MEMORY_LIMIT_GB = int(os.environ.get("MLX_AUDIO_DOTS_MEMORY_LIMIT_GB", "20"))
+if _DOTS_MEMORY_LIMIT_GB > 0:
+    mx.set_memory_limit(int(_DOTS_MEMORY_LIMIT_GB * (1 << 30)))
+
+_LLM_PREFIX = "llm."
+
+
+def _qwen_args(llm_cfg: dict) -> Qwen2Args:
+    # MUST stay in sync with dots_tts_mlx.llm.DotsLLM.from_core's Qwen2Args build:
+    # the quantized skeleton written here is loaded by that path, so any divergence
+    # in the args silently breaks quantized loading.
+    return Qwen2Args(
+        model_type=llm_cfg.get("model_type", "qwen2"),
+        hidden_size=llm_cfg["hidden_size"],
+        num_hidden_layers=llm_cfg["num_hidden_layers"],
+        intermediate_size=llm_cfg["intermediate_size"],
+        num_attention_heads=llm_cfg["num_attention_heads"],
+        rms_norm_eps=llm_cfg["rms_norm_eps"],
+        vocab_size=llm_cfg["vocab_size"],
+        num_key_value_heads=llm_cfg["num_key_value_heads"],
+        max_position_embeddings=llm_cfg.get("max_position_embeddings", 32768),
+        rope_theta=llm_cfg.get("rope_theta", 1000000.0),
+        rope_traditional=llm_cfg.get("rope_traditional", False),
+        rope_scaling=llm_cfg.get("rope_scaling"),
+        tie_word_embeddings=llm_cfg.get("tie_word_embeddings", True),
+    )
+
+
+def _cast_quant(v: mx.array) -> mx.array:
+    """Keep packed uint32 weights as-is; cast float scales/biases to bf16."""
+    return v if v.dtype == mx.uint32 else v.astype(mx.bfloat16)
+
+
+def quantize_dir(src, out, bits: int, group_size: int = 64) -> dict:
+    """Write a bf16/int8/int4 variant of the converted weights dir ``src`` to ``out``.
+
+    ``src`` must be the **fp32 convert output** (``python -m dots_tts_mlx.convert``), not an
+    already-quantized variant — the bf16 path casts every tensor to bf16 and would corrupt
+    packed weights if fed a quantized dir.
+    """
+    src, out = Path(src), Path(out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    cfg = json.loads((src / "config.json").read_text())
+    raw = mx.load(str(src / "core.safetensors"))
+
+    if bits == 16:
+        core_out = {k: v.astype(mx.bfloat16) for k, v in raw.items()}
+        cfg.pop("quantization", None)
+    elif bits in (8, 4):
+        llm_cfg = json.loads((src / "llm_config.json").read_text())
+        model = Qwen2Model(_qwen_args(llm_cfg))
+        llm_w = {
+            k[len(_LLM_PREFIX) :]: v.astype(mx.float32)
+            for k, v in raw.items()
+            if k.startswith(_LLM_PREFIX)
+        }
+        llm_w = model.sanitize(llm_w)
+        model.load_weights(list(llm_w.items()))
+        nn.quantize(model, group_size=group_size, bits=bits)
+        core_out = {
+            k: v.astype(mx.bfloat16)
+            for k, v in raw.items()
+            if not k.startswith(_LLM_PREFIX)
+        }
+        core_out.update(
+            {
+                f"{_LLM_PREFIX}{k}": _cast_quant(v)
+                for k, v in tree_flatten(model.parameters())
+            }
+        )
+        cfg["quantization"] = {
+            "bits": bits,
+            "group_size": group_size,
+            "components": ["llm"],
+        }
+    else:
+        raise ValueError(f"--bits must be 16, 8, or 4 (got {bits})")
+
+    mx.save_safetensors(str(out / "core.safetensors"), core_out)
+    for name in ("vocoder.safetensors", "speaker.safetensors"):
+        w = mx.load(str(src / name))
+        mx.save_safetensors(
+            str(out / name), {k: v.astype(mx.bfloat16) for k, v in w.items()}
+        )
+
+    (out / "config.json").write_text(json.dumps(cfg, indent=2))
+    shutil.copy2(src / "llm_config.json", out / "llm_config.json")
+    shutil.copy2(src / "latent_stats.npz", out / "latent_stats.npz")
+    tok = out / "tokenizer"
+    tok.mkdir(exist_ok=True)
+    for sp in (src / "tokenizer").iterdir():
+        if sp.is_file():
+            shutil.copy2(sp, tok / sp.name)
+
+    return {"out": str(out), "bits": bits, "group_size": group_size}
+
+
+def _main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Quantize a converted dots.tts MLX weights dir."
+    )
+    ap.add_argument(
+        "--src", default="weights/dots_tts_mlx", help="converted fp32 weights dir"
+    )
+    ap.add_argument(
+        "--out", required=True, help="output dir (e.g. weights/dots_tts_mlx_int4)"
+    )
+    ap.add_argument("--bits", type=int, choices=(16, 8, 4), required=True)
+    ap.add_argument("--group-size", type=int, default=64)
+    args = ap.parse_args()
+    summary = quantize_dir(
+        args.src, args.out, bits=args.bits, group_size=args.group_size
+    )
+    print(f"[quantize] wrote {summary}", flush=True)
+
+
+if __name__ == "__main__":
+    _main()

--- a/mlx_audio/tts/models/dots/semantic_encoder.py
+++ b/mlx_audio/tts/models/dots/semantic_encoder.py
@@ -1,0 +1,279 @@
+"""Pure-MLX VAE semantic encoder for dots.tts (``patch_encoder.*``).
+
+Mirrors ``dots_tts.modules.backbone.semantic_encoder.VAESemanticEncoder``: takes a
+generated VAE latent stream ``[B, T, 128]`` and produces a compact ``[B, T/4, 1536]``
+embedding fed back into the LLM. The total time downsample of ``patch_size = 4`` is
+split into a causal stride-2 conv (``ds_proj``) and a 2-step group-reshape in the
+output projection (``out_ds_rate = patch_size // in_ds_rate = 2``).
+
+Imports ONLY mlx (+ shared ``layers.py`` primitives) — never torch.
+
+CONFIG-VS-CODE NOTE (authoritative): the checkpoint's ``PatchEncoder`` config block
+sets ``qk_norm=True`` / ``rotary_bias=True``, but the upstream ``SuperviseEncoder``
+(``semantic_encoder.py:124-133``) forwards ONLY ``num_layers / num_heads /
+hidden_size / ffn_hidden_size / norm_layer`` into ``TransformerEncoderLayer``, which
+in turn passes only ``attn_drop / norm_layer`` (+ empty ``**kwargs``) into
+``MultiHeadAttention``. So the encoder's attention uses the MHA defaults:
+**NO qk_norm, NO rotary, NO qkv_bias** — positions come ONLY from the causal mask.
+Verified against the checkpoint key manifest (zero ``patch_encoder.*.q_norm`` /
+``rotary`` keys); the loader re-asserts this. The FFN activation is **SiLU** (not GELU).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import mlx.core as mx
+from mlx_lm.models.cache import KVCache
+
+from .layers import Conv1d, Linear, Mlp, MultiHeadAttention, RMSNorm
+
+
+@dataclass
+class PatchEncoderDecodeState:
+    """Incremental decode state for the streaming patch encoder.
+
+    Mirrors upstream ``SemanticEncoderDecodeState`` minus ``positions``/``seq_len``:
+    our encoder has no rotary / no qk-norm, so position enters only via the causal
+    mask and each ``KVCache`` tracks its own offset.
+
+      * ``conv_tail`` — the ``ds_proj`` causal conv's left-context: the last
+        ``left_padding`` raw frames (NLC ``[1, left_padding, in_dim]``). Zeros at init,
+        which equals the full conv's zero left-pad on the first patch.
+      * ``layer_caches`` — one ``mlx_lm`` ``KVCache`` per encoder layer (the same cache
+        class the LLM trunk uses).
+    """
+
+    conv_tail: mx.array
+    layer_caches: list = field(default_factory=list)
+
+
+class TransformerEncoderLayer:
+    """Pre-norm transformer block (affine RMSNorm + MHA + SiLU FFN).
+
+    Mirrors ``semantic_encoder.TransformerEncoderLayer.forward``::
+
+        h = attn_norm(x); h = attn(q=h, mask=causal); x = x + h
+        h = ffn_norm(x);  h = ffn(h);                 x = x + h
+
+    ``attn_norm`` / ``ffn_norm`` are affine ``RMSNorm(hidden_size)`` (norm_layer=
+    RMSNorm, eps = finfo(fp32).eps). ``attn`` is a plain causal ``MultiHeadAttention``
+    (no qk_norm, no rotary, no qkv_bias). ``ffn`` is a SiLU ``Mlp``.
+    """
+
+    def __init__(
+        self,
+        attn_norm: RMSNorm,
+        attn: MultiHeadAttention,
+        ffn_norm: RMSNorm,
+        ffn: Mlp,
+    ):
+        self.attn_norm = attn_norm
+        self.attn = attn
+        self.ffn_norm = ffn_norm
+        self.ffn = ffn
+
+    def __call__(self, x: mx.array, mask: mx.array, *, hp: bool = False) -> mx.array:
+        h = self.attn_norm(x)
+        h = self.attn(h, mask=mask, hp=hp)
+        x = x + h
+        h = self.ffn_norm(x)
+        h = self.ffn(h, hp=hp)
+        return x + h
+
+    def decode_step(
+        self, x_new: mx.array, kv_cache, mask: mx.array, *, hp: bool = False
+    ):
+        """Streaming block: attn.step (KV-cached) + FFN, same residual structure as __call__."""
+        h = self.attn_norm(x_new)
+        h = self.attn.step(h, kv_cache, mask, hp=hp)
+        x_new = x_new + h
+        h = self.ffn_norm(x_new)
+        h = self.ffn(h, hp=hp)
+        return x_new + h
+
+
+class SuperviseEncoder:
+    """Stack of ``TransformerEncoderLayer`` run under a shared causal mask.
+
+    Mirrors ``semantic_encoder.SuperviseEncoder.forward`` for the non-streaming
+    (recompute-full) path: builds the ``[T, T]`` lower-triangular bool mask once
+    (the encoder is causal, ``config.causal=True``) and applies every layer with it.
+    """
+
+    def __init__(self, layers: list[TransformerEncoderLayer], *, causal: bool = True):
+        self.layers = layers
+        self.causal = causal
+
+    def __call__(self, x: mx.array, *, hp: bool = False) -> mx.array:
+        t = x.shape[1]
+        if self.causal:
+            # lower-triangular bool mask, True = attend (matches torch.tril(ones(T,T))).
+            ones = mx.ones((t, t), dtype=mx.bool_)
+            mask = mx.tril(ones)[None]  # [1, T, T] -> broadcast over batch + heads
+        else:
+            mask = None
+        for layer in self.layers:
+            x = layer(x, mask, hp=hp)
+        return x
+
+    def decode_step(
+        self, x_new: mx.array, layer_caches: list, *, hp: bool = False
+    ) -> mx.array:
+        """Thread a new token block through every layer with a shared block mask.
+
+        ``x_new`` is [1, n, hidden]; ``layer_caches`` is one KVCache per layer (all at the
+        same offset). The mask [n, t_past + n] is True over the t_past past columns (attend
+        to all history) and lower-triangular over the n new columns (causal within the
+        block). Works for prefill (t_past=0, n=T -> full causal) and decode (t_past=T, n=2).
+        """
+        if not self.causal:
+            raise ValueError("streaming decode_step requires a causal encoder.")
+        n = x_new.shape[1]
+        t_past = layer_caches[0].offset
+        mask = mx.concatenate(
+            [
+                mx.ones((n, t_past), dtype=mx.bool_),
+                mx.tril(mx.ones((n, n), dtype=mx.bool_)),
+            ],
+            axis=1,
+        )
+        for layer, cache in zip(self.layers, layer_caches):
+            x_new = layer.decode_step(x_new, cache, mask, hp=hp)
+        return x_new
+
+
+class VAESemanticEncoder:
+    """VAE latent ``[B, T, 128]`` -> LLM embedding ``[B, T/4, 1536]``.
+
+    Pipeline (``forward``):
+      1. ``_downsample``  causal stride-2 ``ds_proj`` conv (time T -> T/2).
+      2. ``in_proj``      ``Linear(128 -> 1024)``.
+      3. ``encoder``      24-layer causal ``SuperviseEncoder``.
+      4. ``_project_embeddings``  group 2 consecutive timesteps into the feature dim
+         (``rearrange "b (s d) h -> b s (d h)"``, d=out_ds_rate=2) then ``out_proj``
+         ``Linear(2048 -> 1536)`` (time T/2 -> T/4).
+    """
+
+    def __init__(
+        self,
+        ds_proj: Conv1d,
+        in_proj: Linear,
+        encoder: SuperviseEncoder,
+        out_proj: Linear,
+        *,
+        out_ds_rate: int = 2,
+        patch_size: int = 4,
+    ):
+        self.ds_proj = ds_proj
+        self.in_proj = in_proj
+        self.encoder = encoder
+        self.out_proj = out_proj
+        self.out_ds_rate = out_ds_rate
+        self.patch_size = patch_size
+
+    def init_decode_state(
+        self, *, dtype: mx.Dtype = mx.float32
+    ) -> PatchEncoderDecodeState:
+        """Fresh streaming-decode state: zero conv_tail + one empty KVCache per layer."""
+        in_dim = self.ds_proj.weight.shape[-1]
+        conv_tail = mx.zeros((1, self.ds_proj.left_padding, in_dim), dtype=dtype)
+        layer_caches = [KVCache() for _ in self.encoder.layers]
+        return PatchEncoderDecodeState(conv_tail=conv_tail, layer_caches=layer_caches)
+
+    def _downsample(self, x: mx.array) -> mx.array:
+        # Upstream applies ds_proj on [B, C, T] (transpose) then transposes back.
+        # Our Conv1d is channels-last (NLC), so x[B, T, C] feeds it directly.
+        # (The conv's precision is fixed at construction via its own ``hp`` flag.)
+        return self.ds_proj(x)
+
+    def _downsample_step(self, patch: mx.array, conv_tail: mx.array):
+        """Streaming causal stride-2 conv over one patch (NLC), conv-only (no in_proj).
+
+        Mirrors upstream ``_downsample_step``: prepend the carried left-context, run the
+        conv with padding=0 (the tail supplies the left context), and carry the new tail.
+        Returns ``(down [1, out_ds_rate, in_dim], new_conv_tail [1, left_padding, in_dim])``.
+        Numerically identical to ``_downsample`` over the concatenated stream because the
+        conv is causal and the tail reproduces its exact left-context.
+        """
+        conv_input = mx.concatenate([conv_tail, patch], axis=1)  # [1, lp+P, in_dim]
+        y = mx.conv1d(
+            conv_input,
+            self.ds_proj.weight,
+            stride=self.ds_proj.stride,
+            padding=0,
+            dilation=self.ds_proj.dilation,
+            groups=self.ds_proj.groups,
+        )
+        if self.ds_proj.bias is not None:
+            y = y + self.ds_proj.bias
+        new_conv_tail = patch[:, -self.ds_proj.left_padding :, :]
+        return y, new_conv_tail
+
+    def _project_embeddings(self, z: mx.array, *, hp: bool) -> mx.array:
+        if self.out_ds_rate > 1:
+            b, sd, h = z.shape
+            d = self.out_ds_rate
+            s = sd // d
+            # rearrange "b (s d) h -> b s (d h)": split the time axis into (s, d),
+            # then merge the d sub-steps into the feature axis (d varies fastest).
+            z = z.reshape(b, s, d, h).reshape(b, s, d * h)
+        return self.out_proj(z, hp=hp)
+
+    def prefill(
+        self, x: mx.array, state: PatchEncoderDecodeState, *, hp: bool = False
+    ) -> None:
+        """Populate the decode state from the prompt's denormalized latents.
+
+        Runs the full causal downsample + in_proj over the prompt, threads all resulting
+        tokens through the encoder into the per-layer KV caches (offset 0 -> S*out_ds_rate),
+        and sets conv_tail = the prompt's last left_padding raw frames. ``x`` is
+        [1, S*patch_size, in_dim] (the same denormalized stream that seeds the recompute-full
+        history). Mutates ``state``; no return value (the prompt embeddings are computed for
+        the LLM scatter separately in model._prefill).
+        """
+        t = x.shape[1]
+        if t == 0:
+            return
+        if t % self.patch_size != 0:
+            raise ValueError(
+                f"prefill expects T divisible by patch_size={self.patch_size}, got T={t}."
+            )
+        down = self._downsample(x)  # [1, S*out_ds_rate, in_dim]
+        step_inputs = self.in_proj(down, hp=hp)  # [1, S*out_ds_rate, hidden]
+        self.encoder.decode_step(step_inputs, state.layer_caches, hp=hp)
+        state.conv_tail = x[:, -self.ds_proj.left_padding :, :]
+
+    def decode_patch(
+        self, patch: mx.array, state: PatchEncoderDecodeState, *, hp: bool = False
+    ) -> mx.array:
+        """Incrementally encode ONE generated patch -> one LLM token [1, 1, out_dim].
+
+        Streaming equivalent of recompute-full: conv step (with carried tail) + in_proj +
+        per-layer KV-cached decode_step + out_ds_rate grouping + out_proj. Mutates
+        ``state.conv_tail`` and the layer caches.
+        """
+        if patch.shape[1] != self.patch_size:
+            raise ValueError(
+                f"decode_patch expects patch length {self.patch_size}, got {patch.shape[1]}."
+            )
+        down, state.conv_tail = self._downsample_step(patch, state.conv_tail)
+        step_inputs = self.in_proj(down, hp=hp)  # [1, out_ds_rate, hidden]
+        enc = self.encoder.decode_step(step_inputs, state.layer_caches, hp=hp)
+        return self._project_embeddings(enc, hp=hp)  # [1, 1, out_dim]
+
+    def __call__(self, x: mx.array, *, hp: bool = False) -> mx.array:
+        # The recompute-full / patch decode loops always feed a time dimension that is
+        # a multiple of patch_size (one or more whole VAE latent patches); make that
+        # precondition explicit so a misaligned feed fails loudly instead of silently
+        # mis-grouping the out_ds_rate reshape.
+        t = x.shape[1]
+        if t % self.patch_size != 0:
+            raise ValueError(
+                f"VAESemanticEncoder expects T divisible by patch_size={self.patch_size}, "
+                f"got T={t}."
+            )
+        x = self._downsample(x)
+        x = self.in_proj(x, hp=hp)
+        z = self.encoder(x, hp=hp)
+        return self._project_embeddings(z, hp=hp)

--- a/mlx_audio/tts/models/dots/speaker.py
+++ b/mlx_audio/tts/models/dots/speaker.py
@@ -1,0 +1,439 @@
+"""Pure-MLX CAM++ speaker x-vector encoder for dots.tts.
+
+Imports ONLY mlx + numpy — never torch. Two public surfaces:
+
+  * ``kaldi_fbank(wav, sample_rate=16000) -> np.ndarray [T, 80]`` — a numpy
+    reimplementation of the torchaudio ``Kaldi.fbank`` front-end (Povey window,
+    pre-emphasis 0.97, per-frame DC removal, snip_edges framing, FFT 512, 80-mel
+    filterbank low20/high8000, log floor) followed by the per-bin CMN that the
+    upstream ``extract_speaker_fbank`` applies. Matches torch Kaldi to ~1e-5.
+  * ``CAMPPlus`` — the MLX 3D-Speaker CAM++ trunk (FCM Conv2d front-end + dense
+    TDNN trunk + stats pooling + final dense). ``model(fbank[B, T, 80]) -> [B, 512]``.
+
+All BatchNorms are folded to a frozen affine ``y = (x - rm)/sqrt(rv + eps)*w + b``
+(eps 1e-5) at load time (see ``loader.load_speaker``); the affine-free final BN
+folds to ``(x - rm)/sqrt(rv + eps)``. Conv weights are stored in MLX layout
+(Conv1d ``[out, k, in]``, Conv2d ``[out, kh, kw, in]``); activations flow
+channels-last (NLC / NHWC).
+
+tf32 note: MLX's fast conv/matmul round fp32 -> ~tf32 on Apple Silicon, costing
+up to ~1e-1 on large inputs. CAM++ is gated on COSINE (>= 0.9995), which is robust
+to that rounding, so the fast path is used throughout.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+
+# torchaudio Kaldi constants (compliance/kaldi.py).
+_EPSILON = float(np.finfo(np.float32).eps)  # 1.1920928955078125e-07
+_PREEMPH = 0.97
+_POVEY_EXP = 0.85
+
+
+def _next_power_of_2(x: int) -> int:
+    return 1 if x == 0 else 2 ** (x - 1).bit_length()
+
+
+def _mel_scale(freq):
+    return 1127.0 * np.log(1.0 + freq / 700.0)
+
+
+def _inverse_mel_scale(mel_freq):
+    return 700.0 * (np.exp(mel_freq / 1127.0) - 1.0)
+
+
+def _get_mel_banks(
+    num_bins: int,
+    window_length_padded: int,
+    sample_freq: float,
+    low_freq: float,
+    high_freq: float,
+) -> np.ndarray:
+    """numpy port of ``torchaudio.compliance.kaldi.get_mel_banks`` (vtln_warp=1).
+
+    Returns the ``[num_bins, num_fft_bins]`` triangular mel filterbank (fp64),
+    where ``num_fft_bins = window_length_padded // 2``.
+    """
+    num_fft_bins = window_length_padded // 2
+    nyquist = 0.5 * sample_freq
+    if high_freq <= 0.0:
+        high_freq += nyquist
+
+    fft_bin_width = sample_freq / window_length_padded
+    mel_low_freq = _mel_scale(low_freq)
+    mel_high_freq = _mel_scale(high_freq)
+    mel_freq_delta = (mel_high_freq - mel_low_freq) / (num_bins + 1)
+
+    bin_idx = np.arange(num_bins).reshape(num_bins, 1).astype(np.float64)
+    left_mel = mel_low_freq + bin_idx * mel_freq_delta
+    center_mel = mel_low_freq + (bin_idx + 1.0) * mel_freq_delta
+    right_mel = mel_low_freq + (bin_idx + 2.0) * mel_freq_delta
+
+    mel = _mel_scale(fft_bin_width * np.arange(num_fft_bins)).reshape(1, num_fft_bins)
+
+    up_slope = (mel - left_mel) / (center_mel - left_mel)
+    down_slope = (right_mel - mel) / (right_mel - center_mel)
+    bins = np.maximum(0.0, np.minimum(up_slope, down_slope))
+    return bins  # [num_bins, num_fft_bins]
+
+
+def kaldi_fbank(wav, sample_rate: int = 16000) -> np.ndarray:
+    """Compute Kaldi-equivalent log-mel fbank + per-bin CMN, matching the oracle.
+
+    Reproduces ``torchaudio.compliance.kaldi.fbank`` with the dots.tts speaker
+    defaults (80 mel bins, 25 ms / 10 ms frames, Povey window, pre-emphasis 0.97,
+    remove_dc_offset, snip_edges, FFT 512, low 20 Hz / high 8000 Hz, log floor,
+    dither 0, use_energy=False) and then subtracts the per-bin (per-column) mean
+    over time — the ``mean_norm`` step ``extract_speaker_fbank`` applies.
+
+    Args:
+        wav: 1-D waveform in [-1, 1] (NO int16 rescale), already at ``sample_rate``.
+        sample_rate: must match ``wav`` (16000 for the speaker front-end).
+
+    Returns:
+        ``[num_frames, 80]`` fp32 numpy array (post-CMN).
+    """
+    x = np.asarray(wav, dtype=np.float64).reshape(-1)
+    n_mels = 80
+    low_freq = 20.0
+    high_freq = 0.0  # <= 0 => Nyquist (8000 at 16 kHz), per Kaldi default
+    window_size = int(sample_rate * 25.0 * 0.001)  # 400
+    window_shift = int(sample_rate * 10.0 * 0.001)  # 160
+    padded = _next_power_of_2(window_size)  # 512
+
+    num_samples = x.shape[0]
+    if num_samples < window_size:
+        return np.zeros((0, n_mels), dtype=np.float32)
+
+    # --- snip_edges framing: m = 1 + (n - window)//shift, frame i = x[i*shift : +window]
+    m = 1 + (num_samples - window_size) // window_shift
+    idx = np.arange(window_size)[None, :] + window_shift * np.arange(m)[:, None]
+    frames = x[idx]  # [m, window_size]
+
+    # --- remove_dc_offset: per-frame mean subtraction
+    frames = frames - frames.mean(axis=1, keepdims=True)
+
+    # --- pre-emphasis: x[:, j] -= 0.97 * x[:, max(0, j-1)] (first sample replicated)
+    offset = np.concatenate([frames[:, :1], frames[:, :-1]], axis=1)
+    frames = frames - _PREEMPH * offset
+
+    # --- Povey window: hann(periodic=False)^0.85
+    n = np.arange(window_size)
+    hann = 0.5 - 0.5 * np.cos(2.0 * np.pi * n / (window_size - 1))
+    window = hann**_POVEY_EXP
+    frames = frames * window[None, :]
+
+    # --- zero-pad to FFT size, rfft, power spectrum
+    if padded != window_size:
+        frames = np.pad(frames, ((0, 0), (0, padded - window_size)))
+    spectrum = np.abs(np.fft.rfft(frames, n=padded, axis=1))  # [m, padded//2 + 1]
+    spectrum = spectrum**2.0
+
+    # --- mel filterbank (pad one zero column to match padded//2 + 1 bins), apply, log
+    mel = _get_mel_banks(n_mels, padded, float(sample_rate), low_freq, high_freq)
+    mel = np.pad(mel, ((0, 0), (0, 1)))  # [n_mels, padded//2 + 1]
+    mel_energies = spectrum @ mel.T  # [m, n_mels]
+    mel_energies = np.log(np.maximum(mel_energies, _EPSILON))
+
+    # --- per-bin CMN over time (extract_speaker_fbank's mean_norm)
+    mel_energies = mel_energies - mel_energies.mean(axis=0, keepdims=True)
+    return mel_energies.astype(np.float32)
+
+
+# --------------------------------------------------------------------------- #
+# CAM++ trunk (MLX). All conv weights pre-transposed to MLX layout, all BN
+# folded to frozen affine (scale, shift) at load time by loader.load_speaker.
+# --------------------------------------------------------------------------- #
+
+
+class _BN:
+    """Frozen BatchNorm folded to an affine over the channel (last) axis: x*scale + shift."""
+
+    def __init__(self, scale: mx.array, shift: mx.array):
+        self.scale = scale  # [C]
+        self.shift = shift  # [C]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x * self.scale + self.shift
+
+
+def _relu(x: mx.array) -> mx.array:
+    return mx.maximum(x, 0)
+
+
+class _Conv2d:
+    """Conv2d over NHWC tensors. ``weight`` is MLX layout ``[out, kh, kw, in]``."""
+
+    def __init__(
+        self,
+        weight: mx.array,
+        bias: mx.array | None,
+        *,
+        stride: tuple[int, int] = (1, 1),
+        padding: tuple[int, int] = (1, 1),
+    ):
+        self.weight = weight
+        self.bias = bias
+        self.stride = stride
+        self.padding = padding
+
+    def __call__(self, x: mx.array) -> mx.array:
+        y = mx.conv2d(x, self.weight, stride=self.stride, padding=self.padding)
+        if self.bias is not None:
+            y = y + self.bias
+        return y
+
+
+class _Conv1d:
+    """Conv1d over NLC tensors. ``weight`` is MLX layout ``[out, k, in]``.
+
+    ``padding`` is the symmetric zero-pad applied to the time axis (matching
+    torch Conv1d ``padding``); ``stride`` / ``dilation`` mirror torch.
+    """
+
+    def __init__(
+        self,
+        weight: mx.array,
+        bias: mx.array | None,
+        *,
+        stride: int = 1,
+        padding: int = 0,
+        dilation: int = 1,
+    ):
+        self.weight = weight
+        self.bias = bias
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+
+    def __call__(self, x: mx.array) -> mx.array:
+        y = mx.conv1d(
+            x,
+            self.weight,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+        )
+        if self.bias is not None:
+            y = y + self.bias
+        return y
+
+
+class _BasicResBlock:
+    """ResNet basic block over NHWC: conv1(stride,1)-bn1-relu, conv2-bn2, +shortcut, relu."""
+
+    def __init__(self, conv1, bn1, conv2, bn2, shortcut_conv=None, shortcut_bn=None):
+        self.conv1 = conv1
+        self.bn1 = bn1
+        self.conv2 = conv2
+        self.bn2 = bn2
+        self.shortcut_conv = shortcut_conv
+        self.shortcut_bn = shortcut_bn
+
+    def __call__(self, x: mx.array) -> mx.array:
+        out = _relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        if self.shortcut_conv is not None:
+            sc = self.shortcut_bn(self.shortcut_conv(x))
+        else:
+            sc = x
+        return _relu(out + sc)
+
+
+class FCM:
+    """Conv2d front-end folding the mel-height into channels.
+
+    Input ``[B, F=80, T]`` (channels-first F-over-T) is treated as a single-channel
+    image ``[B, 1, F, T]``, run through conv1/bn1/relu, two residual layers (each
+    halving F), conv2/bn2/relu (F halved again, stride (2,1)), then the
+    ``[B, C, H, W]`` feature is folded to ``[B, C*H, W]`` in C-major order.
+
+    Internally everything runs NHWC ``[B, H=F, W=T, C]`` (MLX-native); the leading
+    channel-1 dim becomes the trailing C=1 channel.
+    """
+
+    def __init__(self, conv1, bn1, layer1, layer2, conv2, bn2, out_channels: int):
+        self.conv1 = conv1
+        self.bn1 = bn1
+        self.layer1 = layer1  # list[_BasicResBlock]
+        self.layer2 = layer2
+        self.conv2 = conv2
+        self.bn2 = bn2
+        self.out_channels = out_channels
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # x: [B, F, T] (channels-first) -> NHWC single-channel image [B, F, T, 1]
+        x = x[..., None]
+        out = _relu(self.bn1(self.conv1(x)))
+        for blk in self.layer1:
+            out = blk(out)
+        for blk in self.layer2:
+            out = blk(out)
+        out = _relu(self.bn2(self.conv2(out)))
+        # out: NHWC [B, H, W, C]. Upstream torch had NCHW [B, C, H, W] and reshaped
+        # to [B, C*H, W] (C-major). Reproduce by moving to [B, C, H, W] then folding.
+        b, h, w, c = out.shape
+        out = out.transpose(0, 3, 1, 2)  # [B, C, H, W]
+        out = out.reshape(b, c * h, w)  # [B, C*H, W], C-major (matches torch)
+        return out
+
+
+class _TDNNLayer:
+    """Conv1d -> BN -> ReLU over NLC tensors (the trunk's input projection)."""
+
+    def __init__(self, conv: _Conv1d, bn: _BN):
+        self.conv = conv
+        self.bn = bn
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return _relu(self.bn(self.conv(x)))
+
+
+def _seg_pooling(x: mx.array, seg_len: int = 100) -> mx.array:
+    """avg_pool1d(kernel=seg_len, stride=seg_len, ceil_mode=True) then expand back to T.
+
+    ``x`` is NLC ``[B, T, C]``. With ceil_mode the last (partial) window averages
+    only its valid samples; the pooled value is then repeated ``seg_len`` times and
+    sliced back to ``T`` — reproducing torch's ``F.avg_pool1d(..., ceil_mode=True)``
+    + ``expand``/``reshape``/slice exactly (the most error-prone op in CAM++).
+    """
+    b, t, c = x.shape
+    n_full = t // seg_len
+    pooled = []
+    if n_full > 0:
+        head = x[:, : n_full * seg_len, :].reshape(b, n_full, seg_len, c)
+        pooled.append(head.mean(axis=2))  # [B, n_full, C]
+    rem = t - n_full * seg_len
+    if rem > 0:
+        # ceil_mode: a trailing partial window averaged over its `rem` valid samples.
+        tail = x[:, n_full * seg_len :, :].mean(axis=1, keepdims=True)  # [B, 1, C]
+        pooled.append(tail)
+    seg = mx.concatenate(pooled, axis=1)  # [B, n_seg, C]
+    n_seg = seg.shape[1]
+    # expand each segment value across seg_len, then slice back to T.
+    seg = mx.broadcast_to(seg[:, :, None, :], (b, n_seg, seg_len, c))
+    seg = seg.reshape(b, n_seg * seg_len, c)
+    return seg[:, :t, :]
+
+
+class _CAMLayer:
+    """3D-Speaker CAM attention layer over NLC tensors."""
+
+    def __init__(self, linear_local, linear1, linear2):
+        self.linear_local = linear_local  # _Conv1d (k, dilated)
+        self.linear1 = linear1  # _Conv1d (k=1)
+        self.linear2 = linear2  # _Conv1d (k=1)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        y = self.linear_local(x)
+        context = x.mean(axis=1, keepdims=True) + _seg_pooling(x)
+        context = _relu(self.linear1(context))
+        m = mx.sigmoid(self.linear2(context))
+        return y * m
+
+
+class _CAMDenseTDNNLayer:
+    """nonlinear1(BN-ReLU) -> linear1(k1) -> nonlinear2(BN-ReLU) -> cam_layer."""
+
+    def __init__(self, bn1, relu1, linear1, bn2, relu2, cam_layer):
+        # bn1/bn2 are _BN; relu flags folded as the get_nonlinear "batchnorm-relu".
+        self.bn1 = bn1
+        self.linear1 = linear1  # _Conv1d k=1
+        self.bn2 = bn2
+        self.cam_layer = cam_layer
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.linear1(_relu(self.bn1(x)))
+        x = _relu(self.bn2(x))
+        return self.cam_layer(x)
+
+
+class _CAMDenseTDNNBlock:
+    """Dense block: each layer's output is concatenated (channels-last) onto the input."""
+
+    def __init__(self, layers: list[_CAMDenseTDNNLayer]):
+        self.layers = layers
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for layer in self.layers:
+            x = mx.concatenate([x, layer(x)], axis=2)  # concat over channels (NLC)
+        return x
+
+
+class _TransitLayer:
+    """BN-ReLU -> Conv1d (k=1)."""
+
+    def __init__(self, bn: _BN, linear: _Conv1d):
+        self.bn = bn
+        self.linear = linear
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.linear(_relu(self.bn(x)))
+
+
+def _stats_pooling(x: mx.array) -> mx.array:
+    """Mean ++ UNBIASED (N-1) std over time, concatenated. ``x`` NLC -> [B, 2C]."""
+    t = x.shape[1]
+    mean = x.mean(axis=1)  # [B, C]
+    centered = x - mean[:, None, :]
+    var = (centered * centered).sum(axis=1) / (t - 1)  # unbiased
+    std = mx.sqrt(var)
+    return mx.concatenate([mean, std], axis=1)
+
+
+class CAMPPlus:
+    """Pure-MLX 3D-Speaker CAM++ x-vector encoder.
+
+    ``model(fbank)`` takes ``[B, T, 80]`` log-mel features and returns the
+    ``[B, 512]`` speaker embedding (final BatchNorm-normalized, NOT L2-normalized).
+    """
+
+    def __init__(
+        self,
+        head: FCM,
+        tdnn: _TDNNLayer,
+        block1: _CAMDenseTDNNBlock,
+        transit1: _TransitLayer,
+        block2: _CAMDenseTDNNBlock,
+        transit2: _TransitLayer,
+        block3: _CAMDenseTDNNBlock,
+        transit3: _TransitLayer,
+        out_nonlinear: _BN,
+        dense_linear: _Conv1d,
+        dense_bn: _BN,
+    ):
+        self.head = head
+        self.tdnn = tdnn
+        self.block1 = block1
+        self.transit1 = transit1
+        self.block2 = block2
+        self.transit2 = transit2
+        self.block3 = block3
+        self.transit3 = transit3
+        self.out_nonlinear = out_nonlinear  # BN-ReLU
+        self.dense_linear = dense_linear  # Conv1d k=1 (1024 -> 512)
+        self.dense_bn = dense_bn  # affine-free BN over 512
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # x: [B, T, F=80] -> permute to channels-first [B, F, T] for the FCM.
+        x = x.transpose(0, 2, 1)  # [B, F, T]
+        x = self.head(x)  # [B, C*H=320, W=T']  (channels-first)
+        x = x.transpose(0, 2, 1)  # NLC [B, T', 320] for the conv trunk
+
+        x = self.tdnn(x)
+        x = self.block1(x)
+        x = self.transit1(x)
+        x = self.block2(x)
+        x = self.transit2(x)
+        x = self.block3(x)
+        x = self.transit3(x)
+        x = _relu(self.out_nonlinear(x))  # out_nonlinear = BN-ReLU
+
+        x = _stats_pooling(x)  # [B, 1024]
+        # DenseLayer: Conv1d over a length-1 sequence then affine-free BN.
+        x = x[:, None, :]  # [B, 1, 1024]
+        x = self.dense_linear(x)  # [B, 1, 512]
+        x = self.dense_bn(x)  # affine-free BN
+        return x[:, 0, :]  # [B, 512]

--- a/mlx_audio/tts/models/dots/text.py
+++ b/mlx_audio/tts/models/dots/text.py
@@ -1,0 +1,175 @@
+"""Tokenizer + generation-schedule builder for the dots.tts MLX runtime.
+
+Imports ONLY the ``tokenizers`` library (the HF Rust BPE backend) + stdlib —
+NEVER torch. ``transformers.AutoTokenizer`` transitively imports torch, so we load
+the saved fast tokenizer directly via ``tokenizers.Tokenizer.from_file`` (identical
+BPE merges + special-token table, zero torch).
+
+Ports the dots.tts ``tts`` template + ``build_generation_schedule`` (upstream
+``data/pipelines/{tts_pipeline,tokenizing}.py`` + ``runtime._prepare_inputs``):
+
+  template "tts" = ``[文本]{text}[文本对应语音]{audio}``
+
+  schedule_ids = BPE("[文本]")
+               + BPE(prompt_text + text)            # {text}
+               + BPE("[文本对应语音]")
+               + [audio_gen_start_id]               # {audio} ->
+               + [audio_gen_span_id] * max_audio_tokens
+
+All literals are PLAIN BPE (``encode(s, add_special_tokens=False)``; NO BOS/EOS).
+``prompt_text`` is concatenated directly before the target ``text`` (with a trailing
+space appended to ``prompt_text`` for non-ZH/JA/YUE langs, mirroring upstream
+``_process_prompt_text``). When a ``language`` is given, the ``[CODE]`` uppercase-ISO
+tag is prepended to the ``prompt_text`` (if present), and to the target ``text`` only
+in the no-prompt-text case — matching upstream ``runtime._process_prompt_text`` /
+``_prepare_inputs``. ``YUE`` maps to ``[口音:粤语]``; tagging is idempotent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tokenizers import Tokenizer
+
+# Special tokens (verbatim from dots_tts.utils.tokenizer).
+AUDIO_GEN_START_TOKEN = "<|audio_gen_start|>"
+AUDIO_GEN_SPAN_TOKEN = "<|audio_gen_span|>"
+AUDIO_GEN_END_TOKEN = "<|audio_gen_end|>"
+TEXT_COND_END_TOKEN = "<|text_cond_end|>"
+AUDIO_COMP_SPAN_TOKEN = "<|audio_comp_span|>"
+
+# tts template literals (dots_tts.data.pipelines.tts_pipeline).
+TTS_TEXT_PREFIX = "[文本]"
+TTS_AUDIO_PREFIX = "[文本对应语音]"
+
+# Languages that do NOT get a trailing space appended to the prompt transcript
+# (upstream _process_prompt_text); a CJK/Cantonese set.
+_NO_TRAILING_SPACE_LANGS = {"ZH", "YUE", "JA", "口音:粤语"}
+
+
+class DotsTokenizer:
+    """Thin wrapper over a ``tokenizers.Tokenizer`` with the dots.tts schedule logic.
+
+    Loaded from the saved tokenizer dir (``tokenizer.json``). Exposes the special
+    token ids the AR loop needs and ``build_generation_schedule``.
+    """
+
+    def __init__(self, tokenizer: Tokenizer):
+        self._tk = tokenizer
+        self.audio_gen_start_id = self._require(AUDIO_GEN_START_TOKEN)
+        self.audio_gen_span_id = self._require(AUDIO_GEN_SPAN_TOKEN)
+        self.audio_gen_end_id = self._require(AUDIO_GEN_END_TOKEN)
+        self.text_cond_end_id = self._require(TEXT_COND_END_TOKEN)
+        self.audio_comp_span_id = self._require(AUDIO_COMP_SPAN_TOKEN)
+        # Both span ids are treated as audio placeholders during decode.
+        self.audio_span_token_ids = (self.audio_gen_span_id, self.audio_comp_span_id)
+
+    @classmethod
+    def from_pretrained(cls, tokenizer_dir: str | Path) -> "DotsTokenizer":
+        path = Path(tokenizer_dir)
+        tk_json = path / "tokenizer.json"
+        if not tk_json.exists():
+            raise FileNotFoundError(f"missing tokenizer.json: {tk_json}")
+        return cls(Tokenizer.from_file(str(tk_json)))
+
+    def _require(self, token: str) -> int:
+        tid = self._tk.token_to_id(token)
+        if tid is None:
+            raise ValueError(f"tokenizer missing required special token: {token!r}")
+        return int(tid)
+
+    @staticmethod
+    def _attach_language_tag(text: str, language: str | None) -> str:
+        """Prepend the ``[CODE]`` language tag (mirrors upstream ``attach_language_tag``).
+
+        Uppercase ISO code; ``YUE`` maps to ``口音:粤语``; idempotent (won't double-
+        prepend). Empty ``text`` / ``language`` is a no-op. We skip langdetect-based
+        normalization (callers pass explicit codes); the code is just uppercased.
+        """
+        if not text or not language:
+            return text
+        code = language.strip().upper()
+        if not code:
+            return text
+        if code == "YUE":
+            code = "口音:粤语"
+        tag = f"[{code}]"
+        if text.startswith(tag):
+            return text
+        return f"{tag}{text}"
+
+    def encode(self, text: str) -> list[int]:
+        """Plain BPE (no BOS/EOS), matching ``encode(s, add_special_tokens=False)``."""
+        return list(self._tk.encode(text, add_special_tokens=False).ids)
+
+    def decode(self, ids: list[int]) -> str:
+        return self._tk.decode(ids, skip_special_tokens=True)
+
+    def _process_prompt_text(
+        self, prompt_text: str | None, *, language: str | None
+    ) -> str:
+        """Mirror ``runtime._process_prompt_text`` (sans the auto language detector).
+
+        Appends a trailing space for non-CJK languages, then attaches the ``[CODE]``
+        language tag to the prompt transcript when a ``language`` is given (matching
+        upstream order: trailing-space THEN tag). We do NOT auto-detect the language
+        (no ``langdetect`` dependency); callers pass an explicit code.
+        """
+        if not prompt_text:
+            return ""
+        prompt_text = prompt_text.strip()
+        if not prompt_text:
+            return ""
+        lang = (language or "").upper() if language else None
+        if lang not in _NO_TRAILING_SPACE_LANGS:
+            prompt_text += " "
+        # Upstream attaches the language tag to the prompt transcript whenever a
+        # language is given (runtime._process_prompt_text:260-261).
+        if language:
+            prompt_text = self._attach_language_tag(prompt_text, language)
+        return prompt_text
+
+    def build_generation_schedule(
+        self,
+        text: str,
+        *,
+        prompt_text: str | None = None,
+        language: str | None = None,
+        max_audio_tokens: int = 500,
+    ) -> list[int]:
+        """Build the flat ``schedule_ids`` for the ``tts`` template.
+
+        Args:
+            text: the target text to synthesize.
+            prompt_text: the reference-audio transcript (prefixed before ``text``);
+                empty/None for plain text-to-speech (no reference).
+            language: optional uppercase ISO code; only prepended as a ``[CODE]`` tag
+                to ``text`` when there is NO prompt_text (matches upstream).
+            max_audio_tokens: number of ``audio_gen_span`` placeholders to emit
+                (= ``max_generate_length``, default 500).
+
+        Returns:
+            ``schedule_ids``: a flat list of token ids.
+        """
+        if max_audio_tokens <= 0:
+            raise ValueError("max_audio_tokens must be positive for generation.")
+
+        normalized_prompt_text = self._process_prompt_text(
+            prompt_text, language=language
+        )
+        normalized_text = text.strip()
+        # Language tag attaches to the target text only in the no-prompt-text case
+        # (runtime._prepare_inputs:325-326); the prompt-text path is tagged inside
+        # _process_prompt_text above.
+        if language and not normalized_prompt_text:
+            normalized_text = self._attach_language_tag(normalized_text, language)
+
+        combined_text = f"{normalized_prompt_text}{normalized_text}"
+
+        schedule_ids: list[int] = []
+        schedule_ids.extend(self.encode(TTS_TEXT_PREFIX))
+        schedule_ids.extend(self.encode(combined_text))
+        schedule_ids.extend(self.encode(TTS_AUDIO_PREFIX))
+        schedule_ids.append(self.audio_gen_start_id)
+        schedule_ids.extend([self.audio_gen_span_id] * max_audio_tokens)
+        return schedule_ids

--- a/mlx_audio/tts/tests/test_dots.py
+++ b/mlx_audio/tts/tests/test_dots.py
@@ -1,0 +1,427 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+
+class TestDotsLoadModel(unittest.TestCase):
+    REQUIRED_DOTS_FILES = (
+        "config.json",
+        "llm_config.json",
+        "core.safetensors",
+        "vocoder.safetensors",
+        "speaker.safetensors",
+    )
+
+    def _write_dots_checkpoint(self, root: Path, model_type=None):
+        config = {}
+        if model_type is not None:
+            config["model_type"] = model_type
+
+        (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        (root / "llm_config.json").write_text("{}", encoding="utf-8")
+        for name in self.REQUIRED_DOTS_FILES[2:]:
+            (root / name).write_bytes(b"")
+
+    def _patch_fake_dots_loader(self, return_value):
+        return MagicMock(return_value=return_value)
+
+    def _assert_dispatched_to_dots(self, dots_loader, model_path, lazy, strict):
+        self.assertEqual(dots_loader.call_count, 1)
+        call = dots_loader.call_args
+        called_path = call.kwargs.get("model_path", call.args[0] if call.args else None)
+        self.assertEqual(called_path, model_path)
+        self.assertEqual(call.kwargs.get("lazy"), lazy)
+        self.assertEqual(call.kwargs.get("strict"), strict)
+
+    def _write_variant_root(self, root: Path, *variants: str):
+        for variant in variants:
+            variant_root = root / variant
+            variant_root.mkdir(parents=True, exist_ok=True)
+            self._write_dots_checkpoint(variant_root, model_type="dots_tts_mlx")
+
+    def test_load_model_dispatches_local_dots_checkpoint(self):
+        from mlx_audio.tts import utils as tts_utils
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model_path = Path(tmpdir)
+            self._write_dots_checkpoint(model_path)
+
+            expected_model = object()
+            dots_loader = self._patch_fake_dots_loader(expected_model)
+
+            with (
+                patch("mlx_audio.tts.models.dots.load_model", dots_loader),
+                patch.object(
+                    tts_utils,
+                    "base_load_model",
+                    side_effect=AssertionError(
+                        "dots checkpoints should not fall back to base_load_model"
+                    ),
+                ),
+            ):
+                result = tts_utils.load_model(model_path, lazy=True, strict=False)
+
+        self.assertIs(result, expected_model)
+        self._assert_dispatched_to_dots(
+            dots_loader,
+            model_path=model_path,
+            lazy=True,
+            strict=False,
+        )
+
+    def test_load_model_dispatches_model_type_alias_to_dots_loader(self):
+        from mlx_audio.tts import utils as tts_utils
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model_path = Path(tmpdir)
+            self._write_dots_checkpoint(model_path, model_type="dots_tts_mlx")
+
+            expected_model = object()
+            dots_loader = self._patch_fake_dots_loader(expected_model)
+
+            with (
+                patch("mlx_audio.tts.models.dots.load_model", dots_loader),
+                patch.object(
+                    tts_utils,
+                    "base_load_model",
+                    side_effect=AssertionError(
+                        "dots model_type aliases should bypass base_load_model"
+                    ),
+                ),
+            ):
+                result = tts_utils.load_model(model_path, lazy=False, strict=True)
+
+        self.assertIs(result, expected_model)
+        self._assert_dispatched_to_dots(
+            dots_loader,
+            model_path=model_path,
+            lazy=False,
+            strict=True,
+        )
+
+    def test_load_model_defaults_to_int4_subdir_for_multi_variant_root(self):
+        from mlx_audio.tts import utils as tts_utils
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            self._write_variant_root(repo_root, "int4", "int8")
+
+            expected_model = object()
+            dots_loader = self._patch_fake_dots_loader(expected_model)
+
+            with (
+                patch("mlx_audio.tts.models.dots.load_model", dots_loader),
+                patch.object(tts_utils, "get_model_path", return_value=repo_root),
+                patch.object(
+                    tts_utils,
+                    "base_load_model",
+                    side_effect=AssertionError(
+                        "dots multi-variant roots should bypass base_load_model"
+                    ),
+                ),
+            ):
+                result = tts_utils.load_model(
+                    "shraey/dots-tts-mlx", lazy=True, strict=False
+                )
+
+        self.assertIs(result, expected_model)
+        self._assert_dispatched_to_dots(
+            dots_loader,
+            model_path="shraey/dots-tts-mlx",
+            lazy=True,
+            strict=False,
+        )
+        self.assertEqual(dots_loader.call_args.kwargs.get("subdir"), None)
+
+    def test_load_model_accepts_explicit_subdir_override_for_multi_variant_root(self):
+        from mlx_audio.tts import utils as tts_utils
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            self._write_variant_root(repo_root, "int4", "mf-int8")
+
+            expected_model = object()
+            dots_loader = self._patch_fake_dots_loader(expected_model)
+
+            with (
+                patch("mlx_audio.tts.models.dots.load_model", dots_loader),
+                patch.object(tts_utils, "get_model_path", return_value=repo_root),
+                patch.object(
+                    tts_utils,
+                    "base_load_model",
+                    side_effect=AssertionError(
+                        "dots multi-variant roots should bypass base_load_model"
+                    ),
+                ),
+            ):
+                result = tts_utils.load_model(
+                    "shraey/dots-tts-mlx",
+                    lazy=False,
+                    strict=True,
+                    subdir="mf-int8",
+                )
+
+        self.assertIs(result, expected_model)
+        self._assert_dispatched_to_dots(
+            dots_loader,
+            model_path="shraey/dots-tts-mlx",
+            lazy=False,
+            strict=True,
+        )
+        self.assertEqual(dots_loader.call_args.kwargs.get("subdir"), "mf-int8")
+
+
+class TestDotsDirectLoader(unittest.TestCase):
+    def _write_dots_checkpoint(self, root: Path, model_type="dots_tts_mlx"):
+        config = {"model_type": model_type}
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        (root / "llm_config.json").write_text("{}", encoding="utf-8")
+        for name in ("core.safetensors", "vocoder.safetensors", "speaker.safetensors"):
+            (root / name).write_bytes(b"")
+
+    def test_direct_dots_loader_defaults_to_int4_subdir(self):
+        from mlx_audio.tts.models import dots
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            self._write_dots_checkpoint(repo_root / "int4")
+            self._write_dots_checkpoint(repo_root / "int8")
+
+            with (
+                patch.object(dots, "get_model_path", return_value=repo_root),
+                patch.object(
+                    dots.Model, "load_runtime", autospec=True, return_value=None
+                ),
+            ):
+                model = dots.load_model("shraey/dots-tts-mlx")
+
+        self.assertEqual(model.config.model_path, str(repo_root / "int4"))
+
+    def test_direct_dots_loader_accepts_explicit_subdir_override(self):
+        from mlx_audio.tts.models import dots
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            self._write_dots_checkpoint(repo_root / "int4")
+            self._write_dots_checkpoint(repo_root / "mf-int8")
+
+            with (
+                patch.object(dots, "get_model_path", return_value=repo_root),
+                patch.object(
+                    dots.Model, "load_runtime", autospec=True, return_value=None
+                ),
+            ):
+                model = dots.load_model("shraey/dots-tts-mlx", subdir="mf-int8")
+
+        self.assertEqual(model.config.model_path, str(repo_root / "mf-int8"))
+
+    def test_direct_dots_loader_respects_lazy_flag(self):
+        from mlx_audio.tts.models import dots
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            self._write_dots_checkpoint(repo_root / "int4")
+
+            with (
+                patch.object(dots, "get_model_path", return_value=repo_root),
+                patch.object(
+                    dots.Model, "load_runtime", autospec=True, return_value=None
+                ) as load_runtime,
+            ):
+                model = dots.load_model("shraey/dots-tts-mlx", lazy=True)
+
+        self.assertEqual(model.config.model_path, str(repo_root / "int4"))
+        load_runtime.assert_not_called()
+
+
+class TestDotsModel(unittest.TestCase):
+    def _make_model(self, runtime, sample_rate=24000):
+        from mlx_audio.tts.models.dots import Model
+
+        model = Model.__new__(Model)
+        nn.Module.__init__(model)
+        model.config = SimpleNamespace(sample_rate=sample_rate)
+        model.runtime = runtime
+        model._runtime = runtime
+        return model
+
+    def _contains_reference_path(self, value, expected_path):
+        expected_path = str(expected_path)
+        if isinstance(value, (str, Path)):
+            return str(value) == expected_path
+        if isinstance(value, dict):
+            return any(
+                self._contains_reference_path(item, expected_path)
+                for item in value.values()
+            )
+        if isinstance(value, (list, tuple)):
+            return any(
+                self._contains_reference_path(item, expected_path) for item in value
+            )
+        return False
+
+    def test_generate_preserves_reference_audio_path_and_normalizes_language(self):
+        runtime = MagicMock()
+        runtime.generate.return_value = [
+            {
+                "audio": mx.array([0.1, 0.2], dtype=mx.float32),
+                "sample_rate": 22050,
+                "samples": 2,
+                "segment_idx": 0,
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            reference_audio_path = Path(tmpdir) / "reference.wav"
+            reference_audio_path.write_bytes(b"RIFF")
+
+            model = self._make_model(runtime)
+            next(
+                model.generate(
+                    "hello",
+                    ref_audio=str(reference_audio_path),
+                    lang_code="en",
+                )
+            )
+
+        runtime.generate.assert_called_once()
+        runtime_kwargs = runtime.generate.call_args.kwargs
+        self.assertEqual(runtime_kwargs.get("language"), "EN")
+        self.assertTrue(
+            self._contains_reference_path(
+                {
+                    "args": runtime.generate.call_args.args,
+                    "kwargs": runtime_kwargs,
+                },
+                reference_audio_path,
+            )
+        )
+
+    def test_generate_accepts_predecoded_reference_audio_arrays(self):
+        runtime = MagicMock()
+        runtime.generate.return_value = [
+            {
+                "audio": mx.array([0.1, 0.2], dtype=mx.float32),
+                "sample_rate": 22050,
+                "samples": 2,
+                "segment_idx": 0,
+            }
+        ]
+
+        reference_audio = mx.array([0.0, 0.1, -0.1], dtype=mx.float32)
+        model = self._make_model(runtime)
+        next(
+            model.generate(
+                "hello",
+                ref_audio=reference_audio,
+                ref_text="reference",
+                lang_code="en",
+            )
+        )
+
+        runtime.generate.assert_called_once()
+        runtime_kwargs = runtime.generate.call_args.kwargs
+        self.assertEqual(runtime_kwargs.get("language"), "EN")
+        self.assertIs(runtime_kwargs.get("prompt_audio"), reference_audio)
+        self.assertEqual(runtime_kwargs.get("prompt_text"), "reference")
+
+    @patch("builtins.print")
+    @patch("mlx_audio.tts.generate.audio_write")
+    def test_generate_audio_uses_dots_model_through_common_tts_api(
+        self, mock_audio_write, _mock_print
+    ):
+        from mlx_audio.tts.generate import generate_audio
+
+        runtime = MagicMock()
+        runtime.generate.return_value = [
+            {
+                "audio": mx.array([0.1, 0.2], dtype=mx.float32),
+                "sample_rate": 24000,
+                "samples": 2,
+                "segment_idx": 0,
+            }
+        ]
+
+        model = self._make_model(runtime, sample_rate=24000)
+        generate_audio(
+            text="hello dots",
+            model=model,
+            max_tokens=321,
+            cfg_scale=1.7,
+            ddpm_steps=8,
+            verbose=False,
+        )
+
+        runtime.generate.assert_called_once()
+        runtime_kwargs = runtime.generate.call_args.kwargs
+        self.assertEqual(runtime_kwargs.get("max_generate_length"), 321)
+        self.assertEqual(runtime_kwargs.get("guidance_scale"), 1.7)
+        self.assertEqual(runtime_kwargs.get("num_steps"), 8)
+        for unexpected_key in (
+            "voice",
+            "speed",
+            "temperature",
+            "verbose",
+            "stream",
+            "streaming_interval",
+            "instruct",
+            "use_zero_spk_emb",
+        ):
+            self.assertNotIn(unexpected_key, runtime_kwargs)
+        mock_audio_write.assert_called_once()
+
+    def test_generate_yields_generation_result_like_fields_from_runtime_dict(self):
+        audio = mx.array([0.25, -0.5, 0.75], dtype=mx.float32)
+        runtime = MagicMock()
+        runtime.generate.return_value = [
+            {
+                "audio": audio,
+                "sample_rate": 44100,
+                "samples": 3,
+                "segment_idx": 7,
+            }
+        ]
+
+        model = self._make_model(runtime)
+        result = next(model.generate("future dots"))
+
+        self.assertTrue(hasattr(result, "audio"))
+        self.assertTrue(hasattr(result, "sample_rate"))
+        self.assertTrue(hasattr(result, "samples"))
+        self.assertTrue(hasattr(result, "segment_idx"))
+        np.testing.assert_allclose(np.array(result.audio), np.array(audio))
+        self.assertEqual(result.sample_rate, 44100)
+        self.assertEqual(result.samples, 3)
+        self.assertEqual(result.segment_idx, 7)
+
+    def test_generate_populates_verbose_stats_defaults_from_runtime_dict(self):
+        runtime = MagicMock()
+        runtime.generate.return_value = [
+            {
+                "audio": mx.array([0.25, -0.5, 0.75], dtype=mx.float32),
+                "sample_rate": 44100,
+                "samples": 3,
+                "segment_idx": 7,
+                "num_patches": 4,
+                "processing_time_seconds": 0.5,
+            }
+        ]
+
+        model = self._make_model(runtime)
+        result = next(model.generate("future dots"))
+
+        self.assertEqual(result.prompt["tokens-per-sec"], 8.0)
+        self.assertEqual(result.audio_samples["samples"], 3)
+        self.assertEqual(result.audio_samples["samples-per-sec"], 6.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mlx_audio/tts/tests/test_generate.py
+++ b/mlx_audio/tts/tests/test_generate.py
@@ -298,6 +298,20 @@ class TestGenerateAudio(unittest.TestCase):
 
     @patch("builtins.print")
     @patch("mlx_audio.tts.generate.audio_write")
+    def test_generate_audio_keeps_max_tokens_as_third_positional_arg(
+        self, mock_audio_write, _mock_print
+    ):
+        model = MagicMock()
+        model.sample_rate = 24000
+        model.generate.return_value = [self._result([0.1, 0.2])]
+
+        generate_audio("hello", model, 321, verbose=False)
+
+        self.assertEqual(model.generate.call_args.kwargs["max_tokens"], 321)
+        mock_audio_write.assert_called_once()
+
+    @patch("builtins.print")
+    @patch("mlx_audio.tts.generate.audio_write")
     @patch("mlx_audio.tts.generate.load_audio")
     @patch("mlx_audio.tts.generate.os.path.exists")
     def test_generate_audio_preserves_reference_paths_for_models_that_opt_in(
@@ -324,6 +338,118 @@ class TestGenerateAudio(unittest.TestCase):
         mock_load_audio.assert_not_called()
         self.assertEqual(model.generate.call_args.kwargs["ref_audio"], "speaker.wav")
         mock_audio_write.assert_called_once()
+
+    @patch("builtins.print")
+    @patch("mlx_audio.tts.generate.audio_write")
+    @patch("mlx_audio.tts.generate.load_audio")
+    @patch("mlx_audio.tts.generate.os.path.exists")
+    def test_generate_audio_decodes_non_wav_refs_for_path_preserving_models(
+        self,
+        mock_exists,
+        mock_load_audio,
+        mock_audio_write,
+        _mock_print,
+    ):
+        mock_exists.return_value = True
+        decoded_ref = mx.array([0.1, 0.2, 0.3], dtype=mx.float32)
+        mock_load_audio.return_value = decoded_ref
+        model = MagicMock()
+        model.sample_rate = 48000
+        model.preserve_ref_audio_path = True
+        model.generate.return_value = [self._result([0.1, 0.2], sample_rate=48000)]
+
+        generate_audio(
+            text="hello",
+            model=model,
+            ref_audio="speaker.mp3",
+            ref_text="reference",
+            verbose=False,
+        )
+
+        mock_exists.assert_called_once_with("speaker.mp3")
+        mock_load_audio.assert_called_once_with(
+            "speaker.mp3",
+            sample_rate=48000,
+            volume_normalize=False,
+        )
+        self.assertIs(model.generate.call_args.kwargs["ref_audio"], decoded_ref)
+        mock_audio_write.assert_called_once()
+
+    @patch("builtins.print")
+    @patch("mlx_audio.tts.generate.audio_write")
+    @patch("mlx_audio.tts.generate.load_audio")
+    @patch("mlx_audio.stt.load")
+    @patch("mlx_audio.tts.generate.os.path.exists")
+    def test_generate_audio_transcribes_decoded_non_wav_refs_when_ref_text_missing(
+        self,
+        mock_exists,
+        mock_stt_load,
+        mock_load_audio,
+        mock_audio_write,
+        _mock_print,
+    ):
+        mock_exists.return_value = True
+        decoded_ref = mx.array([0.1, 0.2, 0.3], dtype=mx.float32)
+        mock_load_audio.return_value = decoded_ref
+        stt_model = MagicMock()
+        stt_model.generate.return_value = SimpleNamespace(text="auto transcript")
+        mock_stt_load.return_value = stt_model
+
+        class DummyModel:
+            preserve_ref_audio_path = True
+            sample_rate = 48000
+
+            def __init__(self, result):
+                self._result = result
+                self.calls = []
+
+            def generate(self, text, ref_audio=None, ref_text=None, **kwargs):
+                self.calls.append(
+                    {
+                        "text": text,
+                        "ref_audio": ref_audio,
+                        "ref_text": ref_text,
+                        **kwargs,
+                    }
+                )
+                return [self._result]
+
+        model = DummyModel(self._result([0.1, 0.2], sample_rate=48000))
+
+        generate_audio(
+            text="hello",
+            model=model,
+            ref_audio="speaker.mp3",
+            ref_text=None,
+            verbose=False,
+        )
+
+        mock_load_audio.assert_called_once_with(
+            "speaker.mp3",
+            sample_rate=48000,
+            volume_normalize=False,
+        )
+        stt_model.generate.assert_called_once_with(decoded_ref)
+        self.assertEqual(model.calls[0]["ref_text"], "auto transcript")
+        mock_audio_write.assert_called_once()
+
+    @patch("builtins.print")
+    def test_generate_audio_rejects_multiple_refs_for_single_reference_models(
+        self, _mock_print
+    ):
+        model = MagicMock()
+        model.sample_rate = 48000
+        model.model_type = "dots"
+        model.supports_multiple_references = False
+
+        with self.assertRaisesRegex(ValueError, "single ref_audio/ref_text pair"):
+            generate_audio(
+                text="hello",
+                model=model,
+                ref_audio=["s1.wav", "s2.wav"],
+                ref_text=["speaker one", "speaker two"],
+                verbose=False,
+            )
 
     @patch("builtins.print")
     @patch("mlx_audio.tts.generate.audio_write")

--- a/mlx_audio/tts/utils.py
+++ b/mlx_audio/tts/utils.py
@@ -12,11 +12,15 @@ from mlx.utils import tree_flatten
 from mlx_audio.utils import (
     base_load_model,
     get_model_class,
+    get_model_name_parts,
     get_model_path,
     load_config,
 )
 
 MODEL_REMAPPING = {
+    "dots": "dots",
+    "dots_tts": "dots",
+    "dots_tts_mlx": "dots",
     "qwen3_tts": "qwen3_tts",
     "outetts": "outetts",
     "spark": "spark",
@@ -47,6 +51,49 @@ MODEL_REMAPPING = {
 }
 MAX_FILE_SIZE_GB = 5
 MODEL_CONVERSION_DTYPES = ["float16", "bfloat16", "float32"]
+
+_DOTS_MODEL_TYPES = {"dots", "dots_tts", "dots_tts_mlx"}
+_DOTS_DEFAULT_SUBDIR = "int4"
+_DOTS_REQUIRED_FILES = {
+    "config.json",
+    "llm_config.json",
+    "core.safetensors",
+    "vocoder.safetensors",
+    "speaker.safetensors",
+}
+
+
+def _looks_like_dots_checkpoint(
+    model_path: Path, config: Optional[dict] = None
+) -> bool:
+    config = config or {}
+    model_type = config.get("model_type") or config.get("architecture")
+    if isinstance(model_type, str) and model_type.lower() in _DOTS_MODEL_TYPES:
+        return True
+    if not model_path.exists() or not model_path.is_dir():
+        return False
+    names = {item.name for item in model_path.iterdir()}
+    return _DOTS_REQUIRED_FILES.issubset(names)
+
+
+def _load_config_if_exists(model_path: Path) -> dict:
+    config_path = model_path / "config.json"
+    if not config_path.exists():
+        return {}
+    return load_config(model_path)
+
+
+def _has_dots_model_hint(model_name_parts: List[str]) -> bool:
+    return any(part == "dots" or part in _DOTS_MODEL_TYPES for part in model_name_parts)
+
+
+def _looks_like_dots_variant_root(
+    model_path: Path, subdir: Optional[str] = None
+) -> bool:
+    variant_path = model_path / (subdir or _DOTS_DEFAULT_SUBDIR)
+    return _looks_like_dots_checkpoint(
+        variant_path, _load_config_if_exists(variant_path)
+    )
 
 
 # Get a list of all available model types from the models directory
@@ -98,9 +145,10 @@ def get_model_and_args(model_type: str, model_name: List[str]) -> Tuple[Any, str
 
 
 def load_model(
-    model_path: Path,
+    model_path: Union[str, Path],
     lazy: bool = False,
     strict: bool = True,
+    subdir: Optional[str] = None,
     **kwargs: Any,
 ) -> nn.Module:
     """
@@ -119,10 +167,51 @@ def load_model(
         FileNotFoundError: If the weight files (.safetensors) are not found.
         ValueError: If the model class or args class are not found or cannot be instantiated.
     """
+    model_name_parts = get_model_name_parts(model_path)
+    resolved_model_path = None
+
+    if isinstance(model_path, Path):
+        resolved_model_path = model_path.expanduser()
+    elif isinstance(model_path, str):
+        candidate = Path(model_path).expanduser()
+        if candidate.exists():
+            resolved_model_path = candidate
+        elif _has_dots_model_hint(model_name_parts):
+            from mlx_audio.tts.models import dots
+
+            return dots.load_model(
+                model_path=model_path,
+                lazy=lazy,
+                strict=strict,
+                subdir=subdir,
+                **kwargs,
+            )
+
+    if resolved_model_path is not None and (
+        _has_dots_model_hint(model_name_parts)
+        or _looks_like_dots_checkpoint(
+            resolved_model_path, _load_config_if_exists(resolved_model_path)
+        )
+        or _looks_like_dots_variant_root(resolved_model_path, subdir=subdir)
+    ):
+        from mlx_audio.tts.models import dots
+
+        return dots.load_model(
+            model_path=resolved_model_path,
+            lazy=lazy,
+            strict=strict,
+            subdir=subdir,
+            **kwargs,
+        )
+
+    if resolved_model_path is not None:
+        model_path = resolved_model_path
+
     return base_load_model(
         model_path=model_path,
         category="tts",
         model_remapping=MODEL_REMAPPING,
+        model_name_parts=model_name_parts,
         lazy=lazy,
         strict=strict,
         **kwargs,


### PR DESCRIPTION
## Summary
- add dots model loading, runtime wrapper, and docs
- support dots checkpoint detection plus multi-variant subdir resolution
- extend generate/reference-audio tests and common-API compatibility coverage

## Test Plan
- ./.venv/bin/python -m unittest mlx_audio.tts.tests.test_generate mlx_audio.tts.tests.test_dots -v
- ./.venv/bin/python -m compileall mlx_audio/tts/generate.py mlx_audio/tts/utils.py mlx_audio/tts/models/dots

## Notes
- branch pushed from fork: cppup/mlx-audio:feat/dots-tts-support