### PR TITLE
fix(kokoro): match PyTorch reference semantics in four decoder paths (-2.5 dB level error, F0-path misalignment)

### DIFF
--- a/mlx_audio/tts/models/interpolate.py
+++ b/mlx_audio/tts/models/interpolate.py
@@ -92,6 +92,11 @@ def interpolate1d(
             x = mx.arange(size) * (in_width / size)
             if not align_corners:
                 x = x + 0.5 * (in_width / size) - 0.5
+                # torch clamps source coords at 0; without this, floor(x) = -1
+                # for the first outputs when upsampling and MLX negative
+                # indexing WRAPS to the last frame instead of repeating the
+                # first.
+                x = mx.maximum(x, 0.0)
 
     # Handle the case where input width is 1
     if in_width == 1:

--- a/mlx_audio/tts/models/kokoro/istftnet.py
+++ b/mlx_audio/tts/models/kokoro/istftnet.py
@@ -507,6 +507,10 @@ class MLXSTFT:
             x_stft = real_part + 1j * imag_part
 
             # Inverse STFT
+            # normalized=True selects window-squared (COLA) overlap-add
+            # normalization, matching torch.istft. The plain-window default
+            # attenuates the waveform by sum(w^2)/sum(w) = 0.75 (-2.5 dB) for
+            # Kokoro's periodic-hann win=4*hop configuration.
             audio = istft(
                 x_stft,
                 hop_length=self.hop_length,
@@ -514,6 +518,7 @@ class MLXSTFT:
                 window=self.window,
                 center=True,
                 length=None,
+                normalized=True,
             )
 
             reconstructed.append(audio)
@@ -560,7 +565,8 @@ class SineGen:
         # because 2 * np.pi * n doesn't affect phase
         rad_values = (f0_values / self.sampling_rate) % 1
         # initial phase noise (no noise for fundamental component)
-        rand_ini = mx.random.normal((f0_values.shape[0], f0_values.shape[2]))
+        # torch reference uses rand() — UNIFORM [0,1) phase offsets, not normal
+        rand_ini = mx.random.uniform(shape=(f0_values.shape[0], f0_values.shape[2]))
         rand_ini[:, 0] = 0
         rad_values[:, 0, :] = rad_values[:, 0, :] + rand_ini
         # instantanouse phase sine[t] = sin(2*pi \sum_i=1 ^{t} rad)
@@ -885,10 +891,18 @@ class AdainResBlk1d(nn.Module):
         x = self.norm1(x, s)
         x = self.actv(x)
 
-        # Manually implement grouped ConvTranspose1d since MLX doesn't support groups
+        # torch ConvTranspose1d(k=3, stride=2, padding=1, output_padding=1)
+        # maps T -> 2T by trimming one sample from the LEFT of the unpadded
+        # (2T+1) transpose-conv output. Left-zero-padding the padding=1 output
+        # instead shifts the residual branch one frame against the shortcut
+        # and replaces a computed tail sample with 0.
         x = x.swapaxes(2, 1)
-        x = self.pool(x, mx.conv_transpose1d) if self.upsample_type != "none" else x
-        x = mx.pad(x, ((0, 0), (1, 0), (0, 0))) if self.upsample_type != "none" else x
+        if self.upsample_type != "none":
+            orig_pad = self.pool.padding
+            self.pool.padding = 0
+            x = self.pool(x, mx.conv_transpose1d)
+            self.pool.padding = orig_pad
+            x = x[:, 1:, :]
         x = x.swapaxes(2, 1)
 
         x = x.swapaxes(2, 1)


### PR DESCRIPTION
## Summary

Four places where the MLX Kokoro port diverges from the PyTorch reference (`hexgrad/kokoro`). Each was found by instrumenting both stacks layer-by-layer on identical phoneme/style inputs and comparing every intermediate tensor. Two are clearly audible, two are smaller semantic mismatches found on the way.

### 1. Constant −2.5 dB output attenuation (`MLXSTFT.inverse`)

`dsp.istft` defaults to `normalized=False` (overlap-add division by Σw). `torch.istft` always uses COLA normalization (Σw²). For Kokoro's periodic-hann, win = 4×hop configuration this is a constant amplitude factor of Σw²/Σw = 1.5/2.0 = **0.75 (−2.50 dB)**.

Measured: MLX/torch waveform RMS ratio 0.738 (−2.64 dB) before, −0.16 dB after (residual = stochastic noise paths). This also explains why downstream users compensate with hardcoded gain hacks.

### 2. One-frame misalignment in `AdainResBlk1d` upsample path

torch uses `ConvTranspose1d(k=3, stride=2, groups=dim_in, padding=1, output_padding=1)`, which maps T→2T by trimming one sample from the **left** of the unpadded (2T+1) transpose-conv output. The port ran the transpose conv with `padding=1` (→ 2T−1) and **left**-zero-padded — shifting the residual branch one frame against the shortcut branch and replacing a computed tail sample with 0.

This block (with `upsample=True`) sits in `predictor.F0[1]`, `predictor.N[1]`, and `decoder.decode[3]`, i.e. directly in the pitch/energy contour path. Measured on identical inputs in fp32: `F0_pred` relRMSE **0.134** (corr 0.975) before → **0.0000** (corr 1.0000) after. Every block of `predictor.F0`/`predictor.N` is bit-clean against torch after this change.

### 3. `SineGen` initial harmonic phase distribution

Reference draws initial phase offsets with `torch.rand` (uniform [0,1)); the port used `mx.random.normal`. Uniform is the correct full-circle random phase.

### 4. `interpolate1d` negative source coordinates (align_corners=False)

With `align_corners=False`, the source coordinate for the first outputs is negative (e.g. −0.498 at scale 300, as used by the harmonic source upsampler). torch clamps to 0; here `floor(x) = −1` and MLX negative indexing **wraps to the last frame**, so the first half-frame interpolates against the end of the signal. Clamp to 0.

## Validation

- Layer probe: all decoder-upstream tensors (bert, encoders, durations, F0/N) now match the PyTorch reference at relRMSE ≤ 2e-3 (bf16) / 0.0 (fp32); durations identical.
- 55-utterance eval set rendered before/after and scored against frozen fp32 reference audio (paired log-mel L1, DTW-MCD, multi-res STFT, F0/VUV via pyworld, WavLM-SV speaker cosine), thresholds calibrated against the reference model's own render-to-render noise floor (the decoder is stochastic):
  - mel_l1 0.601 → 0.187 (floor 0.077)
  - MCD 7.29 dB → 4.09 dB (floor 1.86)
  - F0 RMSE 11.5 Hz → 5.1 Hz (floor 3.7)
  - speaker cosine 0.996 → 0.999 (floor 0.9997)
- Whisper-large-v3-turbo WER on the fixed stack matches the PyTorch reference within 0.04 pp on the same texts.
- Output length/durations unchanged by all four fixes; fixes 3 and 4 are measurement-neutral on the battery but correct the sampling semantics.

Happy to split this into separate PRs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
