### PR TITLE
fix(stt): apply logits processors in batched Qwen3-ASR

### DIFF
--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -1097,6 +1097,7 @@ class Qwen3ASRModel(nn.Module):
         *,
         max_tokens,
         sampler,
+        logits_processors,
         language,
         system_prompt,
         batch_size,
@@ -1130,6 +1131,7 @@ class Qwen3ASRModel(nn.Module):
             pad_to = max(len(c[0]) for c in group)
 
             embeds = []
+            token_histories = [] if logits_processors else None
             for chunk_audio, _ in group:
                 audio = chunk_audio
                 if len(audio) < pad_to:
@@ -1138,6 +1140,8 @@ class Qwen3ASRModel(nn.Module):
                 af = self.get_audio_features(feats, fmask)
                 input_ids = self._build_prompt(n_audio, language, system_prompt)
                 embeds.append(self._build_inputs_embeds(input_ids, af)[0])
+                if token_histories is not None:
+                    token_histories.append(input_ids[0, -1:])
 
             x = mx.stack(embeds, axis=0)  # (B, L, H), equal L
             bsz = x.shape[0]
@@ -1156,7 +1160,19 @@ class Qwen3ASRModel(nn.Module):
                 if self.lm_head is not None
                 else self.model.embed_tokens.as_linear(hidden)
             )
-            y = sampler(logits[:, -1, :])
+
+            def apply_logits_processors(logits):
+                if token_histories is None:
+                    return logits
+                processed = []
+                for i, tokens in enumerate(token_histories):
+                    sample_logits = logits[i : i + 1]
+                    for processor in logits_processors:
+                        sample_logits = processor(tokens, sample_logits)
+                    processed.append(sample_logits)
+                return mx.concatenate(processed, axis=0)
+
+            y = sampler(apply_logits_processors(logits[:, -1, :]))
             mx.async_eval(y)
 
             out_ids = [[] for _ in range(bsz)]
@@ -1164,16 +1180,24 @@ class Qwen3ASRModel(nn.Module):
             group_tokens = 0
             budget_exhausted = False
             for _ in range(remaining_tokens):
+                if token_histories is not None:
+                    for i in range(bsz):
+                        if not done[i]:
+                            token_histories[i] = mx.concatenate(
+                                [token_histories[i], y[i : i + 1]]
+                            )
+
                 # Build and kick off the next step before consuming the current
                 # one, so the GPU runs this step while Python walks the tokens
                 # (overlap pattern from mlx_lm.generate_step).
                 next_logits = self._forward_with_embeds(
                     self.model.embed_tokens(y[:, None]), cache
                 )
-                next_y = sampler(next_logits[:, -1, :])
+                next_y = sampler(apply_logits_processors(next_logits[:, -1, :]))
                 mx.async_eval(next_y)
 
-                for i, t in enumerate(y.tolist()):
+                current_tokens = y.tolist()
+                for i, t in enumerate(current_tokens):
                     if budget_exhausted:
                         break
                     if done[i]:
@@ -1315,6 +1339,7 @@ class Qwen3ASRModel(nn.Module):
                 chunks,
                 max_tokens=max_tokens,
                 sampler=sampler,
+                logits_processors=logits_processors,
                 language=language,
                 system_prompt=system_prompt,
                 batch_size=batch_size,

--- a/mlx_audio/stt/tests/test_qwen3_asr_batched.py
+++ b/mlx_audio/stt/tests/test_qwen3_asr_batched.py
@@ -96,6 +96,7 @@ class TestBatchedGeneration(unittest.TestCase):
             [(np.zeros(4), 0.0), (np.zeros(4), 1.0)],
             max_tokens=3,
             sampler=lambda logits: next(sampler_outputs),
+            logits_processors=None,
             language="en",
             system_prompt=None,
             batch_size=2,
@@ -106,6 +107,43 @@ class TestBatchedGeneration(unittest.TestCase):
         self.assertEqual(texts, ["10 11", "20"])
         self.assertEqual(prompt_tokens, [1, 1])
         self.assertEqual(processed, [True, True])
+
+    def test_batched_generation_applies_logits_processors_per_row(self):
+        model = self.make_minimal_model()
+        sampler_outputs = iter(
+            [
+                mx.array([10, 20]),
+                mx.array([11, 21]),
+                mx.array([12, 22]),
+            ]
+        )
+        histories = []
+        processed_logits = []
+
+        def record_history(tokens, logits):
+            histories.append(tokens.tolist())
+            return logits + len(histories)
+
+        def sample(logits):
+            processed_logits.append(logits[:, 0].tolist())
+            return next(sampler_outputs)
+
+        model._generate_chunks_batched(
+            [(np.zeros(4), 0.0), (np.zeros(4), 1.0)],
+            max_tokens=3,
+            sampler=sample,
+            logits_processors=[record_history],
+            language="en",
+            system_prompt=None,
+            batch_size=2,
+            verbose=False,
+        )
+
+        self.assertEqual(
+            histories,
+            [[0], [0], [0, 10], [0, 20], [0, 10, 11], [0, 20, 21]],
+        )
+        self.assertEqual(processed_logits, [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
 
     def test_generate_rejects_invalid_batch_size(self):
         model = self.make_minimal_model()
@@ -132,6 +170,9 @@ class TestBatchedGeneration(unittest.TestCase):
         self.assertEqual(out.generation_tokens, 2)
         self.assertEqual(len(out.segments), 2)
         model._generate_chunks_batched.assert_called_once()
+        self.assertIsNone(
+            model._generate_chunks_batched.call_args.kwargs["logits_processors"]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Pass `logits_processors` into the batched Qwen3-ASR decoder and keep a separate token history for each batch row.
- Add a deterministic regression test that checks both row histories and the logits passed to the sampler.

## Context

This is a follow-up to #783. `Qwen3ASRModel.generate()` builds a logits processor when `repetition_penalty` is enabled, but only the sequential path used it. Calls with `batch_size > 1` silently skipped the processor.

I reproduced the failure on a private two-speaker Mandarin recording split into seven 30-second chunks, using Qwen3-ASR 1.7B 8-bit on an Apple M4. The audio and transcript are not included.

| Path | Completed chunks | Wall time | Generation tokens |
| --- | ---: | ---: | ---: |
| Sequential with repetition penalty | 7/7 | 8.44 s | 546 |
| Batch size 4 before this fix | 4/7 | 61.30 s | 2048 |
| Batch size 4 with this fix | 7/7 | 7.50 s | 543 |

Before the fix, the batched output repeated until it exhausted the 2048-token budget. After the fix, it completed all seven chunks and its token count returned to the sequential range. These timings are one local reproduction, not a general benchmark.

## Implementation

The batched path now follows the token-history convention used by `mlx_lm.generate_step`: each row starts with the last prompt token, then adds its generated tokens before the next processor call. The histories remain MLX arrays so the next decode step can still be scheduled before Python consumes the current tokens. When no processor is configured, the batched path does not allocate or update histories.

## Validation

```text
uv run --with pytest pytest -q mlx_audio/stt/tests/test_qwen3_asr_batched.py
6 passed

uv run --extra dev pre-commit run --all-files
black ... Passed
isort ... Passed
```
