### PR TITLE
Eval all cache arrays before moving streams

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.2.0
+    rev: 26.3.1
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort

--- a/mlx_audio/codec/tests/test_encodec.py
+++ b/mlx_audio/codec/tests/test_encodec.py
@@ -40,14 +40,14 @@ class TestEncodec(unittest.TestCase):
         audio = mx.zeros((1, 120_000, 1))
 
         # default bandwidth
-        (codes, scales) = model.encode(audio)
+        codes, scales = model.encode(audio)
         self.assertEqual(codes.shape, (1, 1, 2, 375))
 
         audio_out = model.decode(codes, scales)
         self.assertEqual(audio_out.shape, (1, 120_000, 1))
 
         # 6kbps bandwidth
-        (codes, scales) = model.encode(audio, bandwidth=6)
+        codes, scales = model.encode(audio, bandwidth=6)
         self.assertEqual(codes.shape, (1, 1, 8, 375))
 
         audio_out = model.decode(codes, scales)

--- a/mlx_audio/convert.py
+++ b/mlx_audio/convert.py
@@ -395,8 +395,7 @@ def generate_readme_content(
     tags = ["mlx"] + config.tags
     tags.append("mlx-audio")
 
-    content = dedent(
-        f"""\
+    content = dedent(f"""\
         # {upload_repo}
 
         This model was converted to MLX format from [`{hf_path}`](https://huggingface.co/{hf_path}) using mlx-audio version **{__version__}**.
@@ -418,8 +417,7 @@ def generate_readme_content(
         ```python\
         {config.python_example.format(repo=upload_repo)}
         ```
-        """
-    )
+        """)
 
     return tags, content
 

--- a/mlx_audio/stt/models/canary/decoder.py
+++ b/mlx_audio/stt/models/canary/decoder.py
@@ -166,6 +166,7 @@ class FixedPositionalEncoding(nn.Module):
             max_len, d_model
         )
         self._pos_enc = pos_enc / math.sqrt(d_model)
+        mx.eval(self._pos_enc)
 
     def __call__(self, position_ids: mx.array) -> mx.array:
         """Get position embeddings for the given position IDs."""

--- a/mlx_audio/stt/models/cohere_asr/audio.py
+++ b/mlx_audio/stt/models/cohere_asr/audio.py
@@ -22,6 +22,7 @@ class CohereAudioFrontend:
             norm="slaney",
             mel_scale="slaney",
         ).astype(mx.float32)
+        mx.eval(self.window, self.fb)
 
     def _build_window(self) -> mx.array:
         window_fn = STR_TO_WINDOW_FN.get(self.config.window, None)
@@ -64,6 +65,8 @@ class CohereAudioFrontend:
         win_key = "preprocessor.featurizer.window"
         if win_key in weights:
             self.window = weights[win_key].astype(mx.float32)
+
+        mx.eval(self.window, self.fb)
 
     def _normalize_waveform(self, waveform: Union[mx.array, np.ndarray]) -> mx.array:
         if isinstance(waveform, mx.array):

--- a/mlx_audio/stt/models/cohere_asr/cohere_asr.py
+++ b/mlx_audio/stt/models/cohere_asr/cohere_asr.py
@@ -119,6 +119,7 @@ class RelPositionalEncoding(nn.Module):
         pe[:, 0::2] = mx.sin(positions * div_term)
         pe[:, 1::2] = mx.cos(positions * div_term)
         self._pe = mx.expand_dims(pe, axis=0)
+        mx.eval(self._pe)
 
     def __call__(self, x: mx.array) -> Tuple[mx.array, mx.array]:
         if x.shape[1] > self.max_len:

--- a/mlx_audio/stt/models/granite_speech/granite_speech.py
+++ b/mlx_audio/stt/models/granite_speech/granite_speech.py
@@ -220,6 +220,7 @@ class CTCEncoder(nn.Module):
             mx.clip(relpos_dist, -config.context_size, config.context_size)
             + config.max_pos_emb
         )
+        mx.eval(self._attention_dists)
 
     def __call__(self, x: mx.array) -> mx.array:
         x = self.input_linear(x)

