### PR TITLE
Fix MLX server thread ownership for model loading

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -250,7 +250,17 @@ async def _preflight_model_load(model_name: str) -> None:
     response. Warm models are a no-op (``ModelProvider.load_model`` is cached).
     """
     try:
-        await asyncio.to_thread(_load_model_for_inference, model_name)
+        handle = get_inference_broker().submit(
+            endpoint_kind="model-load",
+            model_name=model_name,
+            payload=None,
+        )
+        while True:
+            chunk = await _next_inference_chunk(handle)
+            if chunk.kind == "error":
+                raise chunk.error
+            if chunk.kind == "done":
+                break
     except HTTPException:
         raise
     except RepositoryNotFoundError as exc:
@@ -315,6 +325,12 @@ class STTExecutionAdapter(BaseModelExecutionAdapter):
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
 
+        request.emit_done()
+
+
+class ModelLoadExecutionAdapter(BaseModelExecutionAdapter):
+    def run_serial(self, request: InferenceRequest) -> None:
+        _load_model_for_inference(request.model_name)
         request.emit_done()
 
 
@@ -824,6 +840,7 @@ def get_inference_broker() -> InferenceBroker:
     global INFERENCE_BROKER
     if INFERENCE_BROKER is None:
         broker = InferenceBroker()
+        broker.register_adapter("model-load", ModelLoadExecutionAdapter())
         broker.register_adapter("stt", STTExecutionAdapter())
         broker.register_adapter("tts", TTSExecutionAdapter())
         broker.register_adapter("separation", SeparationExecutionAdapter())

--- a/mlx_audio/server_inference.py
+++ b/mlx_audio/server_inference.py
@@ -8,6 +8,8 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Optional, Protocol
 
+import mlx.core as mx
+
 
 @dataclass
 class InferenceResultChunk:
@@ -191,6 +193,13 @@ class InferenceBroker:
         )
 
     def _run(self) -> None:
+        # MLX default streams are thread-local. The inference broker owns all
+        # model execution on this worker, so create its CPU/GPU streams here
+        # rather than inheriting streams from the ASGI or model-load threads.
+        worker_streams = [mx.new_stream(mx.cpu), mx.new_stream(mx.gpu)]
+        for stream in worker_streams:
+            mx.set_default_stream(stream)
+
         pending: list[InferenceRequest] = []
         try:
             while not self._stop.is_set():

--- a/mlx_audio/tests/test_server_inference.py
+++ b/mlx_audio/tests/test_server_inference.py
@@ -1,6 +1,8 @@
 import threading
 import time
 
+import mlx.core as mx
+
 from mlx_audio.server_inference import (
     BaseModelExecutionAdapter,
     InferenceBroker,
@@ -98,6 +100,13 @@ class ContinuousAdapter(BaseModelExecutionAdapter):
         request.emit_done()
 
 
+class MlxWorkerAdapter(BaseModelExecutionAdapter):
+    def run_serial(self, request: InferenceRequest) -> None:
+        value = int(mx.array([request.payload])[0].item())
+        request.emit_data(value)
+        request.emit_done()
+
+
 def test_inference_broker_serializes_requests():
     broker = InferenceBroker()
     adapter = SerializedAdapter()
@@ -118,6 +127,24 @@ def test_inference_broker_serializes_requests():
         assert _collect(first)[0].payload == "first"
         assert _collect(second)[0].payload == "second"
         assert adapter.max_active == 1
+    finally:
+        broker.stop_and_join()
+
+
+def test_inference_broker_initializes_thread_local_mlx_streams():
+    broker = InferenceBroker()
+    broker.register_adapter("mlx", MlxWorkerAdapter())
+
+    try:
+        handle = broker.submit(
+            endpoint_kind="mlx",
+            model_name="model-a",
+            payload=42,
+        )
+
+        chunks = _collect(handle)
+        assert chunks[0].kind == "data"
+        assert chunks[0].payload == 42
     finally:
         broker.stop_and_join()
 


### PR DESCRIPTION
## Summary

Fixes the OpenAI-compatible server path so MLX models are loaded and executed on the same broker-owned thread.

`mlx_audio.server` currently preloads a model with `asyncio.to_thread()`, caches the resulting MLX objects, then executes generation on `InferenceBroker._run`. MLX streams are thread-local, so Fish S2 Pro and other models can fail after the server has already returned HTTP 200 with:

```text
RuntimeError: There is no Stream(gpu, N) in current thread.
```

The broker now initializes its CPU and GPU default streams on its own thread, and model preflight is submitted through a small broker adapter. This preserves the useful pre-header 404/500 behavior while keeping model creation and inference under one MLX thread owner.

Related: #744, #787, #794, #798

## Evidence

- `uv run --with pytest --with pytest-asyncio pytest -q mlx_audio/tests/test_server_inference.py mlx_audio/tests/test_server.py`: 31 passed.
- Added a regression that executes an eager MLX `.item()` operation inside the broker worker.
- Before: `POST /v1/audio/speech` with `mlx-community/fish-audio-s2-pro-8bit` returned HTTP 200, then closed the body with `There is no Stream(gpu, 0) in current thread`.
- After: the same request, including reference audio, returned a valid 44.1 kHz mono WAV (4.83 seconds, 426,028 bytes).
- `git diff --check`: clean.
