### PR TITLE
fix(kokoro, kitten_tts): match PyTorch reference semantics in five decoder paths (-2.5 dB level error, F0-path misalignment, window mismatch)

### DIFF
--- a/mlx_audio/dsp.py
+++ b/mlx_audio/dsp.py
@@ -451,7 +451,11 @@ def istft(
         window: Window function name or array (default: "hann")
         center: If True, remove center padding (default: True)
         length: Target output length (default: None)
-        normalized: If True, use window squared (COLA) normalization. If False, use simple window normalization (default: True)
+        normalized: If True, divide the overlap-add by the summed squared
+            window (least-squares inversion, the division torch.istft always
+            performs). If False, divide by the summed window (default: False).
+            Note this is unrelated to torch.istft's `normalized` argument,
+            which selects FFT scaling.
 
     Returns:
         Reconstructed time-domain signal

--- a/mlx_audio/tts/models/interpolate.py
+++ b/mlx_audio/tts/models/interpolate.py
@@ -92,6 +92,11 @@ def interpolate1d(
             x = mx.arange(size) * (in_width / size)
             if not align_corners:
                 x = x + 0.5 * (in_width / size) - 0.5
+                # torch clamps source coords at 0. Without this, floor(x) = -1
+                # for the first outputs when upsampling, and the gather below
+                # reads an out-of-range index (observed as index -1, i.e. the
+                # last frame) instead of repeating the first frame.
+                x = mx.maximum(x, 0.0)
 
     # Handle the case where input width is 1
     if in_width == 1:

--- a/mlx_audio/tts/models/kitten_tts/istftnet.py
+++ b/mlx_audio/tts/models/kitten_tts/istftnet.py
@@ -471,7 +471,17 @@ class MLXSTFT:
         self.hop_length = hop_length
         self.win_length = win_length
 
-        self.window = window
+        # torch reference uses hann_window(win_length, periodic=True) for BOTH
+        # analysis and synthesis. Materialize it once: the string path in
+        # dsp.stft resolves "hann" to a SYMMETRIC window, while dsp.istft
+        # builds a periodic one — the mismatch breaks exact COLA inversion
+        # (~3% ripple) and skews the harmonic-source STFT features.
+        if isinstance(window, str):
+            if window.lower() not in ("hann", "hanning"):
+                raise ValueError(f"Unsupported window: {window}")
+            self.window = mx.array(np.hanning(win_length + 1)[:-1].astype(np.float32))
+        else:
+            self.window = window
 
     def transform(self, input_data):
         # Ensure 2D
@@ -572,7 +582,8 @@ class SineGen:
         # because 2 * np.pi * n doesn't affect phase
         rad_values = (f0_values / self.sampling_rate) % 1
         # initial phase noise (no noise for fundamental component)
-        rand_ini = mx.random.normal((f0_values.shape[0], f0_values.shape[2]))
+        # torch reference uses rand() — UNIFORM [0,1) phase offsets, not normal
+        rand_ini = mx.random.uniform(shape=(f0_values.shape[0], f0_values.shape[2]))
         rand_ini[:, 0] = 0
         rad_values[:, 0, :] = rad_values[:, 0, :] + rand_ini
         # instantanouse phase sine[t] = sin(2*pi \sum_i=1 ^{t} rad)
@@ -876,8 +887,10 @@ class AdainResBlk1d(nn.Module):
         if upsample == "none":
             self.pool = nn.Identity()
         else:
+            # Unpadded on purpose: _residual slices the (2T+1)-long output to
+            # emulate torch ConvTranspose1d(padding=1, output_padding=1).
             self.pool = ConvWeighted(
-                1, dim_in, kernel_size=3, stride=2, padding=1, groups=dim_in
+                1, dim_in, kernel_size=3, stride=2, padding=0, groups=dim_in
             )
 
     def _build_weights(self, dim_in, dim_out, style_dim):
@@ -905,11 +918,13 @@ class AdainResBlk1d(nn.Module):
         x = self.norm1(x, s)
         x = self.actv(x)
 
-        # Manually implement grouped ConvTranspose1d since MLX doesn't support groups
+        # torch ConvTranspose1d(k=3, stride=2, padding=1, output_padding=1)
+        # maps T -> 2T by trimming one sample from the LEFT of the unpadded
+        # (2T+1) transpose-conv output. Right-zero-padding a padding=1 output
+        # keeps the alignment but replaces the computed tail sample with 0.
         x = x.swapaxes(2, 1)
-        x = self.pool(x, mx.conv_transpose1d) if self.upsample_type != "none" else x
-        # Match ConvTranspose output_padding=1 by padding the right side.
-        x = mx.pad(x, ((0, 0), (0, 1), (0, 0))) if self.upsample_type != "none" else x
+        if self.upsample_type != "none":
+            x = self.pool(x, mx.conv_transpose1d)[:, 1:, :]
         x = x.swapaxes(2, 1)
 
         x = x.swapaxes(2, 1)

--- a/mlx_audio/tts/models/kitten_tts/istftnet.py
+++ b/mlx_audio/tts/models/kitten_tts/istftnet.py
@@ -3,8 +3,8 @@ from typing import List, Optional, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
-import numpy as np
 
+from mlx_audio.dsp import hanning
 from mlx_audio.utils import istft, stft
 
 from ..base import check_array_shape
@@ -479,7 +479,7 @@ class MLXSTFT:
         if isinstance(window, str):
             if window.lower() not in ("hann", "hanning"):
                 raise ValueError(f"Unsupported window: {window}")
-            self.window = mx.array(np.hanning(win_length + 1)[:-1].astype(np.float32))
+            self.window = hanning(win_length, periodic=True)
         else:
             self.window = window
 

--- a/mlx_audio/tts/models/kokoro/istftnet.py
+++ b/mlx_audio/tts/models/kokoro/istftnet.py
@@ -458,7 +458,17 @@ class MLXSTFT:
         self.hop_length = hop_length
         self.win_length = win_length
 
-        self.window = window
+        # torch reference uses hann_window(win_length, periodic=True) for BOTH
+        # analysis and synthesis. Materialize it once: the string path in
+        # dsp.stft resolves "hann" to a SYMMETRIC window, while dsp.istft
+        # builds a periodic one — the mismatch breaks exact COLA inversion
+        # (~3% ripple) and skews the harmonic-source STFT features.
+        if isinstance(window, str):
+            if window.lower() not in ("hann", "hanning"):
+                raise ValueError(f"Unsupported window: {window}")
+            self.window = mx.array(np.hanning(win_length + 1)[:-1].astype(np.float32))
+        else:
+            self.window = window
 
     def transform(self, input_data):
         # Ensure 2D
@@ -507,6 +517,12 @@ class MLXSTFT:
             x_stft = real_part + 1j * imag_part
 
             # Inverse STFT
+            # dsp.istft's `normalized` selects least-squares w^2 overlap-add
+            # normalization — the division torch.istft ALWAYS performs (it is
+            # unrelated to torch.istft's own `normalized` argument, which is
+            # FFT scaling). The plain-window default attenuates the waveform
+            # by sum(w^2)/sum(w) = 0.75 (-2.5 dB) for Kokoro's periodic-hann
+            # win=4*hop configuration.
             audio = istft(
                 x_stft,
                 hop_length=self.hop_length,
@@ -514,6 +530,7 @@ class MLXSTFT:
                 window=self.window,
                 center=True,
                 length=None,
+                normalized=True,
             )
 
             reconstructed.append(audio)
@@ -560,7 +577,8 @@ class SineGen:
         # because 2 * np.pi * n doesn't affect phase
         rad_values = (f0_values / self.sampling_rate) % 1
         # initial phase noise (no noise for fundamental component)
-        rand_ini = mx.random.normal((f0_values.shape[0], f0_values.shape[2]))
+        # torch reference uses rand() — UNIFORM [0,1) phase offsets, not normal
+        rand_ini = mx.random.uniform(shape=(f0_values.shape[0], f0_values.shape[2]))
         rand_ini[:, 0] = 0
         rad_values[:, 0, :] = rad_values[:, 0, :] + rand_ini
         # instantanouse phase sine[t] = sin(2*pi \sum_i=1 ^{t} rad)
@@ -856,8 +874,10 @@ class AdainResBlk1d(nn.Module):
         if upsample == "none":
             self.pool = nn.Identity()
         else:
+            # Unpadded on purpose: _residual slices the (2T+1)-long output to
+            # emulate torch ConvTranspose1d(padding=1, output_padding=1).
             self.pool = ConvWeighted(
-                1, dim_in, kernel_size=3, stride=2, padding=1, groups=dim_in
+                1, dim_in, kernel_size=3, stride=2, padding=0, groups=dim_in
             )
 
     def _build_weights(self, dim_in, dim_out, style_dim):
@@ -885,10 +905,14 @@ class AdainResBlk1d(nn.Module):
         x = self.norm1(x, s)
         x = self.actv(x)
 
-        # Manually implement grouped ConvTranspose1d since MLX doesn't support groups
+        # torch ConvTranspose1d(k=3, stride=2, padding=1, output_padding=1)
+        # maps T -> 2T by trimming one sample from the LEFT of the unpadded
+        # (2T+1) transpose-conv output. Left-zero-padding a padding=1 output
+        # instead shifts the residual branch one frame against the shortcut
+        # and replaces a computed tail sample with 0.
         x = x.swapaxes(2, 1)
-        x = self.pool(x, mx.conv_transpose1d) if self.upsample_type != "none" else x
-        x = mx.pad(x, ((0, 0), (1, 0), (0, 0))) if self.upsample_type != "none" else x
+        if self.upsample_type != "none":
+            x = self.pool(x, mx.conv_transpose1d)[:, 1:, :]
         x = x.swapaxes(2, 1)
 
         x = x.swapaxes(2, 1)

--- a/mlx_audio/tts/models/kokoro/istftnet.py
+++ b/mlx_audio/tts/models/kokoro/istftnet.py
@@ -3,8 +3,8 @@ from typing import List, Optional, Tuple, Union
 
 import mlx.core as mx
 import mlx.nn as nn
-import numpy as np
 
+from mlx_audio.dsp import hanning
 from mlx_audio.utils import istft, stft
 
 from ..base import check_array_shape
@@ -466,7 +466,7 @@ class MLXSTFT:
         if isinstance(window, str):
             if window.lower() not in ("hann", "hanning"):
                 raise ValueError(f"Unsupported window: {window}")
-            self.window = mx.array(np.hanning(win_length + 1)[:-1].astype(np.float32))
+            self.window = hanning(win_length, periodic=True)
         else:
             self.window = window
 

--- a/mlx_audio/tts/tests/test_interpolate.py
+++ b/mlx_audio/tts/tests/test_interpolate.py
@@ -73,8 +73,17 @@ class TestInterpolate(unittest.TestCase):
 
         # Test upsampling with align_corners=False
         result = interpolate1d(x, size=7, mode="linear", align_corners=False)
-        # Shape should be correct
         self.assertEqual(result.shape, (1, 1, 7))
+
+        # Values from torch.nn.functional.interpolate(..., align_corners=False).
+        # The first element must be 1.0: torch clamps the (negative) source
+        # coordinate of the first output at 0 instead of gathering index -1.
+        expected = mx.array(
+            np.array(
+                [[[1.0, 1.7142857, 2.8571429, 4.0, 5.1428576, 6.2857141, 7.0]]]
+            )
+        )
+        np.testing.assert_allclose(result.tolist(), expected.tolist(), rtol=1e-5)
 
         # Test edge case: input width = 1
         x_single = mx.array(np.array([[[5.0]]]))  # Shape: (1, 1, 1)

--- a/mlx_audio/tts/tests/test_interpolate.py
+++ b/mlx_audio/tts/tests/test_interpolate.py
@@ -79,9 +79,7 @@ class TestInterpolate(unittest.TestCase):
         # The first element must be 1.0: torch clamps the (negative) source
         # coordinate of the first output at 0 instead of gathering index -1.
         expected = mx.array(
-            np.array(
-                [[[1.0, 1.7142857, 2.8571429, 4.0, 5.1428576, 6.2857141, 7.0]]]
-            )
+            np.array([[[1.0, 1.7142857, 2.8571429, 4.0, 5.1428576, 6.2857141, 7.0]]])
         )
         np.testing.assert_allclose(result.tolist(), expected.tolist(), rtol=1e-5)
 

--- a/mlx_audio/tts/tests/test_istftnet_fidelity.py
+++ b/mlx_audio/tts/tests/test_istftnet_fidelity.py
@@ -1,0 +1,46 @@
+"""Fidelity regression tests for the iSTFTNet ports (kokoro / kitten_tts).
+
+Pins the two numerically-checkable divergences fixed against the PyTorch
+reference implementation: the grouped-ConvTranspose1d emulation alignment and
+the COLA (window-squared) iSTFT normalization.
+"""
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mlx_audio.tts.models.kitten_tts.istftnet import ConvWeighted as KittenConvWeighted
+from mlx_audio.tts.models.kitten_tts.istftnet import MLXSTFT as KittenMLXSTFT
+from mlx_audio.tts.models.kokoro.istftnet import ConvWeighted as KokoroConvWeighted
+from mlx_audio.tts.models.kokoro.istftnet import MLXSTFT as KokoroMLXSTFT
+
+
+@pytest.mark.parametrize("conv_cls", [KokoroConvWeighted, KittenConvWeighted])
+def test_conv_transpose_emulation_matches_torch(conv_cls):
+    # torch.nn.ConvTranspose1d(1, 1, 3, stride=2, padding=1, output_padding=1)
+    # with weight [1, 2, 3] and input [1, 2, 3, 4] yields the values below.
+    # The AdainResBlk1d pool emulates it as unpadded-conv-then-slice[1:].
+    conv = conv_cls(1, 1, kernel_size=3, stride=2, padding=0)
+    conv.weight_v = mx.array([1.0, 2.0, 3.0]).reshape(1, 3, 1)
+    conv.weight_g = mx.array([float(np.sqrt(14.0))]).reshape(1, 1, 1)
+
+    x = mx.array([1.0, 2.0, 3.0, 4.0]).reshape(1, 4, 1)  # (B, T, C)
+    out = conv(x, mx.conv_transpose1d)[:, 1:, :]
+
+    expected = [2.0, 5.0, 4.0, 9.0, 6.0, 13.0, 8.0, 12.0]
+    np.testing.assert_allclose(np.array(out).reshape(-1), expected, rtol=1e-4)
+
+
+@pytest.mark.parametrize("stft_cls", [KokoroMLXSTFT, KittenMLXSTFT])
+def test_mlxstft_roundtrip_preserves_amplitude(stft_cls):
+    # transform -> inverse must reconstruct the signal at unity gain.
+    # Plain-window (non-COLA) normalization reconstructs at sum(w^2)/sum(w)
+    # = 0.75 for this periodic-hann win=4*hop configuration.
+    stft = stft_cls(filter_length=20, hop_length=5, win_length=20)
+    t = np.arange(2000, dtype=np.float32)
+    x = (0.5 * np.sin(2 * np.pi * 220 * t / 24000)).astype(np.float32)
+
+    recon = np.array(stft.inverse(*stft.transform(mx.array(x)[None, :])))
+    recon = recon.reshape(-1)[: x.shape[0]]
+
+    np.testing.assert_allclose(recon[20:-20], x[20:-20], atol=1e-3)

--- a/mlx_audio/tts/tests/test_istftnet_fidelity.py
+++ b/mlx_audio/tts/tests/test_istftnet_fidelity.py
@@ -9,10 +9,10 @@ import mlx.core as mx
 import numpy as np
 import pytest
 
-from mlx_audio.tts.models.kitten_tts.istftnet import ConvWeighted as KittenConvWeighted
 from mlx_audio.tts.models.kitten_tts.istftnet import MLXSTFT as KittenMLXSTFT
-from mlx_audio.tts.models.kokoro.istftnet import ConvWeighted as KokoroConvWeighted
+from mlx_audio.tts.models.kitten_tts.istftnet import ConvWeighted as KittenConvWeighted
 from mlx_audio.tts.models.kokoro.istftnet import MLXSTFT as KokoroMLXSTFT
+from mlx_audio.tts.models.kokoro.istftnet import ConvWeighted as KokoroConvWeighted
 
 
 @pytest.mark.parametrize("conv_cls", [KokoroConvWeighted, KittenConvWeighted])


### PR DESCRIPTION
## Summary

Five places where the MLX iSTFTNet ports (kokoro, kitten_tts) diverge from the PyTorch reference (`hexgrad/kokoro`). Each was found by instrumenting both stacks layer-by-layer on identical phoneme/style inputs and comparing every intermediate tensor. Two are clearly audible; the rest are smaller semantic mismatches found on the way. Value-pinned regression tests included for the three numerically-checkable fixes.

### 1. Constant −2.5 dB output attenuation (`MLXSTFT.inverse`, kokoro)

`dsp.istft` defaults to `normalized=False` (overlap-add division by Σw). `torch.istft` always divides by Σw² (least-squares inversion — unrelated to torch.istft's own `normalized` argument, which is FFT scaling). For the periodic-hann, win = 4×hop configuration this is a constant amplitude factor of Σw²/Σw = 1.5/2.0 = **0.75 (−2.50 dB)**.

Measured: MLX/torch waveform RMS ratio 0.738 (−2.64 dB) before, −0.16 dB after (residual = stochastic noise paths). This also explains why downstream users compensate with hardcoded gain hacks.

**⚠️ User-facing change: all Kokoro output becomes ~2.5 dB louder (×4/3).** This restores the reference level the network was trained against (no clipping observed across a 55-utterance eval set; post-fix mean level ≈ −26 dB RMS on af_heart), but anyone with downstream loudness calibration or golden outputs will notice. kitten_tts already passed `normalized=True`.

### 2. Symmetric/periodic window mismatch (`MLXSTFT`, kokoro + kitten_tts)

The torch reference uses `hann_window(win, periodic=True)` for both analysis and synthesis. The MLX string path resolves `"hann"` to a **symmetric** window in `dsp.stft` while `dsp.istft` builds a **periodic** one. The mismatch breaks exact COLA inversion (~3% reconstruction ripple — caught by the new round-trip test) and skews the harmonic-source STFT features fed to the generator. `MLXSTFT` now materializes the periodic window once and passes it to both directions; `dsp.stft`'s string behavior is untouched (no blast radius onto other callers).

### 3. One-frame misalignment in `AdainResBlk1d` upsample path (kokoro + kitten_tts)

torch uses `ConvTranspose1d(k=3, stride=2, groups=dim_in, padding=1, output_padding=1)`, which maps T→2T by trimming one sample from the **left** of the unpadded (2T+1) transpose-conv output. The kokoro port ran the transpose conv with `padding=1` (→ 2T−1) and **left**-zero-padded — shifting the residual branch one frame against the shortcut and replacing a computed tail sample with 0. kitten_tts right-padded (aligned) but still zeroed the computed tail sample.

Both now build the pool conv with `padding=0` (construction-time, no runtime state mutation) and slice `[:, 1:, :]` — exact by derivation and pinned against torch constants in the new test.

This block sits in `predictor.F0[1]`, `predictor.N[1]`, and `decoder.decode[3]` — directly in the pitch/energy contour path. Measured on identical inputs in fp32 (kokoro): `F0_pred` relRMSE **0.134** (corr 0.975) before → **0.0000** (corr 1.0000) after.

### 4. `SineGen` initial harmonic phase distribution (kokoro + kitten_tts)

Reference draws initial phase offsets with `torch.rand` (uniform [0,1)); the ports used `mx.random.normal`. Uniform is the correct full-circle random phase.

### 5. `interpolate1d` negative source coordinates (shared `tts/models/interpolate.py`)

With `align_corners=False`, the source coordinate for the first outputs is negative (e.g. −0.498 at scale 300, as used by the harmonic-source upsampler). torch clamps to 0; here `floor(x) = −1` and the gather read an out-of-range index (observed as the last frame), so the first half-frame interpolated against the end of the signal. Clamped to 0.

**Note:** this is a shared utility — the clamp corrects output for every linear/`align_corners=False` caller (kokoro, kitten_tts, soprano), not just kokoro.

## Tests

`mlx_audio/tts/tests/test_istftnet_fidelity.py` (new, parametrized over kokoro + kitten_tts):
- transpose-conv emulation vs pinned `torch.nn.ConvTranspose1d(k=3, s=2, p=1, op=1)` constants
- `MLXSTFT` transform→inverse round trip at unity gain (old code reconstructs at 0.75×)

`test_interpolate.py`: the existing `align_corners=False` case asserted only the output *shape* (which is how the wrap bug survived); it now pins values from `torch.nn.functional.interpolate` — first element must be 1.0, old code produced 2.5.

Full `mlx_audio/tts/tests` suite passes (586 passed; `TestSparkTTSModel::test_init` fails identically on clean main — pre-existing, unrelated).

## Validation beyond unit tests

- Layer probe vs PyTorch `kokoro` (fp32 weights `prince-canuma/Kokoro-82M`, torch 2.12.1, kokoro 0.9.4, misaki 0.9.4): all decoder-upstream tensors match at relRMSE ≤ 2e-3 (bf16) / 0.0 (fp32); predicted durations identical.
- 55-utterance eval battery against frozen fp32 reference audio (paired log-mel L1, DTW-MCD, multi-res STFT, F0/VUV via pyworld, WavLM-SV speaker cosine), thresholds calibrated against the reference model's own render-to-render noise floor (the decoder is stochastic): mel_l1 0.601 → 0.187 (floor 0.077), MCD 7.29 → 4.09 dB (floor 1.86), F0 RMSE 11.5 → 5.1 Hz (floor 3.7), speaker cosine 0.996 → 0.999 (floor 0.9997).
- Whisper-large-v3-turbo WER on the fixed stack matches the PyTorch reference within 0.04 pp on the same texts.
- Output durations are unchanged by all five fixes.

## Scope notes

- Other `dsp.istft` callers (soprano, vocos, deepfilternet, lfm_audio, …) still use the plain-Σw default and were **not** audited here; if they were trained against `torch.istft`, they may carry the same 0.75× attenuation. Flagging rather than changing, since each model has its own training convention.
- Happy to split this into separate PRs if preferred.