--- a/mlx_audio/stt/models/granite_speech_nar/encoder.py
+++ b/mlx_audio/stt/models/granite_speech_nar/encoder.py
@@ -75,6 +75,7 @@ class ConformerAttention(nn.Module):
         dist = idx[:, None] - idx[None, :]
         dist = mx.clip(dist, -context_size, context_size) + max_pos_emb
         self._dist = dist  # shape [ctx, ctx], int
+        mx.eval(self._dist)
 
     def __call__(self, x: mx.array) -> mx.array:
         B, T, H = x.shape

--- a/mlx_audio/stt/models/granite_speech_nar/granite_speech_nar.py
+++ b/mlx_audio/stt/models/granite_speech_nar/granite_speech_nar.py
@@ -52,6 +52,7 @@ _WINDOW = mx.concatenate(
     ]
 )
 _MEL_T = dsp.mel_filters(SAMPLING_RATE, N_FFT, N_MELS, precise=True).T
+mx.eval(_WINDOW, _MEL_T)
 
 
 def _compute_features(waveform: mx.array) -> mx.array:

--- a/mlx_audio/stt/models/mega_asr/mega_asr.py
+++ b/mlx_audio/stt/models/mega_asr/mega_asr.py
@@ -76,6 +76,7 @@ class Model:
         if lora_path.exists():
             model._deltas = load_lora_factors(lora_path)
 
+        mx.eval(model._router.parameters(), model._deltas)
         return model
 
     def _set_lora(self, want: bool) -> None:

--- a/mlx_audio/stt/models/moonshine/moonshine.py
+++ b/mlx_audio/stt/models/moonshine/moonshine.py
@@ -16,6 +16,7 @@ class MoonshineRotaryEmbedding(nn.Module):
         super().__init__()
         inv_freq = 1.0 / (base ** (mx.arange(0, dim, 2, dtype=mx.float32) / dim))
         self._inv_freq = inv_freq  # shape: (dim // 2,)
+        mx.eval(self._inv_freq)
         self._dim = dim
         self._max_seq_len = max_position_embeddings
 

--- a/mlx_audio/stt/models/moss_music/audio.py
+++ b/mlx_audio/stt/models/moss_music/audio.py
@@ -31,6 +31,7 @@ class MossMusicFeatureExtractor:
             mel_scale="slaney",
             precise=True,
         ).astype(mx.float32)
+        mx.eval(self.window, self.filters)
 
     def _normalize_waveform(self, audio: Union[mx.array, np.ndarray]) -> mx.array:
         if isinstance(audio, mx.array):

--- a/mlx_audio/stt/models/moss_music/moss_music.py
+++ b/mlx_audio/stt/models/moss_music/moss_music.py
@@ -148,6 +148,7 @@ class MossMusicEncoder(nn.Module):
             )
         }
         self._embed_positions = sinusoids(config.max_source_positions, config.d_model)
+        mx.eval(self._embed_positions)
 
     @staticmethod
     def compute_downsampled_length(length: int) -> int:
@@ -355,6 +356,7 @@ class Model(nn.Module):
                 model.audio_encoder.conv1.weight.dtype
             )
         )
+        mx.eval(model.audio_encoder._embed_positions)
         return model
 
     def _ensure_processor(self) -> MossMusicProcessor:

--- a/mlx_audio/stt/models/qwen2_audio/qwen2_audio.py
+++ b/mlx_audio/stt/models/qwen2_audio/qwen2_audio.py
@@ -112,6 +112,7 @@ class Qwen2AudioEncoder(nn.Module):
         self._embed_positions = sinusoids(
             config.max_source_positions + 1, config.d_model
         )
+        mx.eval(self._embed_positions)
 
     @property
     def embed_positions(self) -> mx.array:
@@ -301,6 +302,7 @@ class Model(nn.Module):
 
         enc = model.audio_tower
         enc._embed_positions = enc._embed_positions.astype(enc.conv1.weight.dtype)
+        mx.eval(enc._embed_positions)
 
         return model
 

--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -188,6 +188,7 @@ class SinusoidalPositionEmbedding(nn.Module):
         self._positional_embedding = mx.concatenate(
             [mx.sin(scaled_time), mx.cos(scaled_time)], axis=1
         )
+        mx.eval(self._positional_embedding)
 
     def __call__(self, seqlen: int) -> mx.array:
         return self._positional_embedding[:seqlen, :]

