### PR TITLE
Add a registry to classify supported audio models by kind

### DIFF
--- a/mlx_audio/registry.py
+++ b/mlx_audio/registry.py
@@ -1,0 +1,147 @@
+"""Lightweight, import-free classification of the audio models mlx-audio supports.
+
+Every model architecture lives under ``mlx_audio/<kind>/models/<family>`` (``tts``,
+``stt``, ``sts``, ``codec``, …), and each ``<kind>/utils.py`` carries a
+``MODEL_REMAPPING`` that aliases config ``model_type`` values onto those families.
+This module surfaces that organisation as data so callers can ask "what kind of
+audio model is this?" without importing mlx or any model code.
+"""
+
+from __future__ import annotations
+
+import ast
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, FrozenSet, List, Optional, Tuple
+
+_ROOT = Path(__file__).resolve().parent
+
+# User-facing voice kinds first so an ambiguous type resolves to the kind a person
+# would actually pick; remaining kinds (codec, …) follow.
+_PREFERRED_ORDER = ("tts", "stt", "sts")
+
+# Generic backbones that also ship as audio sub-models. A bare ``model_type`` of
+# these is far more likely a plain LLM, so they only classify as audio via an
+# explicit, audio-specific remapping alias (e.g. ``qwen3_tts``), never by name.
+_AMBIGUOUS_FAMILIES = frozenset({"llama", "qwen3", "dense"})
+
+
+@lru_cache(maxsize=None)
+def kinds() -> Tuple[str, ...]:
+    """All model kinds that ship a ``models/`` directory, voice kinds first."""
+    discovered = {
+        path.name
+        for path in _ROOT.iterdir()
+        if path.is_dir()
+        and not path.name.startswith("__")
+        and (path / "models").is_dir()
+    }
+    preferred = [kind for kind in _PREFERRED_ORDER if kind in discovered]
+    rest = sorted(discovered - set(preferred))
+    return tuple(preferred + rest)
+
+
+@lru_cache(maxsize=None)
+def _families(kind: str) -> FrozenSet[str]:
+    models_dir = _ROOT / kind / "models"
+    if not models_dir.is_dir():
+        return frozenset()
+    return frozenset(
+        path.name
+        for path in models_dir.iterdir()
+        if path.is_dir() and not path.name.startswith("__")
+    )
+
+
+@lru_cache(maxsize=None)
+def _remapping(kind: str) -> Dict[str, str]:
+    source = _ROOT / kind / "utils.py"
+    if not source.is_file():
+        return {}
+    try:
+        tree = ast.parse(source.read_text())
+    except (OSError, SyntaxError):
+        return {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "MODEL_REMAPPING"
+            for target in node.targets
+        ):
+            continue
+        try:
+            value = ast.literal_eval(node.value)
+        except (ValueError, SyntaxError):
+            return {}
+        return {str(k).lower(): str(v).lower() for k, v in value.items()}
+    return {}
+
+
+@lru_cache(maxsize=None)
+def supported_model_types(kind: str) -> FrozenSet[str]:
+    """Every ``model_type`` the given kind accepts: families and remapping aliases."""
+    remap = _remapping(kind)
+    return _families(kind) | frozenset(remap) | frozenset(remap.values())
+
+
+def _segments(name: str) -> List[str]:
+    lowered = name.lower()
+    for separator in "/\\-_. ":
+        lowered = lowered.replace(separator, " ")
+    return [segment for segment in lowered.split() if segment]
+
+
+@lru_cache(maxsize=None)
+def _matchable_families(kind: str) -> FrozenSet[str]:
+    return _families(kind) - _AMBIGUOUS_FAMILIES
+
+
+def _matches(kind: str, model_type: str, segments: List[str]) -> bool:
+    families = _matchable_families(kind)
+    remap = _remapping(kind)
+    if model_type and remap.get(model_type, model_type) in families:
+        return True
+    return any(
+        remap.get(segment, segment) in families or segment in remap
+        for segment in segments
+    )
+
+
+def classify_model(model_type: str, model_name: str = "") -> Optional[str]:
+    """Resolve a config ``model_type`` (and optional repo name) to its audio kind.
+
+    Returns a kind such as ``"tts"``, ``"stt"`` or ``"sts"``, or ``None`` when the
+    model is not a supported audio model. Mirrors the resolution mlx-audio uses when
+    loading: exact ``model_type``, then a single family match, then repo-name hints.
+    """
+    model_type = (model_type or "").strip().lower()
+    available = kinds()
+
+    for kind in available:
+        if model_type and model_type in _remapping(kind):
+            return kind
+
+    folder_hits = [
+        kind for kind in available if model_type and model_type in _matchable_families(kind)
+    ]
+    if len(folder_hits) == 1:
+        return folder_hits[0]
+
+    segments = _segments(model_name)
+    for kind in available:
+        if _matches(kind, model_type, segments):
+            return kind
+
+    return None
+
+
+def is_supported_model(model_type: str, model_name: str = "") -> bool:
+    """Whether mlx-audio can serve the given model as any audio kind."""
+    return classify_model(model_type, model_name) is not None
+
+
+#: ``{kind: frozenset(model_types)}`` for every discovered kind.
+SUPPORTED_MODEL_TYPES: Dict[str, FrozenSet[str]] = {
+    kind: supported_model_types(kind) for kind in kinds()
+}

