### PR TITLE
feat(stt): route shared context to Fun-ASR hotwords

### DIFF
--- a/docs/models/stt/fun-asr-nano.md
+++ b/docs/models/stt/fun-asr-nano.md
@@ -37,7 +37,8 @@ The converted directory is directly uploadable to Hugging Face as `mlx-community
       --model mlx-community/Fun-ASR-Nano-2512 \
       --audio audio.wav \
       --output-path transcript \
-      --language zh
+      --language zh \
+      --context "开放时间, 地址"
     ```
 
 ## Options
@@ -45,6 +46,10 @@ The converted directory is directly uploadable to Hugging Face as `mlx-community
 `language` accepts ISO hints for the current Nano checkpoint: `zh`, Chinese dialect codes that map to the Chinese prompt (`yue`, `wuu`, `nan`, `hak`, `gan`, `hsn`, `cjy`), `en`, and `ja`. Pass `None` or `auto` to omit the language constraint.
 
 `hotwords` accepts a list of domain terms to include in the upstream prompt.
+The shared CLI and server `context` string is supported as an alias, so the same
+contextual biasing works through `mlx_audio.stt.generate --context ...` and
+`POST /v1/audio/transcriptions`. Non-empty `hotwords` and `context` values are
+mutually exclusive.
 
 `itn=False` asks the model to skip inverse text normalization.
 

--- a/mlx_audio/stt/models/fun_asr_nano/README.md
+++ b/mlx_audio/stt/models/fun_asr_nano/README.md
@@ -31,7 +31,7 @@ mlx_audio.stt.generate \
   --audio audio.wav \
   --output-path transcript \
   --language zh \
-  --gen-kwargs '{"hotwords": ["开放时间"]}'
+  --context "开放时间, 地址"
 ```
 
 ## Options
@@ -43,6 +43,10 @@ Hotwords can be supplied as a list of domain terms:
 ```python
 result = model.generate("audio.wav", language="zh", hotwords=["开放时间", "地址"])
 ```
+
+The shared CLI and OpenAI-compatible server API expose contextual biasing as a
+single `context` string. It is an alias for `hotwords`; non-empty values are
+mutually exclusive.
 
 Inverse text normalization is enabled by default. Set `itn=False` to ask the model to keep spoken-form text:
 

--- a/mlx_audio/stt/models/fun_asr_nano/fun_asr_nano.py
+++ b/mlx_audio/stt/models/fun_asr_nano/fun_asr_nano.py
@@ -396,6 +396,23 @@ class FunASRNano(nn.Module):
         return language
 
     @staticmethod
+    def _resolve_hotwords(
+        hotwords: Optional[Iterable[str]], context: Optional[str]
+    ) -> Optional[List[str]]:
+        resolved_hotwords = []
+        if hotwords is not None:
+            for item in hotwords:
+                word = item.strip()
+                if word:
+                    resolved_hotwords.append(word)
+        context = context.strip() if context is not None else ""
+        if resolved_hotwords and context:
+            raise ValueError("Pass either hotwords or context, not both.")
+        if resolved_hotwords:
+            return resolved_hotwords
+        return [context] if context else None
+
+    @staticmethod
     def _prompt_text(
         hotwords: Optional[Iterable[str]] = None,
         language: Optional[str] = None,
@@ -475,11 +492,13 @@ class FunASRNano(nn.Module):
         logits_processors=None,
         language: Optional[str] = None,
         hotwords: Optional[Iterable[str]] = None,
+        context: Optional[str] = None,
         itn: bool = True,
         prefill_step_size: int = 2048,
     ):
         from mlx_lm.generate import generate_step
 
+        hotwords = self._resolve_hotwords(hotwords, context)
         input_ids, inputs_embeds = self._build_inputs_embeds(
             audio, language=language, hotwords=hotwords, itn=itn
         )
@@ -558,6 +577,7 @@ class FunASRNano(nn.Module):
         repetition_context_size: int = 100,
         language: Optional[str] = None,
         hotwords: Optional[Iterable[str]] = None,
+        context: Optional[str] = None,
         itn: bool = True,
         prefill_step_size: int = 2048,
         chunk_duration: float = 1200.0,
@@ -572,6 +592,7 @@ class FunASRNano(nn.Module):
         del verbose, kwargs
         start_time = time.time()
         max_tokens = int(max_tokens or self.config.default_max_tokens)
+        hotwords = self._resolve_hotwords(hotwords, context)
 
         audio_input = audio[0] if isinstance(audio, list) else audio
         if isinstance(audio_input, (str, Path)):

--- a/mlx_audio/stt/tests/test_fun_asr_nano.py
+++ b/mlx_audio/stt/tests/test_fun_asr_nano.py
@@ -1,5 +1,11 @@
+import importlib
+import inspect
+from types import MethodType, SimpleNamespace
+
+import mlx.core as mx
 import pytest
 