--- a/mlx_audio/stt/models/whisper/whisper.py
+++ b/mlx_audio/stt/models/whisper/whisper.py
@@ -420,6 +420,7 @@ class AudioEncoder(nn.Module):
         self.conv1 = nn.Conv1d(n_mels, n_state, kernel_size=3, padding=1)
         self.conv2 = nn.Conv1d(n_state, n_state, kernel_size=3, stride=2, padding=1)
         self._positional_embedding = sinusoids(n_ctx, n_state).astype(dtype)
+        mx.eval(self._positional_embedding)
 
         self.blocks = [ResidualAttentionBlock(n_state, n_head) for _ in range(n_layer)]
         self.ln_post = nn.LayerNorm(n_state)
@@ -460,6 +461,7 @@ class TextDecoder(nn.Module):
         self._mask = nn.MultiHeadAttention.create_additive_causal_mask(n_ctx).astype(
             dtype
         )
+        mx.eval(self._mask)
 
     def __call__(self, x, xa, kv_cache=None):
         """

--- a/mlx_audio/stt/tests/mega_asr/fixtures/dump_router_keys.py
+++ b/mlx_audio/stt/tests/mega_asr/fixtures/dump_router_keys.py
@@ -12,6 +12,7 @@ If no path is given, falls back to the HF cache copy of
 Writes `router_state_dict_keys.json` next to this script and prints a summary
 (d_model, num transformer layers, conv layout, classifier head dims).
 """
+
 from __future__ import annotations
 
 import json

--- a/mlx_audio/stt/tests/test_buffer_materialization.py
+++ b/mlx_audio/stt/tests/test_buffer_materialization.py
@@ -1,0 +1,138 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import mlx.core as mx
+import pytest
+
+from mlx_audio.stt.models.canary.decoder import FixedPositionalEncoding
+from mlx_audio.stt.models.cohere_asr.audio import CohereAudioFrontend
+from mlx_audio.stt.models.cohere_asr.cohere_asr import RelPositionalEncoding
+from mlx_audio.stt.models.cohere_asr.config import PreprocessorConfig
+from mlx_audio.stt.models.granite_speech.config import EncoderConfig as GraniteConfig
+from mlx_audio.stt.models.granite_speech.granite_speech import CTCEncoder
+from mlx_audio.stt.models.granite_speech_nar import granite_speech_nar
+from mlx_audio.stt.models.granite_speech_nar.encoder import ConformerAttention
+from mlx_audio.stt.models.moonshine.moonshine import MoonshineRotaryEmbedding
+from mlx_audio.stt.models.moss_music.audio import MossMusicFeatureExtractor
+from mlx_audio.stt.models.moss_music.config import AudioEncoderConfig as MossConfig
+from mlx_audio.stt.models.moss_music.moss_music import MossMusicEncoder
+from mlx_audio.stt.models.qwen2_audio.config import EncoderConfig as Qwen2Config
+from mlx_audio.stt.models.qwen2_audio.qwen2_audio import Qwen2AudioEncoder
+from mlx_audio.stt.models.qwen3_asr.qwen3_asr import SinusoidalPositionEmbedding
+from mlx_audio.stt.models.whisper.whisper import AudioEncoder, TextDecoder
+
+
+def _qwen3_buffers():
+    embedding = SinusoidalPositionEmbedding(32, 16)
+    return [embedding._positional_embedding]
+
+
+def _qwen2_buffers():
+    encoder = Qwen2AudioEncoder(
+        Qwen2Config(
+            d_model=16,
+            encoder_layers=0,
+            encoder_attention_heads=2,
+            encoder_ffn_dim=32,
+            num_mel_bins=8,
+            max_source_positions=32,
+        )
+    )
+    return [encoder._embed_positions]
+
+
+def _whisper_buffers():
+    encoder = AudioEncoder(8, 16, 16, 2, 0)
+    decoder = TextDecoder(32, 16, 16, 2, 0)
+    return [encoder._positional_embedding, decoder._mask]
+
+
+def _moonshine_buffers():
+    rope = MoonshineRotaryEmbedding(16)
+    return [rope._inv_freq]
+
+
+def _moss_buffers():
+    encoder = MossMusicEncoder(
+        MossConfig(
+            d_model=16,
+            output_dim=16,
+            num_mel_bins=8,
+            encoder_layers=0,
+            encoder_attention_heads=2,
+            encoder_ffn_dim=32,
+            downsample_hidden_size=4,
+            max_source_positions=32,
+            deepstack_encoder_layer_indexes=[],
+        )
+    )
+    extractor = MossMusicFeatureExtractor(num_mel_bins=8, n_fft=32)
+    return [encoder._embed_positions, extractor.window, extractor.filters]
+
+
+def _canary_buffers():
+    encoding = FixedPositionalEncoding(16, 32)
+    return [encoding._pos_enc]
+
+
+def _cohere_buffers():
+    encoding = RelPositionalEncoding(16, 32)
+    frontend = CohereAudioFrontend(
+        PreprocessorConfig(features=8, n_fft=32, window_size=0.001)
+    )
+    return [encoding._pe, frontend.window, frontend.fb]
+
+
+def _granite_buffers():
+    encoder = CTCEncoder(
+        GraniteConfig(
+            input_dim=4,
+            num_layers=0,
+            hidden_dim=8,
+            num_heads=2,
+            dim_head=4,
+            output_dim=4,
+            context_size=8,
+            max_pos_emb=16,
+        )
+    )
+    return [encoder._attention_dists]
+
+
+def _granite_nar_buffers():
+    attention = ConformerAttention(
+        hidden_dim=16,
+        num_heads=2,
+        dim_head=8,
+        max_pos_emb=32,
+        context_size=16,
+    )
+    return [attention._dist]
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        _qwen3_buffers,
+        _qwen2_buffers,
+        _whisper_buffers,
+        _moonshine_buffers,
+        _moss_buffers,
+        _canary_buffers,
+        _cohere_buffers,
+        _granite_buffers,
+        _granite_nar_buffers,
+    ],
+)
+def test_fixed_buffers_can_cross_threads(factory):
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        buffers = executor.submit(factory).result()
+
+    mx.eval(*[buffer + 0 for buffer in buffers])
+
+
+def test_granite_nar_module_buffers_can_cross_threads():
+    def evaluate():
+        mx.eval(granite_speech_nar._WINDOW + 0, granite_speech_nar._MEL_T + 0)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(evaluate).result()