--- a/mlx_audio/registry.py
+++ b/mlx_audio/registry.py
@@ -123,7 +123,9 @@ def classify_model(model_type: str, model_name: str = "") -> Optional[str]:
             return kind
 
     folder_hits = [
-        kind for kind in available if model_type and model_type in _matchable_families(kind)
+        kind
+        for kind in available
+        if model_type and model_type in _matchable_families(kind)
     ]
     if len(folder_hits) == 1:
         return folder_hits[0]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,51 @@
+from mlx_audio.registry import (
+    SUPPORTED_MODEL_TYPES,
+    classify_model,
+    is_supported_model,
+    kinds,
+)
+
+
+def test_kinds_discovered_with_voice_first():
+    discovered = kinds()
+    assert {"tts", "stt", "sts"} <= set(discovered)
+    assert discovered[:3] == ("tts", "stt", "sts")
+
+
+def test_supported_types_are_populated():
+    assert len(SUPPORTED_MODEL_TYPES["tts"]) > 10
+    assert len(SUPPORTED_MODEL_TYPES["stt"]) > 10
+    assert "kokoro" in SUPPORTED_MODEL_TYPES["tts"]
+    assert "whisper" in SUPPORTED_MODEL_TYPES["stt"]
+
+
+def test_classify_text_to_speech():
+    assert classify_model("csm", "Marvis-AI/marvis-tts-250m") == "tts"
+    assert classify_model("kokoro", "prince-canuma/Kokoro-82M") == "tts"
+    assert classify_model("dia", "nari-labs/Dia-1.6B") == "tts"
+    assert classify_model("bark", "suno/bark") == "tts"
+
+
+def test_classify_speech_to_text():
+    assert classify_model("tdt", "mlx-community/parakeet-tdt-0.6b-v2") == "stt"
+    assert classify_model("whisper", "openai/whisper-base") == "stt"
+    assert classify_model("moonshine", "UsefulSensors/moonshine-base") == "stt"
+    assert classify_model("qwen3_asr", "Qwen/Qwen3-ASR") == "stt"
+
+
+def test_classify_other_voice_kinds():
+    assert classify_model("moshi", "kyutai/moshiko") == "sts"
+    assert classify_model("mimi", "kyutai/mimi") == "codec"
+
+
+def test_repo_name_recovers_generic_model_type():
+    # parakeet's config model_type is "tdt"; the family is recovered from the name.
+    assert classify_model("tdt", "parakeet") == "stt"
+
+
+def test_language_models_are_not_audio():
+    assert classify_model("llama", "meta-llama/Llama-3.1-8B") is None
+    assert classify_model("qwen3", "Qwen/Qwen3-8B") is None
+    assert classify_model("gemma3", "google/gemma-3-4b") is None
+    assert classify_model("", "") is None
+    assert not is_supported_model("foobar", "acme/whatever")


### PR DESCRIPTION
Adds classify_model(model_type, model_name) + SUPPORTED_MODEL_TYPES — a lightweight, import-free way to resolve any config model_type (and repo name) to its audio kind (tts/stt/sts/codec/…), mirroring the existing models/ layout + MODEL_REMAPPING. Rejects non-audio models (LLMs) so downstream tools can filter reliably(this case, nativ).