+from mlx_audio.stt.generate import generate_transcription
 from mlx_audio.stt.models.fun_asr_nano.config import FunASRNanoConfig
 from mlx_audio.stt.models.fun_asr_nano.convert import _convert_weights
 from mlx_audio.stt.models.fun_asr_nano.fun_asr_nano import FunASRNano
@@ -26,6 +32,92 @@ def test_language_mapping_uses_current_model_iso_hints():
 
     with pytest.raises(ValueError, match="Unsupported ISO language"):
         FunASRNano._map_language("ko")
+
+
+def test_shared_context_api_is_exposed_for_fun_asr_hotwords():
+    assert "context" in inspect.signature(FunASRNano.generate).parameters
+    assert "context" in inspect.signature(FunASRNano.stream_generate).parameters
+
+    assert FunASRNano._resolve_hotwords(None, " MLX, Apple Silicon ") == [
+        "MLX, Apple Silicon"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("hotwords", "context", "expected"),
+    [
+        (None, None, None),
+        (None, "", None),
+        (None, "   ", None),
+        ([], None, None),
+        (["", "   "], None, None),
+        ([], "MLX", ["MLX"]),
+        (["", " MLX ", "Apple Silicon"], None, ["MLX", "Apple Silicon"]),
+        (["MLX"], "", ["MLX"]),
+        (["MLX"], "   ", ["MLX"]),
+    ],
+)
+def test_shared_context_api_ignores_empty_values(hotwords, context, expected):
+    assert FunASRNano._resolve_hotwords(hotwords, context) == expected
+
+
+def test_hotword_iterators_are_materialized_for_chunk_reuse():
+    hotwords = (word for word in ["MLX", "Apple Silicon"])
+
+    assert FunASRNano._resolve_hotwords(hotwords, None) == ["MLX", "Apple Silicon"]
+
+
+def test_cli_context_reaches_each_fun_asr_audio_chunk(tmp_path):
+    model = FunASRNano.__new__(FunASRNano)
+    model.config = SimpleNamespace(
+        default_max_tokens=10, frontend_conf=SimpleNamespace(fs=16_000)
+    )
+    captured_hotwords = []
+
+    def fake_generate_chunk(self, audio, **kwargs):
+        captured_hotwords.append(kwargs["hotwords"])
+        return "chunk", 1, 1
+
+    model._generate_single_chunk = MethodType(fake_generate_chunk, model)
+
+    result = generate_transcription(
+        model=model,
+        audio=mx.zeros((32_000,)),
+        output_path=str(tmp_path / "transcript"),
+        context=" MLX, Apple Silicon ",
+        language="en",
+        chunk_duration=1.0,
+    )
+
+    assert result.text == "chunk chunk"
+    assert captured_hotwords == [
+        ["MLX, Apple Silicon"],
+        ["MLX, Apple Silicon"],
+    ]
+
+
+def test_stream_context_reaches_fun_asr_prompt(monkeypatch):
+    model = FunASRNano.__new__(FunASRNano)
+    captured_hotwords = []
+
+    def fake_build_inputs(self, audio, **kwargs):
+        captured_hotwords.append(kwargs["hotwords"])
+        return mx.array([[1]]), mx.zeros((1, 1, 1))
+
+    def fake_generate_step(**kwargs):
+        yield 151643, None
+
+    model._build_inputs_embeds = MethodType(fake_build_inputs, model)
+    generate_module = importlib.import_module("mlx_lm.generate")
+    monkeypatch.setattr(generate_module, "generate_step", fake_generate_step)
+
+    assert list(model.stream_generate(mx.zeros((1,)), context=" MLX ")) == []
+    assert captured_hotwords == [["MLX"]]
+
+
+def test_shared_context_api_rejects_ambiguous_hotwords():
+    with pytest.raises(ValueError, match="either hotwords or context"):
+        FunASRNano._resolve_hotwords(["MLX"], "Apple Silicon")
 
 
 def test_converter_transposes_fsmn_and_skips_tied_lm_head():


### PR DESCRIPTION
## Summary

- expose the shared `context` argument on Fun-ASR batch and streaming generation
- normalize non-empty context/hotword values once, reject ambiguous input, and preserve hotwords across long-audio chunks
- document CLI and OpenAI-compatible server usage and add regression coverage for CLI, streaming, empty values, conflicts, and iterators

## Why

Fun-ASR-Nano already supports the model-specific `hotwords=[...]` API added in #760. However, mlx-audio advertises `context` as the common CLI/server interface for contextual biasing, and signature filtering silently dropped it for Fun-ASR. This makes `--context` and the transcription API behave consistently with the direct Python API.

## Validation

- `uv run pytest -q mlx_audio/stt/tests` — 246 passed, 9 skipped, 18 subtests passed
- `uv run pre-commit run --files ...` — black and isort passed
- Apple Silicon real-model smoke with `mlx-community/Fun-ASR-Nano-2512` and `--context "开放时间, 地址"` — output: `开放时间：早上九点至下午五点。`

Closes #339