--- a/mlx_audio/tts/models/confucius4/confucius4.py
+++ b/mlx_audio/tts/models/confucius4/confucius4.py
@@ -4,6 +4,7 @@
 Pipeline: w2v-bert semantic features + CAMPPlus speaker emb -> T2S (GPT-2) ->
 S2A flow-matching (DiT+WaveNet) -> BigVGAN vocoder. All MLX; ref-mel DSP numpy.
 """
+
 import time
 from dataclasses import dataclass
 from pathlib import Path

--- a/mlx_audio/tts/models/confucius4/convert.py
+++ b/mlx_audio/tts/models/confucius4/convert.py
@@ -4,6 +4,7 @@ torch is used ONLY here (conversion), never at inference.
 
     python -m mlx_audio.tts.models.confucius4.convert --out ./confucius4-model
 """
+
 import argparse
 import glob
 from pathlib import Path

--- a/mlx_audio/tts/models/confucius4/features.py
+++ b/mlx_audio/tts/models/confucius4/features.py
@@ -7,6 +7,7 @@ Reimplements transformers' SeamlessM4TFeatureExtractor: povey window, remove-dc
 convert time (fbank_filters.npz). Validated to ~1e-6 vs transformers; the MLX
 path matches that reference to float32 precision.
 """
+
 import mlx.core as mx
 
 FRAME, HOP, NFFT, MEL_FLOOR = 400, 160, 512, 1.192092955078125e-07

--- a/mlx_audio/tts/models/confucius4/prefix.py
+++ b/mlx_audio/tts/models/confucius4/prefix.py
@@ -6,6 +6,7 @@ Produces the [condition_emb | text_emb] prefix from (w2v condition_vector, token
 so the T2S decode no longer needs the torch prefix. Weights read from
 t2s_model.safetensors (text_projector.*, speaker_encoder.*, text_position_embedding.*).
 """
+
 import mlx.core as mx
 
 from .t2s import find_ckpt

