### PR TITLE
fix(server): STT requests fail with "There is no Stream(gpu, 1) in current thread" — load models on the broker thread

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -248,9 +248,27 @@ async def _preflight_model_load(model_name: str) -> None:
     surfaces as 200 OK with an empty body. Pre-flighting the load here lets the
     framework's exception handlers turn the failure into a real HTTP error
     response. Warm models are a no-op (``ModelProvider.load_model`` is cached).
+
+    The load is routed through the inference broker rather than
+    ``asyncio.to_thread``: MLX arrays are anchored to the stream of the thread
+    that materializes them, so a model loaded (and cached) on a transient
+    threadpool thread fails later on the broker thread with
+    ``RuntimeError: There is no Stream(gpu, 1) in current thread.``
+    Loading on the broker thread keeps model load and inference on the same
+    persistent thread.
     """
     try:
-        await asyncio.to_thread(_load_model_for_inference, model_name)
+        handle = get_inference_broker().submit(
+            endpoint_kind="model_load",
+            model_name=model_name,
+            payload=None,
+        )
+        while True:
+            chunk = await asyncio.to_thread(handle.result_queue.get)
+            if chunk.kind == "error":
+                raise chunk.error
+            if chunk.kind == "done":
+                break
     except HTTPException:
         raise
     except RepositoryNotFoundError as exc:
@@ -263,6 +281,19 @@ async def _preflight_model_load(model_name: str) -> None:
             status_code=500,
             detail=f"Failed to load model {model_name!r}: {exc}",
         ) from exc
+
+
+class ModelLoadExecutionAdapter(BaseModelExecutionAdapter):
+    """Load (and cache) a model on the broker thread without running inference.
+
+    Used by ``_preflight_model_load``. MLX arrays are anchored to the stream of
+    the thread that materializes them, so models must be loaded on the same
+    persistent thread that later evaluates them.
+    """
+
+    def run_serial(self, request: InferenceRequest) -> None:
+        _load_model_for_inference(request.model_name)
+        request.emit_done()
 
 
 _STT_EXTRA_KWARGS = {"word_timestamps", "timestamp_granularities"}
@@ -824,6 +855,7 @@ def get_inference_broker() -> InferenceBroker:
     global INFERENCE_BROKER
     if INFERENCE_BROKER is None:
         broker = InferenceBroker()
+        broker.register_adapter("model_load", ModelLoadExecutionAdapter())
         broker.register_adapter("stt", STTExecutionAdapter())
         broker.register_adapter("tts", TTSExecutionAdapter())
         broker.register_adapter("separation", SeparationExecutionAdapter())


### PR DESCRIPTION
## Context

On Apple Silicon, the API server's STT endpoint is currently broken for several models. Every `POST /v1/audio/transcriptions` with a Qwen3-ASR model returns 500 with:

```
RuntimeError: There is no Stream(gpu, 1) in current thread.
```

With `mlx-community/whisper-large-v3-turbo-asr-fp16` the same error escapes as an uncaught C++ exception and **aborts the whole server process**:

```
libc++abi: terminating due to uncaught exception of type std::runtime_error: There is no Stream(gpu, 1) in current thread.
```

This looks like the same root cause as #744 (TTS side — the reporter's attempted workarounds there, e.g. `mx.set_default_device` in the worker thread, don't work for the reason below).

## Description

**Root cause:** `_preflight_model_load` loads the model via `asyncio.to_thread`, i.e. on a transient threadpool thread, and `ModelProvider.load_model` caches that instance. MLX arrays are anchored to the stream of the thread that materializes them, so the cached weights belong to the pool thread's stream (`Stream(gpu, 1)`). When the persistent `InferenceBroker` thread later evaluates against them, MLX raises the stream error. Wrapping the broker's `generate()` call in a fresh `mx.stream(...)` context does *not* help — the weights themselves are anchored elsewhere. The fix must align the load thread with the inference thread.

**Fix:** route the preflight load through the broker via a minimal `ModelLoadExecutionAdapter` (`endpoint_kind="model_load"`). The model is loaded, cached, and later evaluated on the same persistent broker thread. Preflight keeps its contract: load failures are still translated into proper HTTP errors before a `StreamingResponse` commits its status line (verified: unknown repo still returns 404).

## Changes in the codebase

- `mlx_audio/server.py`
  - `_preflight_model_load`: submit a `model_load` job to the inference broker instead of `asyncio.to_thread`; await the result queue without blocking the event loop.
  - new `ModelLoadExecutionAdapter` (loads + caches on the broker thread, emits done; errors are handled by the broker's existing guard).
  - register the adapter in `get_inference_broker()`.

## Changes outside the codebase

None.

## Additional information

Verified on Apple M5 (32 GB), macOS, Python 3.12, mlx 0.32.0, branch based on `9b50bf4`:

| Test | Before | After |
|---|---|---|
| Qwen3-ASR-1.7B-8bit, `/v1/audio/transcriptions` | 500 on every request | 200, correct output |
| whisper-large-v3-turbo-asr-fp16 | process abort (libc++abi) | 200 |
| Alternate Qwen3 → Whisper → Qwen3, one process | first failure kills it | all 200, server stays up |
| Unknown model name | 404 | 404 (preflight contract preserved) |

## Checklist
- [ ] Tests added/updated — none added; existing test layout for the server broker wasn't obvious, glad to add if you point me at the right place
- [x] Documentation updated — docstrings on the changed function/adapter
- [x] Issue referenced — related: #744