--- a/mlx_audio/tts/models/confucius4/s2a.py
+++ b/mlx_audio/tts/models/confucius4/s2a.py
@@ -6,6 +6,7 @@ Validate-driven: phan DiT estimator truoc (RoPE interleaved fp32, adaLN/RMSNorm,
 SwiGLU, U-Net skip, WaveNet gated). Weights: b2/s2a_mlx.safetensors (weight_norm
 da fold, layout torch giu nguyen: Linear (out,in), Conv1d (out,in,k)).
 """
+
 import math
 import os
 

--- a/mlx_audio/tts/models/confucius4/t2s.py
+++ b/mlx_audio/tts/models/confucius4/t2s.py
@@ -7,6 +7,7 @@ final_norm + semantic_head. Prefix (speaker/text encoder) van do torch tinh o
 B1 de co lap phep toan GPT-2. Weight doc thang tu t2s_model.safetensors (F32,
 GPT-2 Conv1D layout [in,out]).
 """
+
 import math
 import os
 

--- a/mlx_audio/tts/models/confucius4/vocoder.py
+++ b/mlx_audio/tts/models/confucius4/vocoder.py
@@ -6,6 +6,7 @@ snakebeta logscale + anti-aliased activation (upsample->snake->downsample with
 fixed FIR filters). Weights b2/bigvgan_mlx.safetensors (weight_norm folded).
 Config: ups [4,4,2,2,2,2], init ch 1536, resblock k[3,7,11] dil[1,3,5].
 """
+
 import os
 
 import mlx.core as mx

--- a/mlx_audio/tts/models/confucius4/w2vbert.py
+++ b/mlx_audio/tts/models/confucius4/w2vbert.py
@@ -6,6 +6,7 @@ feature_projection + 17 conformer layers. Each layer: ffn1(*0.5) -> self_attn
 (relative_key) -> conv_module (causal depthwise) -> ffn2(*0.5) -> final LN.
 Weights: b4/w2vbert_mlx.safetensors (fp32, torch layout).
 """
+
 import math
 import os
 

--- a/mlx_audio/tts/models/spark/modules/speaker/ecapa_tdnn.py
+++ b/mlx_audio/tts/models/spark/modules/speaker/ecapa_tdnn.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" This implementation is adapted from github repo:
-    https://github.com/lawlict/ECAPA-TDNN.
+"""This implementation is adapted from github repo:
+https://github.com/lawlict/ECAPA-TDNN.
 """
 
 import mlx.core as mx

--- a/mlx_audio/tts/models/spark/modules/speaker/pooling_layers.py
+++ b/mlx_audio/tts/models/spark/modules/speaker/pooling_layers.py
@@ -18,6 +18,7 @@ into segment-level speaker embeddings
 High-order statistics are surprisingly effective, TSDP acts similarly as TSTP,
 even though we remove the mean statistic, on Voxceleb.
 """
+
 import mlx.core as mx
 import mlx.nn as nn
 

--- a/mlx_audio/tts/utils.py
+++ b/mlx_audio/tts/utils.py
@@ -180,8 +180,7 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
 
     card = ModelCard.load(hf_path)
     card.data.tags = ["mlx"] if card.data.tags is None else card.data.tags + ["mlx"]
-    card.text = dedent(
-        f"""
+    card.text = dedent(f"""
         # {upload_repo}
         This model was converted to MLX format from [`{hf_path}`](https://huggingface.co/{hf_path}) using mlx-audio version **{__version__}**.
         Refer to the [original model card](https://huggingface.co/{hf_path}) for more details on the model.
@@ -194,8 +193,7 @@ def upload_to_hub(path: str, upload_repo: str, hf_path: str):
         ```bash
         python -m mlx_audio.tts.generate --model {upload_repo} --text "Describe this image."
         ```
-        """
-    )
+        """)
     card.save(os.path.join(path, "README.md"))
 
     logging.set_verbosity_info()


### PR DESCRIPTION
Reported in https://github.com/Blaizzy/mlx-audio/pull/857. This is a more correct fix to make sure the models themselves evaluate all of their non-Module mx.array caches before moving streams.

Note I bumped the formatter version hence the minor whitespace changes (needed to clear CI).