### PR TITLE
Add arktts (Audio8-TTS-Preview-0.6b): DualAR TTS with zero-shot voice cloning

### DIFF
--- a/mlx_audio/tts/models/arktts/README.md
+++ b/mlx_audio/tts/models/arktts/README.md
@@ -1,0 +1,93 @@
+# Audio8 TTS (arktts)
+
+Multilingual zero-shot voice cloning across 11 languages, with a bundled 44.1 kHz neural codec.
+Based on [Audio8/Audio8-TTS-Preview-0.6b](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.6b).
+
+## Supported Models
+
+- `mlx-community/Audio8-TTS-Preview-0.6b-bf16`
+
+## Usage
+
+Python API:
+
+```python
+import soundfile as sf
+from mlx_audio.tts.utils import load
+
+model = load("mlx-community/Audio8-TTS-Preview-0.6b-bf16")
+
+# Zero-shot cloning. The reference transcript must match what the clip says —
+# the model conditions on the (audio, text) pair, not on the audio alone.
+for result in model.generate(
+    text="Welcome to Audio8 TTS, running on Apple Silicon.",
+    ref_audio="reference.wav",
+    ref_text="Transcript of the reference clip.",
+):
+    sf.write("output.wav", result.audio, result.sample_rate)
+```
+
+Without `ref_audio` the model synthesizes with its own default voice.
+
+CLI (default voice — the CLI has no flags for a reference clip, so cloning is Python-API only):
+
+```bash
+python -m mlx_audio.tts.generate \
+  --model mlx-community/Audio8-TTS-Preview-0.6b-bf16 \
+  --text "Welcome to Audio8 TTS, running on Apple Silicon."
+```
+
+## Languages
+
+Cantonese, Chinese, Dutch, English, French, German, Italian, Japanese, Korean, Polish, Spanish.
+
+Language coverage is intentionally limited in this preview release; results are best within the
+list above.
+
+## Options
+
+| | default | |
+|---|---|---|
+| `temperature` | 0.7 | |
+| `top_p` | 0.9 | |
+| `top_k` | 50 | |
+| `max_tokens` | 512 | frames; one frame ≈ 46 ms of audio, so 512 ≈ 23.8 s |
+| `do_sample` | `True` | set `False` for deterministic argmax decoding |
+| `seed` | — | reproducible sampling |
+
+The upstream demo Space runs hotter (`0.8 / 0.95 / 1024`) than the model card's defaults, which
+are used here.
+
+## Architecture
+
+DualAR, in the style of Fish Audio S2 Pro:
+
+- **Slow AR** — 24 layers, width 896, 14 heads / 2 KV heads. Emits one semantic token per audio
+  frame.
+- **Fast AR** — 4 layers, same width. Emits that frame's 10 residual codec codebooks, conditioned
+  on the slow hidden state and the preceding codebooks.
+- **Codec** — 44.1 kHz, 2048 samples per frame (~21.5 frames/s). DAC-style encoder/decoder with a
+  split semantic + residual RVQ and windowed transformer pre/post modules. Handles both
+  reference-audio encoding and waveform decoding, so no separate codec checkpoint is needed.
+
+Sampling reproduces the reference implementation exactly: semantic-range logit filtering, the
+legacy top-k/top-p order (filter *before* temperature), exponential-race sampling, and RAS
+repetition rescue.
+
+## Conversion notes
+
+The upstream repository ships its codec as a PyTorch `.pth` with unfused weight norm. The
+converted `mlx-community` weights are **pre-sanitized** — weight norm folded, conv weights in
+MLX's channels-last layout, Snake alphas reshaped — so `sanitize()` passes them through
+unchanged. It stays able to consume a raw upstream checkpoint as well.
+
+## Parity
+
+Verified against the PyTorch reference on CPU in fp32:
+
+| | |
+|---|---|
+| unit / block outputs | max-abs 1e-6 … 1e-4 |
+| reference-audio codec encode | **100% code-exact** |
+| greedy generation | **100% token-exact** over a 102-frame utterance |
+| decoded waveform | max-abs 7.5e-6 |

--- a/mlx_audio/tts/models/arktts/__init__.py
+++ b/mlx_audio/tts/models/arktts/__init__.py
@@ -1,0 +1,1 @@
+from .arktts import Model, ModelConfig

--- a/mlx_audio/tts/models/arktts/arktts.py
+++ b/mlx_audio/tts/models/arktts/arktts.py
@@ -73,7 +73,8 @@ class ModelConfig(BaseModelArgs):
 
 def _precompute_rope(length: int, head_dim: int, base: float) -> mx.array:
     frequencies = 1.0 / (
-        base ** (mx.arange(0, head_dim, 2).astype(mx.float32)[: head_dim // 2] / head_dim)
+        base
+        ** (mx.arange(0, head_dim, 2).astype(mx.float32)[: head_dim // 2] / head_dim)
     )
     phases = mx.arange(length).astype(mx.float32)[:, None] * frequencies[None, :]
     # reference stores the (real, imag) table in bf16; keep the same rounding
@@ -113,7 +114,9 @@ class ArkttsRMSNorm(nn.Module):
 
 
 class ArkttsKVCache:
-    def __init__(self, batch_size: int, max_length: int, heads: int, head_dim: int, dtype):
+    def __init__(
+        self, batch_size: int, max_length: int, heads: int, head_dim: int, dtype
+    ):
         shape = (batch_size, heads, max_length, head_dim)
         self.keys = mx.zeros(shape, dtype=dtype)
         self.values = mx.zeros(shape, dtype=dtype)
@@ -212,14 +215,23 @@ class ArkttsTransformerBlock(nn.Module):
     ):
         super().__init__()
         self.attention = ArkttsAttention(
-            dim, n_head, n_local_heads, head_dim, qkv_bias, output_bias, qk_norm, norm_eps
+            dim,
+            n_head,
+            n_local_heads,
+            head_dim,
+            qkv_bias,
+            output_bias,
+            qk_norm,
+            norm_eps,
         )
         self.feed_forward = ArkttsFeedForward(dim, intermediate_size)
         self.ffn_norm = ArkttsRMSNorm(dim, norm_eps)
         self.attention_norm = ArkttsRMSNorm(dim, norm_eps)
 
     def __call__(self, x, rope, attention_mask, cache_start=None):
-        hidden = x + self.attention(self.attention_norm(x), rope, attention_mask, cache_start)
+        hidden = x + self.attention(
+            self.attention_norm(x), rope, attention_mask, cache_start
+        )
         return hidden + self.feed_forward(self.ffn_norm(hidden))
 
 
@@ -233,9 +245,15 @@ class ArkttsModel(nn.Module):
         )
         self.layers = [
             ArkttsTransformerBlock(
-                config.dim, config.intermediate_size, config.n_head, config.n_local_heads,
-                config.head_dim, config.attention_qkv_bias, config.attention_o_bias,
-                config.attention_qk_norm, config.norm_eps,
+                config.dim,
+                config.intermediate_size,
+                config.n_head,
+                config.n_local_heads,
+                config.head_dim,
+                config.attention_qkv_bias,
+                config.attention_o_bias,
+                config.attention_qk_norm,
+                config.norm_eps,
             )
             for _ in range(config.n_layer)
         ]
@@ -248,16 +266,23 @@ class ArkttsModel(nn.Module):
         self.fast_embeddings = nn.Embedding(config.codebook_size, config.fast_dim)
         self.fast_layers = [
             ArkttsTransformerBlock(
-                config.fast_dim, config.fast_intermediate_size, config.fast_n_head,
-                config.fast_n_local_heads, config.fast_head_dim,
-                config.fast_attention_qkv_bias, config.fast_attention_o_bias,
-                config.fast_attention_qk_norm, config.norm_eps,
+                config.fast_dim,
+                config.fast_intermediate_size,
+                config.fast_n_head,
+                config.fast_n_local_heads,
+                config.fast_head_dim,
+                config.fast_attention_qkv_bias,
+                config.fast_attention_o_bias,
+                config.fast_attention_qk_norm,
+                config.norm_eps,
             )
             for _ in range(config.n_fast_layer)
         ]
         self.fast_norm = ArkttsRMSNorm(config.fast_dim, config.norm_eps)
         self.fast_output = nn.Linear(config.fast_dim, config.codebook_size, bias=False)
-        self._freqs_cis = _precompute_rope(config.max_seq_len, config.head_dim, config.rope_base)
+        self._freqs_cis = _precompute_rope(
+            config.max_seq_len, config.head_dim, config.rope_base
+        )
         self._fast_freqs_cis = _precompute_rope(
             config.num_codebooks, config.fast_head_dim, config.rope_base
         )
@@ -268,7 +293,9 @@ class ArkttsModel(nn.Module):
         codebook_embeds = []
         for index in range(config.num_codebooks):
             codebook_embeds.append(
-                self.codebook_embeddings(input_ids[:, index + 1] + index * config.codebook_size)
+                self.codebook_embeddings(
+                    input_ids[:, index + 1] + index * config.codebook_size
+                )
             )
         codebook_sum = mx.stack(codebook_embeds, axis=1).sum(axis=1)
         semantic = mx.logical_and(
@@ -279,7 +306,9 @@ class ArkttsModel(nn.Module):
         return self.embeddings(input_ids[:, 0]) + codebook_sum
 
     @staticmethod
-    def _causal_mask(attention_mask: mx.array, query_positions: mx.array, key_length: int) -> mx.array:
+    def _causal_mask(
+        attention_mask: mx.array, query_positions: mx.array, key_length: int
+    ) -> mx.array:
         if attention_mask.shape[1] < key_length:
             attention_mask = mx.pad(
                 attention_mask, ((0, 0), (0, key_length - attention_mask.shape[1]))
@@ -287,14 +316,17 @@ class ArkttsModel(nn.Module):
         key_positions = mx.arange(key_length)
         causal = key_positions[None, :] <= query_positions[:, None]
         return mx.logical_and(
-            causal[None, None], attention_mask[:, None, None, :key_length].astype(mx.bool_)
+            causal[None, None],
+            attention_mask[:, None, None, :key_length].astype(mx.bool_),
         )
 
     # -- prefill (no-cache) forward, for parity ------------------------------
     def __call__(self, input_ids: mx.array, attention_mask: Optional[mx.array] = None):
         config = self.config
         if input_ids.ndim != 3 or input_ids.shape[1] != config.num_codebooks + 1:
-            raise ValueError(f"input_ids must have shape [B, {config.num_codebooks + 1}, T]")
+            raise ValueError(
+                f"input_ids must have shape [B, {config.num_codebooks + 1}, T]"
+            )
         batch, _, length = input_ids.shape
         if attention_mask is None:
             attention_mask = mx.ones((batch, length), dtype=mx.int64)
@@ -315,12 +347,19 @@ class ArkttsModel(nn.Module):
         config = self.config
         for layer in self.layers:
             layer.attention.kv_cache = ArkttsKVCache(
-                batch_size, config.max_seq_len, config.n_local_heads, config.head_dim, dtype
+                batch_size,
+                config.max_seq_len,
+                config.n_local_heads,
+                config.head_dim,
+                dtype,
             )
         for layer in self.fast_layers:
             layer.attention.kv_cache = ArkttsKVCache(
-                batch_size, config.num_codebooks, config.fast_n_local_heads,
-                config.fast_head_dim, dtype,
+                batch_size,
+                config.num_codebooks,
+                config.fast_n_local_heads,
+                config.fast_head_dim,
+                dtype,
             )
 
     def _clear_generation_caches(self):
@@ -411,11 +450,15 @@ class ArkttsModel(nn.Module):
         )
         return mx.where(mx.logical_and(repeated, semantic), high, normal)
 
-    def _generate_codebooks(self, slow_hidden, semantic, top_k, top_p, temperature, do_sample, rng_key):
+    def _generate_codebooks(
+        self, slow_hidden, semantic, top_k, top_p, temperature, do_sample, rng_key
+    ):
         config = self.config
         hidden = self.fast_project_in(slow_hidden)
         self._fast_step(hidden, 0)
-        current = mx.clip(semantic - config.semantic_begin_id, 0, config.codebook_size - 1)
+        current = mx.clip(
+            semantic - config.semantic_begin_id, 0, config.codebook_size - 1
+        )
         codebooks = [current]
         hidden = self.fast_embeddings(current)[:, None]
         for position in range(1, config.num_codebooks):
@@ -447,19 +490,27 @@ class ArkttsModel(nn.Module):
             suffix = np.asarray(suffix_input_ids[batch_index], dtype=np.int64)
             if reference_codes is None:
                 semantic_row = np.concatenate((prefix, suffix))
-                values = np.zeros((config.num_codebooks + 1, semantic_row.size), dtype=np.int64)
+                values = np.zeros(
+                    (config.num_codebooks + 1, semantic_row.size), dtype=np.int64
+                )
                 values[0] = semantic_row
             else:
                 length = int(reference_code_lengths[batch_index])
-                codes = np.asarray(reference_codes[batch_index][:, :length], dtype=np.int64)
+                codes = np.asarray(
+                    reference_codes[batch_index][:, :length], dtype=np.int64
+                )
                 semantic_codes = codes[0] + config.semantic_begin_id
                 semantic_row = np.concatenate((prefix, semantic_codes, suffix))
-                values = np.zeros((config.num_codebooks + 1, semantic_row.size), dtype=np.int64)
+                values = np.zeros(
+                    (config.num_codebooks + 1, semantic_row.size), dtype=np.int64
+                )
                 values[0] = semantic_row
                 values[1:, prefix.size : prefix.size + length] = codes
             rows.append(values)
         max_length = max(row.shape[1] for row in rows)
-        prompt = np.zeros((batch_size, config.num_codebooks + 1, max_length), dtype=np.int64)
+        prompt = np.zeros(
+            (batch_size, config.num_codebooks + 1, max_length), dtype=np.int64
+        )
         prompt[:, 0] = config.pad_token_id
         prompt_mask = np.zeros((batch_size, max_length), dtype=np.int64)
         for batch_index, row in enumerate(rows):
@@ -495,7 +546,9 @@ class ArkttsModel(nn.Module):
         max_new_tokens = min(max_new_tokens, config.max_seq_len - prompt_width)
         dtype = self.embeddings.weight.dtype
         self._setup_generation_caches(batch_size, dtype)
-        rng_key = mx.random.key(seed if seed is not None else int(time.time_ns() % (2**63)))
+        rng_key = mx.random.key(
+            seed if seed is not None else int(time.time_ns() % (2**63))
+        )
 
         position_ids = mx.maximum(mx.cumsum(prompt_mask, axis=-1) - 1, 0)
         logits, slow_hidden = self._slow_step(
@@ -513,7 +566,13 @@ class ArkttsModel(nn.Module):
             keys = mx.random.split(rng_key, 4)
             rng_key = keys[3]
             semantic = self._sample_semantic(
-                logits, top_k, top_p, temperature, previous, do_sample, (keys[0], keys[1])
+                logits,
+                top_k,
+                top_p,
+                temperature,
+                previous,
+                do_sample,
+                (keys[0], keys[1]),
             )
             codebooks = self._generate_codebooks(
                 slow_hidden, semantic, top_k, top_p, temperature, do_sample, keys[2]
@@ -524,7 +583,9 @@ class ArkttsModel(nn.Module):
             code_lengths = code_lengths + emitted.astype(mx.int64)
 
             if previous is None:
-                previous = mx.zeros((batch_size, config.ras_window_size), dtype=mx.int64)
+                previous = mx.zeros(
+                    (batch_size, config.ras_window_size), dtype=mx.int64
+                )
             else:
                 previous = mx.concatenate((previous[:, 1:], semantic[:, None]), axis=1)
             finished = mx.logical_or(finished, semantic == config.eos_token_id)
@@ -532,7 +593,9 @@ class ArkttsModel(nn.Module):
             if bool(mx.all(finished)):
                 break
 
-            next_column = mx.concatenate((semantic[:, None], codebooks), axis=1)[..., None]
+            next_column = mx.concatenate((semantic[:, None], codebooks), axis=1)[
+                ..., None
+            ]
             new_valid = active_before.astype(mx.int64)[:, None]
             prompt_mask_np = mx.concatenate((prompt_mask_np, new_valid), axis=1)
             physical_position = prompt_width + step
@@ -598,7 +661,9 @@ class Model(nn.Module):
             return cleaned
         return f"<|speaker:0|>{cleaned}"
 
-    def _prompt_segments(self, text: str, reference_text: Optional[str], has_reference: bool):
+    def _prompt_segments(
+        self, text: str, reference_text: Optional[str], has_reference: bool
+    ):
         tokenizer = self._load_tokenizer()
 
         def encode_parts(parts):
@@ -611,31 +676,39 @@ class Model(nn.Module):
         if not target:
             raise ValueError("text must not be empty")
         if not has_reference:
-            full = encode_parts([
+            full = encode_parts(
+                [
+                    "<|im_start|>system\n",
+                    "convert the provided text to speech",
+                    "<|im_end|>\n",
+                    "<|im_start|>user\n",
+                    target,
+                    "<|im_end|>\n",
+                    "<|im_start|>assistant\n<|voice|>",
+                ]
+            )
+            return full, np.asarray([], dtype=np.int64)
+        if not reference_text:
+            raise ValueError(
+                "reference_text is required when a reference voice is provided"
+            )
+        prefix = encode_parts(
+            [
                 "<|im_start|>system\n",
-                "convert the provided text to speech",
+                "convert the provided text to speech reference to the following:\n\nText:\n",
+                self._format_reference_text(reference_text),
+                "\n\nSpeech:\n",
+            ]
+        )
+        suffix = encode_parts(
+            [
                 "<|im_end|>\n",
                 "<|im_start|>user\n",
                 target,
                 "<|im_end|>\n",
                 "<|im_start|>assistant\n<|voice|>",
-            ])
-            return full, np.asarray([], dtype=np.int64)
-        if not reference_text:
-            raise ValueError("reference_text is required when a reference voice is provided")
-        prefix = encode_parts([
-            "<|im_start|>system\n",
-            "convert the provided text to speech reference to the following:\n\nText:\n",
-            self._format_reference_text(reference_text),
-            "\n\nSpeech:\n",
-        ])
-        suffix = encode_parts([
-            "<|im_end|>\n",
-            "<|im_start|>user\n",
-            target,
-            "<|im_end|>\n",
-            "<|im_start|>assistant\n<|voice|>",
-        ])
+            ]
+        )
         return prefix, suffix
 
     # audio ------------------------------------------------------------------
@@ -645,7 +718,9 @@ class Model(nn.Module):
         from mlx_audio.utils import resample_audio
 
         if isinstance(ref_audio, (str, Path)):
-            array, source_rate = sf.read(str(ref_audio), dtype="float32", always_2d=True)
+            array, source_rate = sf.read(
+                str(ref_audio), dtype="float32", always_2d=True
+            )
             array = array.mean(axis=1)
         else:
             array = np.asarray(ref_audio, dtype=np.float32)
@@ -751,7 +826,7 @@ class Model(nn.Module):
             if key.endswith(("freqs_cis", "causal_mask")):
                 continue
             if key.startswith("generator."):
-                key = key[len("generator."):]
+                key = key[len("generator.") :]
             if not key.startswith(("model.", "codec.")):
                 # raw reference LM checkpoint keys arrive unprefixed;
                 # raw codec.pth keys arrive as encoder./decoder./quantizer.
@@ -794,7 +869,9 @@ class Model(nn.Module):
                     else:
                         # Conv1d: torch (O, I, K) -> mlx (O, K, I)
                         value = value.transpose(0, 2, 1)
-                elif (".in_proj.weight" in key or ".out_proj.weight" in key) and value.ndim == 3:
+                elif (
+                    ".in_proj.weight" in key or ".out_proj.weight" in key
+                ) and value.ndim == 3:
                     # VQ 1x1 convs: torch (O, I, 1) -> mlx (O, 1, I)
                     value = value.transpose(0, 2, 1)
             remapped[key] = value

--- a/mlx_audio/tts/models/arktts/arktts.py
+++ b/mlx_audio/tts/models/arktts/arktts.py
@@ -1,0 +1,814 @@
+"""MLX port of Audio8-TTS-Preview-0.6b (model_type: arktts).
+
+Mirrors the reference modeling_arktts.py structure: a DualAR transformer — a
+slow AR stack predicting one semantic token per audio frame, and a fast AR
+stack predicting the frame's residual codec codebooks — plus the bundled
+44.1 kHz codec (codec.py). Sampling reproduces the reference exactly:
+semantic-range logit filtering, the legacy top-k/top-p order (filter before
+temperature), exponential-race sampling, and RAS repetition rescue.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..base import BaseModelArgs, GenerationResult
+from .codec import ArkttsCodec
+
+
+@dataclass
+class ModelConfig(BaseModelArgs):
+    model_type: str = "arktts"
+    vocab_size: int = 155776
+    dim: int = 896
+    n_layer: int = 24
+    n_head: int = 14
+    n_local_heads: int = 2
+    head_dim: int = 64
+    intermediate_size: int = 4864
+    max_seq_len: int = 2048
+    rope_base: float = 1_000_000
+    norm_eps: float = 1e-6
+    attention_qkv_bias: bool = True
+    attention_qk_norm: bool = False
+    attention_o_bias: bool = False
+    tie_word_embeddings: bool = True
+    codebook_size: int = 4096
+    num_codebooks: int = 10
+    semantic_begin_id: int = 151678
+    semantic_end_id: int = 155773
+    n_fast_layer: int = 4
+    fast_dim: int = 896
+    fast_n_head: int = 14
+    fast_n_local_heads: int = 2
+    fast_head_dim: int = 64
+    fast_intermediate_size: int = 4864
+    fast_attention_qkv_bias: bool = False
+    fast_attention_qk_norm: bool = False
+    fast_attention_o_bias: bool = False
+    norm_fastlayer_input: bool = True
+    codec_filename: str = "codec.pth"
+    codec_sample_rate: int = 44100
+    codec_frame_size: int = 2048
+    codec_post_n_layer: int = 8
+    codec_post_n_head: int = 16
+    codec_post_n_local_heads: int = 8
+    codec_post_intermediate_size: int = 1216
+    ras_window_size: int = 10
+    ras_temperature: float = 1.0
+    ras_top_p: float = 0.9
+    eos_token_id: int = 151645
+    pad_token_id: int = 151643
+    sample_rate: int = 44100
+
+
+def _precompute_rope(length: int, head_dim: int, base: float) -> mx.array:
+    frequencies = 1.0 / (
+        base ** (mx.arange(0, head_dim, 2).astype(mx.float32)[: head_dim // 2] / head_dim)
+    )
+    phases = mx.arange(length).astype(mx.float32)[:, None] * frequencies[None, :]
+    # reference stores the (real, imag) table in bf16; keep the same rounding
+    return mx.stack((mx.cos(phases), mx.sin(phases)), axis=-1).astype(mx.bfloat16)
+
+
+def _apply_rope(x: mx.array, rope: mx.array) -> mx.array:
+    # x: (B, T, H, D); rope: (T, D/2, 2) or (B, T, D/2, 2)
+    shaped = x.astype(mx.float32).reshape(*x.shape[:-1], -1, 2)
+    rope = rope.astype(mx.float32)
+    if rope.ndim == 3:
+        rope = rope[None, :, None]
+    elif rope.ndim == 4:
+        rope = rope[:, :, None]
+    else:
+        raise ValueError(f"Unexpected RoPE shape: {tuple(rope.shape)}")
+    output = mx.stack(
+        (
+            shaped[..., 0] * rope[..., 0] - shaped[..., 1] * rope[..., 1],
+            shaped[..., 1] * rope[..., 0] + shaped[..., 0] * rope[..., 1],
+        ),
+        axis=-1,
+    )
+    return output.flatten(3).astype(x.dtype)
+
+
+class ArkttsRMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float):
+        super().__init__()
+        self.eps = float(eps)
+        self.weight = mx.ones((dim,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        xf = x.astype(mx.float32)
+        normalized = xf * mx.rsqrt(mx.mean(xf * xf, axis=-1, keepdims=True) + self.eps)
+        return normalized.astype(x.dtype) * self.weight
+
+
+class ArkttsKVCache:
+    def __init__(self, batch_size: int, max_length: int, heads: int, head_dim: int, dtype):
+        shape = (batch_size, heads, max_length, head_dim)
+        self.keys = mx.zeros(shape, dtype=dtype)
+        self.values = mx.zeros(shape, dtype=dtype)
+
+    def update(self, start: int, keys: mx.array, values: mx.array):
+        length = keys.shape[2]
+        self.keys[:, :, start : start + length] = keys
+        self.values[:, :, start : start + length] = values
+        return self.keys, self.values
+
+
+class ArkttsAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        n_head: int,
+        n_local_heads: int,
+        head_dim: int,
+        qkv_bias: bool,
+        output_bias: bool,
+        qk_norm: bool,
+        norm_eps: float,
+    ):
+        super().__init__()
+        total = (n_head + 2 * n_local_heads) * head_dim
+        self.wqkv = nn.Linear(dim, total, bias=qkv_bias)
+        self.wo = nn.Linear(n_head * head_dim, dim, bias=output_bias)
+        self.n_head = int(n_head)
+        self.n_local_heads = int(n_local_heads)
+        self.head_dim = int(head_dim)
+        self.qk_norm = bool(qk_norm)
+        if self.qk_norm:
+            self.q_norm = ArkttsRMSNorm(head_dim, norm_eps)
+            self.k_norm = ArkttsRMSNorm(head_dim, norm_eps)
+        self.kv_cache: Optional[ArkttsKVCache] = None
+
+    def __call__(
+        self,
+        x: mx.array,
+        rope: mx.array,
+        attention_mask: Optional[mx.array],
+        cache_start: Optional[int] = None,
+    ) -> mx.array:
+        batch, length, _ = x.shape
+        query_size = self.n_head * self.head_dim
+        kv_size = self.n_local_heads * self.head_dim
+        qkv = self.wqkv(x)
+        query, key, value = mx.split(qkv, [query_size, query_size + kv_size], axis=-1)
+        query = query.reshape(batch, length, self.n_head, self.head_dim)
+        key = key.reshape(batch, length, self.n_local_heads, self.head_dim)
+        value = value.reshape(batch, length, self.n_local_heads, self.head_dim)
+        if self.qk_norm:
+            query = self.q_norm(query)
+            key = self.k_norm(key)
+        query = _apply_rope(query, rope).transpose(0, 2, 1, 3)
+        key = _apply_rope(key, rope).transpose(0, 2, 1, 3)
+        value = value.transpose(0, 2, 1, 3)
+        if self.kv_cache is not None:
+            if cache_start is None:
+                raise ValueError("cache_start is required when KV cache is enabled")
+            key, value = self.kv_cache.update(cache_start, key, value)
+        output = mx.fast.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            scale=1.0 / math.sqrt(self.head_dim),
+            mask=attention_mask,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, query_size)
+        return self.wo(output)
+
+
+class ArkttsFeedForward(nn.Module):
+    def __init__(self, dim: int, intermediate_size: int):
+        super().__init__()
+        self.w1 = nn.Linear(dim, intermediate_size, bias=False)
+        self.w2 = nn.Linear(intermediate_size, dim, bias=False)
+        self.w3 = nn.Linear(dim, intermediate_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.w2(nn.silu(self.w1(x)) * self.w3(x))
+
+
+class ArkttsTransformerBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        intermediate_size: int,
+        n_head: int,
+        n_local_heads: int,
+        head_dim: int,
+        qkv_bias: bool,
+        output_bias: bool,
+        qk_norm: bool,
+        norm_eps: float,
+    ):
+        super().__init__()
+        self.attention = ArkttsAttention(
+            dim, n_head, n_local_heads, head_dim, qkv_bias, output_bias, qk_norm, norm_eps
+        )
+        self.feed_forward = ArkttsFeedForward(dim, intermediate_size)
+        self.ffn_norm = ArkttsRMSNorm(dim, norm_eps)
+        self.attention_norm = ArkttsRMSNorm(dim, norm_eps)
+
+    def __call__(self, x, rope, attention_mask, cache_start=None):
+        hidden = x + self.attention(self.attention_norm(x), rope, attention_mask, cache_start)
+        return hidden + self.feed_forward(self.ffn_norm(hidden))
+
+
+class ArkttsModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.embeddings = nn.Embedding(config.vocab_size, config.dim)
+        self.codebook_embeddings = nn.Embedding(
+            config.codebook_size * config.num_codebooks, config.dim
+        )
+        self.layers = [
+            ArkttsTransformerBlock(
+                config.dim, config.intermediate_size, config.n_head, config.n_local_heads,
+                config.head_dim, config.attention_qkv_bias, config.attention_o_bias,
+                config.attention_qk_norm, config.norm_eps,
+            )
+            for _ in range(config.n_layer)
+        ]
+        self.norm = ArkttsRMSNorm(config.dim, config.norm_eps)
+        self.fast_project_in = (
+            nn.Linear(config.dim, config.fast_dim)
+            if config.fast_dim != config.dim
+            else nn.Identity()
+        )
+        self.fast_embeddings = nn.Embedding(config.codebook_size, config.fast_dim)
+        self.fast_layers = [
+            ArkttsTransformerBlock(
+                config.fast_dim, config.fast_intermediate_size, config.fast_n_head,
+                config.fast_n_local_heads, config.fast_head_dim,
+                config.fast_attention_qkv_bias, config.fast_attention_o_bias,
+                config.fast_attention_qk_norm, config.norm_eps,
+            )
+            for _ in range(config.n_fast_layer)
+        ]
+        self.fast_norm = ArkttsRMSNorm(config.fast_dim, config.norm_eps)
+        self.fast_output = nn.Linear(config.fast_dim, config.codebook_size, bias=False)
+        self._freqs_cis = _precompute_rope(config.max_seq_len, config.head_dim, config.rope_base)
+        self._fast_freqs_cis = _precompute_rope(
+            config.num_codebooks, config.fast_head_dim, config.rope_base
+        )
+
+    # -- embedding -----------------------------------------------------------
+    def _embed(self, input_ids: mx.array) -> mx.array:
+        config = self.config
+        codebook_embeds = []
+        for index in range(config.num_codebooks):
+            codebook_embeds.append(
+                self.codebook_embeddings(input_ids[:, index + 1] + index * config.codebook_size)
+            )
+        codebook_sum = mx.stack(codebook_embeds, axis=1).sum(axis=1)
+        semantic = mx.logical_and(
+            input_ids[:, 0] >= config.semantic_begin_id,
+            input_ids[:, 0] <= config.semantic_end_id,
+        )
+        codebook_sum = mx.where(semantic[..., None], codebook_sum, 0.0)
+        return self.embeddings(input_ids[:, 0]) + codebook_sum
+
+    @staticmethod
+    def _causal_mask(attention_mask: mx.array, query_positions: mx.array, key_length: int) -> mx.array:
+        if attention_mask.shape[1] < key_length:
+            attention_mask = mx.pad(
+                attention_mask, ((0, 0), (0, key_length - attention_mask.shape[1]))
+            )
+        key_positions = mx.arange(key_length)
+        causal = key_positions[None, :] <= query_positions[:, None]
+        return mx.logical_and(
+            causal[None, None], attention_mask[:, None, None, :key_length].astype(mx.bool_)
+        )
+
+    # -- prefill (no-cache) forward, for parity ------------------------------
+    def __call__(self, input_ids: mx.array, attention_mask: Optional[mx.array] = None):
+        config = self.config
+        if input_ids.ndim != 3 or input_ids.shape[1] != config.num_codebooks + 1:
+            raise ValueError(f"input_ids must have shape [B, {config.num_codebooks + 1}, T]")
+        batch, _, length = input_ids.shape
+        if attention_mask is None:
+            attention_mask = mx.ones((batch, length), dtype=mx.int64)
+        position_ids = mx.maximum(
+            mx.cumsum(attention_mask.astype(mx.int64), axis=-1) - 1, 0
+        )
+        rope = self._freqs_cis[position_ids]
+        mask = self._causal_mask(attention_mask, mx.arange(length), length)
+        hidden = self._embed(input_ids)
+        for layer in self.layers:
+            hidden = layer(hidden, rope, mask)
+        normalized = self.norm(hidden)
+        logits = normalized @ self.embeddings.weight.T
+        return logits, hidden
+
+    # -- cached decode steps -------------------------------------------------
+    def _setup_generation_caches(self, batch_size: int, dtype):
+        config = self.config
+        for layer in self.layers:
+            layer.attention.kv_cache = ArkttsKVCache(
+                batch_size, config.max_seq_len, config.n_local_heads, config.head_dim, dtype
+            )
+        for layer in self.fast_layers:
+            layer.attention.kv_cache = ArkttsKVCache(
+                batch_size, config.num_codebooks, config.fast_n_local_heads,
+                config.fast_head_dim, dtype,
+            )
+
+    def _clear_generation_caches(self):
+        for layer in list(self.layers) + list(self.fast_layers):
+            layer.attention.kv_cache = None
+
+    def _slow_step(
+        self,
+        input_ids: mx.array,
+        cache_start: int,
+        cache_positions: mx.array,
+        position_ids: mx.array,
+        attention_mask: mx.array,
+    ):
+        config = self.config
+        hidden = self._embed(input_ids)
+        rope = self._freqs_cis[position_ids]
+        mask = self._causal_mask(attention_mask, cache_positions, config.max_seq_len)
+        for layer in self.layers:
+            hidden = layer(hidden, rope, mask, cache_start)
+        hidden = hidden[:, -1:]
+        normalized = self.norm(hidden)
+        logits = (normalized @ self.embeddings.weight.T)[:, -1]
+        fast_hidden = normalized if config.norm_fastlayer_input else hidden
+        return logits, fast_hidden
+
+    def _fast_step(self, hidden: mx.array, position: int) -> mx.array:
+        config = self.config
+        rope = self._fast_freqs_cis[mx.array([position])]
+        key_mask = mx.ones((hidden.shape[0], config.num_codebooks), dtype=mx.bool_)
+        mask = self._causal_mask(key_mask, mx.array([position]), config.num_codebooks)
+        for layer in self.fast_layers:
+            hidden = layer(hidden, rope, mask, position)
+        return self.fast_output(self.fast_norm(hidden))[:, -1]
+
+    # -- sampling (mirrors the reference exactly) ----------------------------
+    @staticmethod
+    def _legacy_top_k_top_p(scores: mx.array, top_k: int, top_p: float) -> mx.array:
+        sorted_indices = mx.argsort(-scores, axis=-1)
+        sorted_scores = mx.take_along_axis(scores, sorted_indices, axis=-1)
+        cumulative = mx.cumsum(mx.softmax(sorted_scores, axis=-1), axis=-1)
+        positions = mx.arange(scores.shape[-1])
+        remove_sorted = mx.logical_or(cumulative > top_p, positions[None, :] >= top_k)
+        remove_sorted[:, 0] = False
+        remove = mx.zeros_like(remove_sorted)
+        remove = mx.put_along_axis(remove, sorted_indices, remove_sorted, axis=-1)
+        return mx.where(remove, mx.array(-mx.inf, dtype=scores.dtype), scores)
+
+    def _semantic_filter(self, scores: mx.array) -> mx.array:
+        config = self.config
+        filtered = mx.full(scores.shape, -mx.inf, dtype=scores.dtype)
+        filtered[:, config.semantic_begin_id : config.semantic_end_id + 1] = scores[
+            :, config.semantic_begin_id : config.semantic_end_id + 1
+        ]
+        filtered[:, config.eos_token_id] = scores[:, config.eos_token_id]
+        return filtered
+
+    @staticmethod
+    def _sample(scores: mx.array, rng_key) -> mx.array:
+        probabilities = mx.softmax(scores, axis=-1)
+        random = mx.random.uniform(shape=probabilities.shape, key=rng_key)
+        noise = -mx.log(random)
+        return mx.argmax(probabilities / noise, axis=-1).astype(mx.int64)
+
+    def _processed_scores(self, scores, top_k, top_p, temperature, semantic: bool):
+        if semantic:
+            scores = self._semantic_filter(scores)
+        scores = self._legacy_top_k_top_p(scores, top_k, top_p)
+        return scores / max(temperature, 1e-5)
+
+    def _sample_semantic(
+        self, logits, top_k, top_p, temperature, previous, do_sample, rng_keys
+    ):
+        config = self.config
+        regular_scores = self._processed_scores(logits, top_k, top_p, temperature, True)
+        if not do_sample:
+            return mx.argmax(regular_scores, axis=-1).astype(mx.int64)
+        normal = self._sample(regular_scores, rng_keys[0])
+        high_scores = self._processed_scores(
+            logits, top_k, config.ras_top_p, config.ras_temperature, True
+        )
+        high = self._sample(high_scores, rng_keys[1])
+        if previous is None:
+            return normal
+        repeated = mx.any(previous == normal[:, None], axis=1)
+        semantic = mx.logical_and(
+            normal >= config.semantic_begin_id, normal <= config.semantic_end_id
+        )
+        return mx.where(mx.logical_and(repeated, semantic), high, normal)
+
+    def _generate_codebooks(self, slow_hidden, semantic, top_k, top_p, temperature, do_sample, rng_key):
+        config = self.config
+        hidden = self.fast_project_in(slow_hidden)
+        self._fast_step(hidden, 0)
+        current = mx.clip(semantic - config.semantic_begin_id, 0, config.codebook_size - 1)
+        codebooks = [current]
+        hidden = self.fast_embeddings(current)[:, None]
+        for position in range(1, config.num_codebooks):
+            scores = self._fast_step(hidden, position)
+            scores = self._processed_scores(scores, top_k, top_p, temperature, False)
+            if do_sample:
+                rng_key, sub = mx.random.split(rng_key)
+                current = self._sample(scores, sub)
+            else:
+                current = mx.argmax(scores, axis=-1).astype(mx.int64)
+            codebooks.append(current)
+            hidden = self.fast_embeddings(current)[:, None]
+        return mx.stack(codebooks, axis=1)
+
+    # -- prompt building -----------------------------------------------------
+    def _prepare_prompt(
+        self,
+        prefix_input_ids: np.ndarray,
+        suffix_input_ids: np.ndarray,
+        reference_codes: Optional[np.ndarray] = None,
+        reference_code_lengths: Optional[np.ndarray] = None,
+    ):
+        """Single-row (B=1 per row) numpy prompt assembly, mirroring the reference."""
+        config = self.config
+        rows = []
+        batch_size = len(prefix_input_ids)
+        for batch_index in range(batch_size):
+            prefix = np.asarray(prefix_input_ids[batch_index], dtype=np.int64)
+            suffix = np.asarray(suffix_input_ids[batch_index], dtype=np.int64)
+            if reference_codes is None:
+                semantic_row = np.concatenate((prefix, suffix))
+                values = np.zeros((config.num_codebooks + 1, semantic_row.size), dtype=np.int64)
+                values[0] = semantic_row
+            else:
+                length = int(reference_code_lengths[batch_index])
+                codes = np.asarray(reference_codes[batch_index][:, :length], dtype=np.int64)
+                semantic_codes = codes[0] + config.semantic_begin_id
+                semantic_row = np.concatenate((prefix, semantic_codes, suffix))
+                values = np.zeros((config.num_codebooks + 1, semantic_row.size), dtype=np.int64)
+                values[0] = semantic_row
+                values[1:, prefix.size : prefix.size + length] = codes
+            rows.append(values)
+        max_length = max(row.shape[1] for row in rows)
+        prompt = np.zeros((batch_size, config.num_codebooks + 1, max_length), dtype=np.int64)
+        prompt[:, 0] = config.pad_token_id
+        prompt_mask = np.zeros((batch_size, max_length), dtype=np.int64)
+        for batch_index, row in enumerate(rows):
+            start = max_length - row.shape[1]
+            prompt[batch_index, :, start:] = row
+            prompt_mask[batch_index, start:] = 1
+        return mx.array(prompt), mx.array(prompt_mask)
+
+    # -- generation ----------------------------------------------------------
+    def generate_codes(
+        self,
+        prefix_input_ids,
+        suffix_input_ids,
+        reference_codes=None,
+        reference_code_lengths=None,
+        max_new_tokens: int = 512,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int = 50,
+        do_sample: bool = True,
+        seed: Optional[int] = None,
+    ) -> mx.array:
+        """Returns generated codec codes (B, num_codebooks, T). Batch size 1."""
+        config = self.config
+        prompt, prompt_mask = self._prepare_prompt(
+            prefix_input_ids, suffix_input_ids, reference_codes, reference_code_lengths
+        )
+        batch_size, _, prompt_width = prompt.shape
+        if prompt_width >= config.max_seq_len:
+            raise ValueError(
+                f"Prompt length {prompt_width} must be smaller than {config.max_seq_len}"
+            )
+        max_new_tokens = min(max_new_tokens, config.max_seq_len - prompt_width)
+        dtype = self.embeddings.weight.dtype
+        self._setup_generation_caches(batch_size, dtype)
+        rng_key = mx.random.key(seed if seed is not None else int(time.time_ns() % (2**63)))
+
+        position_ids = mx.maximum(mx.cumsum(prompt_mask, axis=-1) - 1, 0)
+        logits, slow_hidden = self._slow_step(
+            prompt, 0, mx.arange(prompt_width), position_ids, prompt_mask
+        )
+        prompt_lengths = prompt_mask.sum(axis=-1)
+        previous = None
+        finished = mx.zeros((batch_size,), dtype=mx.bool_)
+        code_lengths = mx.zeros((batch_size,), dtype=mx.int64)
+        generated_frames = []
+        prompt_mask_np = prompt_mask
+
+        for step in range(max_new_tokens):
+            active_before = mx.logical_not(finished)
+            keys = mx.random.split(rng_key, 4)
+            rng_key = keys[3]
+            semantic = self._sample_semantic(
+                logits, top_k, top_p, temperature, previous, do_sample, (keys[0], keys[1])
+            )
+            codebooks = self._generate_codebooks(
+                slow_hidden, semantic, top_k, top_p, temperature, do_sample, keys[2]
+            )
+            emitted = mx.logical_and(active_before, semantic != config.eos_token_id)
+            frame = mx.where(emitted[:, None], codebooks, -1)
+            generated_frames.append(frame)
+            code_lengths = code_lengths + emitted.astype(mx.int64)
+
+            if previous is None:
+                previous = mx.zeros((batch_size, config.ras_window_size), dtype=mx.int64)
+            else:
+                previous = mx.concatenate((previous[:, 1:], semantic[:, None]), axis=1)
+            finished = mx.logical_or(finished, semantic == config.eos_token_id)
+            mx.eval(finished, frame, code_lengths)
+            if bool(mx.all(finished)):
+                break
+
+            next_column = mx.concatenate((semantic[:, None], codebooks), axis=1)[..., None]
+            new_valid = active_before.astype(mx.int64)[:, None]
+            prompt_mask_np = mx.concatenate((prompt_mask_np, new_valid), axis=1)
+            physical_position = prompt_width + step
+            token_position = (prompt_lengths + step)[:, None]
+            logits, slow_hidden = self._slow_step(
+                next_column,
+                physical_position,
+                mx.array([physical_position]),
+                token_position,
+                prompt_mask_np,
+            )
+
+        self._clear_generation_caches()
+        if generated_frames:
+            codes = mx.stack(generated_frames, axis=2)
+            max_valid = int(mx.max(code_lengths).item()) if code_lengths.size else 0
+            codes = codes[:, :, :max_valid]
+        else:
+            codes = mx.zeros((batch_size, config.num_codebooks, 0), dtype=mx.int64)
+        return codes
+
+
+class Model(nn.Module):
+    """mlx-audio entry point wrapping ArkttsModel + ArkttsCodec + the prompt builder."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model = ArkttsModel(config)
+        self.codec = ArkttsCodec(config)
+        self._tokenizer = None
+        self.model_path: Optional[Path] = None
+
+    @property
+    def sample_rate(self) -> int:
+        return self.config.codec_sample_rate
+
+    @classmethod
+    def post_load_hook(cls, model: "Model", model_path: Path) -> "Model":
+        model.model_path = Path(model_path)
+        return model
+
+    # tokenizer / prompt -----------------------------------------------------
+    def _load_tokenizer(self):
+        if self._tokenizer is None:
+            from transformers import AutoTokenizer
+
+            # the reference processor pins fix_mistral_regex=False; match it
+            self._tokenizer = AutoTokenizer.from_pretrained(
+                str(self.model_path), use_fast=True, fix_mistral_regex=False
+            )
+        return self._tokenizer
+
+    @staticmethod
+    def _clean_text(text: str) -> str:
+        return " ".join(str(text).strip().split())
+
+    def _format_reference_text(self, text: str) -> str:
+        import re
+
+        cleaned = self._clean_text(text)
+        if re.search(r"<\|speaker:\d+\|>", cleaned):
+            return cleaned
+        return f"<|speaker:0|>{cleaned}"
+
+    def _prompt_segments(self, text: str, reference_text: Optional[str], has_reference: bool):
+        tokenizer = self._load_tokenizer()
+
+        def encode_parts(parts):
+            out = []
+            for part in parts:
+                out.extend(tokenizer.encode(part, add_special_tokens=False))
+            return np.asarray(out, dtype=np.int64)
+
+        target = self._clean_text(text)
+        if not target:
+            raise ValueError("text must not be empty")
+        if not has_reference:
+            full = encode_parts([
+                "<|im_start|>system\n",
+                "convert the provided text to speech",
+                "<|im_end|>\n",
+                "<|im_start|>user\n",
+                target,
+                "<|im_end|>\n",
+                "<|im_start|>assistant\n<|voice|>",
+            ])
+            return full, np.asarray([], dtype=np.int64)
+        if not reference_text:
+            raise ValueError("reference_text is required when a reference voice is provided")
+        prefix = encode_parts([
+            "<|im_start|>system\n",
+            "convert the provided text to speech reference to the following:\n\nText:\n",
+            self._format_reference_text(reference_text),
+            "\n\nSpeech:\n",
+        ])
+        suffix = encode_parts([
+            "<|im_end|>\n",
+            "<|im_start|>user\n",
+            target,
+            "<|im_end|>\n",
+            "<|im_start|>assistant\n<|voice|>",
+        ])
+        return prefix, suffix
+
+    # audio ------------------------------------------------------------------
+    def _load_reference_audio(self, ref_audio) -> mx.array:
+        import soundfile as sf
+
+        from mlx_audio.utils import resample_audio
+
+        if isinstance(ref_audio, (str, Path)):
+            array, source_rate = sf.read(str(ref_audio), dtype="float32", always_2d=True)
+            array = array.mean(axis=1)
+        else:
+            array = np.asarray(ref_audio, dtype=np.float32)
+            source_rate = self.config.codec_sample_rate
+        if int(source_rate) != self.config.codec_sample_rate:
+            array = np.asarray(
+                resample_audio(array, int(source_rate), self.config.codec_sample_rate),
+                dtype=np.float32,
+            )
+        return mx.array(array)
+
+    def encode_reference(self, ref_audio) -> tuple[mx.array, mx.array]:
+        audio = self._load_reference_audio(ref_audio)
+        codes, code_lengths = self.codec.encode(
+            audio[None], mx.array([audio.shape[0]], dtype=mx.int64)
+        )
+        return codes, code_lengths
+
+    # generation -------------------------------------------------------------
+    def generate(
+        self,
+        text: str,
+        ref_audio=None,
+        ref_text: Optional[str] = None,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int = 50,
+        max_tokens: int = 512,
+        do_sample: bool = True,
+        seed: Optional[int] = None,
+        verbose: bool = False,
+        **kwargs,
+    ):
+        start = time.time()
+        has_reference = ref_audio is not None
+        prefix, suffix = self._prompt_segments(text, ref_text, has_reference)
+        reference_codes = reference_code_lengths = None
+        if has_reference:
+            codes, lengths = self.encode_reference(ref_audio)
+            mx.eval(codes, lengths)
+            reference_codes = [np.asarray(codes[0])]
+            reference_code_lengths = np.asarray(lengths)
+
+        codes = self.model.generate_codes(
+            [prefix],
+            [suffix],
+            reference_codes,
+            reference_code_lengths,
+            max_new_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            do_sample=do_sample,
+            seed=seed,
+        )
+        mx.eval(codes)
+        token_count = codes.shape[-1]
+        if token_count == 0:
+            raise RuntimeError("Model generated no audio frames")
+        waveform = self.codec.decode(codes)[0]
+        mx.eval(waveform)
+        elapsed = time.time() - start
+        samples = waveform.shape[0]
+        duration = samples / self.sample_rate
+        yield GenerationResult(
+            audio=waveform,
+            samples=samples,
+            sample_rate=self.sample_rate,
+            segment_idx=0,
+            token_count=token_count,
+            audio_duration=time.strftime("%H:%M:%S", time.gmtime(duration)),
+            real_time_factor=elapsed / duration if duration else 0.0,
+            prompt={"text": text, "ref_text": ref_text},
+            audio_samples={"samples-per-sec": samples / elapsed if elapsed else 0.0},
+            processing_time_seconds=elapsed,
+            peak_memory_usage=mx.get_peak_memory() / 1e9,
+        )
+
+    # weights ----------------------------------------------------------------
+    def sanitize(self, weights: dict) -> dict:
+        """Remap reference checkpoints to this module tree.
+
+        Handles: LM keys (prefix under model.), codec keys (prefix under codec.),
+        weight-norm folding (both parametrizations and legacy g/v), conv layout
+        transposes, Snake alpha reshape, and dropped rope buffers.
+
+        Idempotent: weights already carrying the model./codec. prefixes (i.e. a
+        pre-converted mlx repo) pass through untouched.
+        """
+        if all(key.startswith(("model.", "codec.")) for key in weights):
+            return weights
+        out = {}
+        pending: dict[str, dict] = {}
+
+        def fold_weight_norm(g: mx.array, v: mx.array) -> mx.array:
+            # PyTorch weight_norm dim=0: per-output-channel norm over (I, K)
+            norm = mx.sqrt(
+                mx.sum(mx.square(v.reshape(v.shape[0], -1)), axis=1, keepdims=True)
+            ).reshape(v.shape[0], *([1] * (v.ndim - 1)))
+            return g * v / norm
+
+        for key, value in weights.items():
+            if key.endswith(("freqs_cis", "causal_mask")):
+                continue
+            if key.startswith("generator."):
+                key = key[len("generator."):]
+            if not key.startswith(("model.", "codec.")):
+                # raw reference LM checkpoint keys arrive unprefixed;
+                # raw codec.pth keys arrive as encoder./decoder./quantizer.
+                if key.split(".")[0] in ("encoder", "decoder", "quantizer"):
+                    key = "codec." + key
+                else:
+                    key = "model." + key
+            # collect weight-norm pairs for folding
+            if ".parametrizations.weight.original0" in key:
+                base = key.replace(".parametrizations.weight.original0", ".weight")
+                pending.setdefault(base, {})["g"] = value
+                continue
+            if ".parametrizations.weight.original1" in key:
+                base = key.replace(".parametrizations.weight.original1", ".weight")
+                pending.setdefault(base, {})["v"] = value
+                continue
+            if key.endswith(".weight_g"):
+                base = key[: -len(".weight_g")] + ".weight"
+                pending.setdefault(base, {})["g"] = value
+                continue
+            if key.endswith(".weight_v"):
+                base = key[: -len(".weight_v")] + ".weight"
+                pending.setdefault(base, {})["v"] = value
+                continue
+            out[key] = value
+
+        for base, pair in pending.items():
+            out[base] = fold_weight_norm(pair["g"], pair["v"])
+
+        remapped = {}
+        for key, value in out.items():
+            if key.startswith("codec."):
+                if key.endswith("alpha"):
+                    # Snake (1, C, 1) -> (1, 1, C)
+                    value = value.transpose(0, 2, 1)
+                elif key.endswith(".conv.weight") and value.ndim == 3:
+                    if isinstance_transpose(key):
+                        # ConvTranspose1d: torch (I, O, K) -> mlx (O, K, I)
+                        value = value.transpose(1, 2, 0)
+                    else:
+                        # Conv1d: torch (O, I, K) -> mlx (O, K, I)
+                        value = value.transpose(0, 2, 1)
+                elif (".in_proj.weight" in key or ".out_proj.weight" in key) and value.ndim == 3:
+                    # VQ 1x1 convs: torch (O, I, 1) -> mlx (O, 1, I)
+                    value = value.transpose(0, 2, 1)
+            remapped[key] = value
+        return remapped
+
+
+def isinstance_transpose(key: str) -> bool:
+    """Conv keys that belong to ArkttsCausalConvTranspose1d modules:
+    decoder blocks 1..4 hold theirs at block.1.conv; the quantizer's upsample
+    stages hold theirs at upsample.<i>.0.conv (the .1 ConvNeXt dwconv is a
+    regular grouped conv)."""
+    import re
+
+    return (
+        re.search(r"decoder\.model\.[1-4]\.block\.1\.conv\.weight$", key) is not None
+        or re.search(r"quantizer\.upsample\.\d+\.0\.conv\.weight$", key) is not None
+    )

--- a/mlx_audio/tts/models/arktts/arktts.py
+++ b/mlx_audio/tts/models/arktts/arktts.py
@@ -286,6 +286,11 @@ class ArkttsModel(nn.Module):
         self._fast_freqs_cis = _precompute_rope(
             config.num_codebooks, config.fast_head_dim, config.rope_base
         )
+        # Materialize the rope tables now. They are plain attributes rather than module
+        # parameters, so nothing else forces them; left lazy, their graph would first be
+        # evaluated inside whichever stream/thread happens to run the first forward, which
+        # crashes when the model is moved across streams.
+        mx.eval((self._freqs_cis, self._fast_freqs_cis))
 
     # -- embedding -----------------------------------------------------------
     def _embed(self, input_ids: mx.array) -> mx.array:

--- a/mlx_audio/tts/models/arktts/codec.py
+++ b/mlx_audio/tts/models/arktts/codec.py
@@ -28,7 +28,9 @@ def _rope(length: int, head_dim: int, base: float) -> mx.array:
 def _apply_rope(x: mx.array, values: mx.array) -> mx.array:
     # x: (B, T, H, D)
     shaped = x.astype(mx.float32).reshape(*x.shape[:-1], -1, 2)
-    values = values.astype(mx.float32).reshape(1, shaped.shape[1], 1, shaped.shape[3], 2)
+    values = values.astype(mx.float32).reshape(
+        1, shaped.shape[1], 1, shaped.shape[3], 2
+    )
     output = mx.stack(
         (
             shaped[..., 0] * values[..., 0] - shaped[..., 1] * values[..., 1],
@@ -143,15 +145,21 @@ class ArkttsCodecWindowTransformer(nn.Module):
         causal: bool = True,
     ):
         super().__init__()
-        self.layers = [ArkttsCodecTransformerBlock(config) for _ in range(config.n_layer)]
+        self.layers = [
+            ArkttsCodecTransformerBlock(config) for _ in range(config.n_layer)
+        ]
         self.norm = ArkttsCodecRMSNorm(config.dim, config.norm_eps)
         self.window_size = window_size
         self.causal = causal
         self.input_proj = (
-            nn.Linear(input_dim, config.dim) if input_dim != config.dim else nn.Identity()
+            nn.Linear(input_dim, config.dim)
+            if input_dim != config.dim
+            else nn.Identity()
         )
         self.output_proj = (
-            nn.Linear(config.dim, input_dim) if input_dim != config.dim else nn.Identity()
+            nn.Linear(config.dim, input_dim)
+            if input_dim != config.dim
+            else nn.Identity()
         )
         self.head_dim = config.head_dim
         self.rope_base = config.rope_base
@@ -174,7 +182,9 @@ class ArkttsCodecWindowTransformer(nn.Module):
         return self.output_proj(self.norm(x))
 
 
-def _extra_padding(x: mx.array, kernel_size: int, stride: int, padding_total: int = 0) -> int:
+def _extra_padding(
+    x: mx.array, kernel_size: int, stride: int, padding_total: int = 0
+) -> int:
     length = x.shape[1]
     frames = (length - kernel_size + padding_total) / stride + 1
     ideal = (math.ceil(frames) - 1) * stride + kernel_size - padding_total
@@ -182,11 +192,17 @@ def _extra_padding(x: mx.array, kernel_size: int, stride: int, padding_total: in
 
 
 class ArkttsCausalConv1d(nn.Module):
-    def __init__(self, in_channels, out_channels, kernel_size, dilation=1, stride=1, groups=1):
+    def __init__(
+        self, in_channels, out_channels, kernel_size, dilation=1, stride=1, groups=1
+    ):
         super().__init__()
         self.conv = nn.Conv1d(
-            in_channels, out_channels, kernel_size,
-            stride=stride, dilation=dilation, groups=groups,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            dilation=dilation,
+            groups=groups,
         )
         self.stride = stride
         self.kernel_size = (kernel_size - 1) * dilation + 1
@@ -279,7 +295,9 @@ class ArkttsEncoder(nn.Module):
         for stride, transformer_layers in zip((2, 4, 8, 8), (0, 0, 0, 4)):
             dim *= 2
             modules.append(ArkttsEncoderBlock(dim, stride, transformer_layers))
-        modules.extend((ArkttsSnake1d(dim), ArkttsCausalConv1d(dim, 1024, kernel_size=3)))
+        modules.extend(
+            (ArkttsSnake1d(dim), ArkttsCausalConv1d(dim, 1024, kernel_size=3))
+        )
         self.block = modules
 
     def __call__(self, x: mx.array) -> mx.array:
@@ -293,7 +311,9 @@ class ArkttsDecoderBlock(nn.Module):
         super().__init__()
         self.block = [
             ArkttsSnake1d(input_dim),
-            ArkttsCausalConvTranspose1d(input_dim, output_dim, kernel_size=2 * stride, stride=stride),
+            ArkttsCausalConvTranspose1d(
+                input_dim, output_dim, kernel_size=2 * stride, stride=stride
+            ),
             ArkttsResidualUnit(output_dim, 1),
             ArkttsResidualUnit(output_dim, 3),
             ArkttsResidualUnit(output_dim, 9),
@@ -315,7 +335,10 @@ class ArkttsDecoder(nn.Module):
             output_dim = channels // (2 ** (index + 1))
             modules.append(ArkttsDecoderBlock(input_dim, output_dim, stride))
         modules.extend(
-            (ArkttsSnake1d(output_dim), ArkttsCausalConv1d(output_dim, 1, kernel_size=7))
+            (
+                ArkttsSnake1d(output_dim),
+                ArkttsCausalConv1d(output_dim, 1, kernel_size=7),
+            )
         )
         self.model = modules
 
@@ -364,7 +387,9 @@ class ArkttsVectorQuantizer(nn.Module):
 
 
 class ArkttsResidualQuantizer(nn.Module):
-    def __init__(self, input_dim: int, n_codebooks: int, codebook_size: int, codebook_dim: int):
+    def __init__(
+        self, input_dim: int, n_codebooks: int, codebook_size: int, codebook_dim: int
+    ):
         super().__init__()
         self.n_codebooks = int(n_codebooks)
         self.codebook_size = int(codebook_size)
@@ -414,12 +439,24 @@ class ArkttsDownsampleQuantizer(nn.Module):
         self.semantic_quantizer = ArkttsResidualQuantizer(1024, 1, 4096, 8)
         self.quantizer = ArkttsResidualQuantizer(1024, 9, 1024, 8)
         self.downsample = [
-            [ArkttsCausalConv1d(1024, 1024, kernel_size=2, stride=2), ArkttsConvNeXtBlock(1024)],
-            [ArkttsCausalConv1d(1024, 1024, kernel_size=2, stride=2), ArkttsConvNeXtBlock(1024)],
+            [
+                ArkttsCausalConv1d(1024, 1024, kernel_size=2, stride=2),
+                ArkttsConvNeXtBlock(1024),
+            ],
+            [
+                ArkttsCausalConv1d(1024, 1024, kernel_size=2, stride=2),
+                ArkttsConvNeXtBlock(1024),
+            ],
         ]
         self.upsample = [
-            [ArkttsCausalConvTranspose1d(1024, 1024, kernel_size=2, stride=2), ArkttsConvNeXtBlock(1024)],
-            [ArkttsCausalConvTranspose1d(1024, 1024, kernel_size=2, stride=2), ArkttsConvNeXtBlock(1024)],
+            [
+                ArkttsCausalConvTranspose1d(1024, 1024, kernel_size=2, stride=2),
+                ArkttsConvNeXtBlock(1024),
+            ],
+            [
+                ArkttsCausalConvTranspose1d(1024, 1024, kernel_size=2, stride=2),
+                ArkttsConvNeXtBlock(1024),
+            ],
         ]
         pre_transformer_config = ArkttsCodecTransformerConfig(
             n_layer=8, n_head=16, dim=1024, intermediate_size=3072
@@ -429,10 +466,16 @@ class ArkttsDownsampleQuantizer(nn.Module):
             n_head=int(getattr(config, "codec_post_n_head", 16)),
             n_local_heads=int(getattr(config, "codec_post_n_local_heads", 8)),
             dim=1024,
-            intermediate_size=int(getattr(config, "codec_post_intermediate_size", 1216)),
+            intermediate_size=int(
+                getattr(config, "codec_post_intermediate_size", 1216)
+            ),
         )
-        self.pre_module = ArkttsCodecWindowTransformer(pre_transformer_config, 1024, window_size=128)
-        self.post_module = ArkttsCodecWindowTransformer(post_transformer_config, 1024, window_size=128)
+        self.pre_module = ArkttsCodecWindowTransformer(
+            pre_transformer_config, 1024, window_size=128
+        )
+        self.post_module = ArkttsCodecWindowTransformer(
+            post_transformer_config, 1024, window_size=128
+        )
 
     def _run(self, stages, x: mx.array) -> mx.array:
         for stage in stages:
@@ -454,7 +497,9 @@ class ArkttsDownsampleQuantizer(nn.Module):
         return z, mx.concatenate((semantic_codes, residual_codes), axis=1)
 
     def decode(self, indices: mx.array) -> mx.array:
-        semantic_indices = mx.clip(indices[:, :1], 0, self.semantic_quantizer.codebook_size - 1)
+        semantic_indices = mx.clip(
+            indices[:, :1], 0, self.semantic_quantizer.codebook_size - 1
+        )
         residual_indices = mx.clip(indices[:, 1:], 0, self.quantizer.codebook_size - 1)
         semantic = self.semantic_quantizer.from_codes(semantic_indices)
         residual = self.quantizer.from_codes(residual_indices)
@@ -479,7 +524,10 @@ class ArkttsCodec(nn.Module):
         if audio.ndim != 3 or audio.shape[-1] != 1:
             raise ValueError("audio must have shape [B, samples, 1]")
         original_length = audio.shape[1]
-        right = math.ceil(original_length / self.frame_length) * self.frame_length - original_length
+        right = (
+            math.ceil(original_length / self.frame_length) * self.frame_length
+            - original_length
+        )
         if right:
             audio = mx.pad(audio, ((0, 0), (0, right), (0, 0)))
         if audio_lengths is None:
@@ -487,7 +535,9 @@ class ArkttsCodec(nn.Module):
         encoded = self.encoder(audio)
         _, codes = self.quantizer(encoded)
         codes = codes.astype(mx.int64)
-        code_lengths = mx.ceil(audio_lengths.astype(mx.float32) / self.frame_length).astype(mx.int64)
+        code_lengths = mx.ceil(
+            audio_lengths.astype(mx.float32) / self.frame_length
+        ).astype(mx.int64)
         max_codes = codes.shape[-1]
         frame_positions = mx.arange(max_codes)[None, None, :]
         valid = frame_positions < code_lengths[:, None, None]

--- a/mlx_audio/tts/models/arktts/codec.py
+++ b/mlx_audio/tts/models/arktts/codec.py
@@ -1,0 +1,499 @@
+"""MLX port of modeling_arktts_codec.py (Audio8-TTS 44.1 kHz codec).
+
+Layout note: MLX convs are channels-last, so every tensor here is (B, T, C)
+where the reference uses (B, C, T). The reference's `channels_first` transposes
+therefore become no-ops; time-axis pads/crops move from axis -1 to axis 1.
+Everything else mirrors the reference file class-for-class, line-for-line.
+Weight-norm folding and conv-layout transposes happen in Model.sanitize().
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _rope(length: int, head_dim: int, base: float) -> mx.array:
+    frequencies = 1.0 / (
+        base ** (mx.arange(0, head_dim, 2).astype(mx.float32) / head_dim)
+    )
+    phases = mx.arange(length).astype(mx.float32)[:, None] * frequencies[None, :]
+    # reference builds torch.polar(...) then casts the (real, imag) stack to bf16
+    return mx.stack((mx.cos(phases), mx.sin(phases)), axis=-1).astype(mx.bfloat16)
+
+
+def _apply_rope(x: mx.array, values: mx.array) -> mx.array:
+    # x: (B, T, H, D)
+    shaped = x.astype(mx.float32).reshape(*x.shape[:-1], -1, 2)
+    values = values.astype(mx.float32).reshape(1, shaped.shape[1], 1, shaped.shape[3], 2)
+    output = mx.stack(
+        (
+            shaped[..., 0] * values[..., 0] - shaped[..., 1] * values[..., 1],
+            shaped[..., 1] * values[..., 0] + shaped[..., 0] * values[..., 1],
+        ),
+        axis=-1,
+    )
+    return output.flatten(3).astype(x.dtype)
+
+
+class ArkttsCodecRMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = float(eps)
+        self.weight = mx.ones((dim,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        xf = x.astype(mx.float32)
+        output = xf * mx.rsqrt(mx.mean(xf * xf, axis=-1, keepdims=True) + self.eps)
+        return output.astype(x.dtype) * self.weight
+
+
+class ArkttsCodecLayerScale(nn.Module):
+    def __init__(self, dim: int, init_values: float = 1e-2):
+        super().__init__()
+        self.gamma = init_values * mx.ones((dim,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x * self.gamma
+
+
+@dataclass
+class ArkttsCodecTransformerConfig:
+    n_layer: int
+    n_head: int
+    dim: int
+    intermediate_size: int
+    n_local_heads: int = -1
+    head_dim: int = 64
+    rope_base: float = 10000
+    norm_eps: float = 1e-5
+    channels_first: bool = True
+
+    def __post_init__(self):
+        if self.n_local_heads == -1:
+            self.n_local_heads = self.n_head
+
+
+class ArkttsCodecAttention(nn.Module):
+    def __init__(self, config: ArkttsCodecTransformerConfig):
+        super().__init__()
+        total = (config.n_head + 2 * config.n_local_heads) * config.head_dim
+        self.wqkv = nn.Linear(config.dim, total, bias=False)
+        self.wo = nn.Linear(config.head_dim * config.n_head, config.dim, bias=False)
+        self.n_head = config.n_head
+        self.n_local_heads = config.n_local_heads
+        self.head_dim = config.head_dim
+
+    def __call__(self, x: mx.array, rope_values: mx.array, mask: mx.array) -> mx.array:
+        batch, length, _ = x.shape
+        query_size = self.n_head * self.head_dim
+        kv_size = self.n_local_heads * self.head_dim
+        qkv = self.wqkv(x)
+        query, key, value = mx.split(qkv, [query_size, query_size + kv_size], axis=-1)
+        query = query.reshape(batch, length, self.n_head, self.head_dim)
+        key = key.reshape(batch, length, self.n_local_heads, self.head_dim)
+        value = value.reshape(batch, length, self.n_local_heads, self.head_dim)
+        query = _apply_rope(query, rope_values).transpose(0, 2, 1, 3)
+        key = _apply_rope(key, rope_values).transpose(0, 2, 1, 3)
+        value = value.transpose(0, 2, 1, 3)
+        output = mx.fast.scaled_dot_product_attention(
+            query, key, value, scale=1.0 / math.sqrt(self.head_dim), mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, query_size)
+        return self.wo(output)
+
+
+class ArkttsCodecFeedForward(nn.Module):
+    def __init__(self, config: ArkttsCodecTransformerConfig):
+        super().__init__()
+        self.w1 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w3 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w2 = nn.Linear(config.intermediate_size, config.dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.w2(nn.silu(self.w1(x)) * self.w3(x))
+
+
+class ArkttsCodecTransformerBlock(nn.Module):
+    def __init__(self, config: ArkttsCodecTransformerConfig):
+        super().__init__()
+        self.attention = ArkttsCodecAttention(config)
+        self.feed_forward = ArkttsCodecFeedForward(config)
+        self.ffn_norm = ArkttsCodecRMSNorm(config.dim, config.norm_eps)
+        self.attention_norm = ArkttsCodecRMSNorm(config.dim, config.norm_eps)
+        self.attention_layer_scale = ArkttsCodecLayerScale(config.dim)
+        self.ffn_layer_scale = ArkttsCodecLayerScale(config.dim)
+
+    def __call__(self, x: mx.array, rope_values: mx.array, mask: mx.array) -> mx.array:
+        hidden = x + self.attention_layer_scale(
+            self.attention(self.attention_norm(x), rope_values, mask)
+        )
+        return hidden + self.ffn_layer_scale(self.feed_forward(self.ffn_norm(hidden)))
+
+
+class ArkttsCodecWindowTransformer(nn.Module):
+    def __init__(
+        self,
+        config: ArkttsCodecTransformerConfig,
+        input_dim: int,
+        window_size: int | None,
+        causal: bool = True,
+    ):
+        super().__init__()
+        self.layers = [ArkttsCodecTransformerBlock(config) for _ in range(config.n_layer)]
+        self.norm = ArkttsCodecRMSNorm(config.dim, config.norm_eps)
+        self.window_size = window_size
+        self.causal = causal
+        self.input_proj = (
+            nn.Linear(input_dim, config.dim) if input_dim != config.dim else nn.Identity()
+        )
+        self.output_proj = (
+            nn.Linear(config.dim, input_dim) if input_dim != config.dim else nn.Identity()
+        )
+        self.head_dim = config.head_dim
+        self.rope_base = config.rope_base
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # reference transposes channels-first input; MLX tensors are already (B, T, C)
+        x = self.input_proj(x)
+        length = x.shape[1]
+        row = mx.arange(length)[:, None]
+        column = mx.arange(length)[None, :]
+        mask = column <= row
+        if self.window_size is not None:
+            mask = mx.logical_and(
+                mask, column >= mx.maximum(row - self.window_size + 1, 0)
+            )
+        mask = mask[None, None]
+        rope_values = _rope(length, self.head_dim, self.rope_base)
+        for layer in self.layers:
+            x = layer(x, rope_values, mask)
+        return self.output_proj(self.norm(x))
+
+
+def _extra_padding(x: mx.array, kernel_size: int, stride: int, padding_total: int = 0) -> int:
+    length = x.shape[1]
+    frames = (length - kernel_size + padding_total) / stride + 1
+    ideal = (math.ceil(frames) - 1) * stride + kernel_size - padding_total
+    return ideal - length
+
+
+class ArkttsCausalConv1d(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size, dilation=1, stride=1, groups=1):
+        super().__init__()
+        self.conv = nn.Conv1d(
+            in_channels, out_channels, kernel_size,
+            stride=stride, dilation=dilation, groups=groups,
+        )
+        self.stride = stride
+        self.kernel_size = (kernel_size - 1) * dilation + 1
+        self.padding = self.kernel_size - self.stride
+
+    def __call__(self, x: mx.array) -> mx.array:
+        right = _extra_padding(x, self.kernel_size, self.stride, self.padding)
+        x = mx.pad(x, ((0, 0), (self.padding, right), (0, 0)))
+        return self.conv(x)
+
+
+class ArkttsCausalConvTranspose1d(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1, dilation=1):
+        super().__init__()
+        self.conv = nn.ConvTranspose1d(
+            in_channels, out_channels, kernel_size, stride=stride
+        )
+        self.stride = stride
+        self.kernel_size = kernel_size
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = self.conv(x)
+        crop = self.kernel_size - self.stride
+        return x[:, : x.shape[1] - crop] if crop else x
+
+
+class ArkttsSnake1d(nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        # reference alpha is (1, C, 1); sanitize reshapes it to (1, 1, C) for channels-last
+        self.alpha = mx.ones((1, 1, channels))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x + mx.reciprocal(self.alpha + 1e-9) * mx.square(mx.sin(self.alpha * x))
+
+
+class ArkttsResidualUnit(nn.Module):
+    def __init__(self, dim: int, dilation: int):
+        super().__init__()
+        self.block = [
+            ArkttsSnake1d(dim),
+            ArkttsCausalConv1d(dim, dim, kernel_size=7, dilation=dilation),
+            ArkttsSnake1d(dim),
+            ArkttsCausalConv1d(dim, dim, kernel_size=1),
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        output = x
+        for module in self.block:
+            output = module(output)
+        difference = x.shape[1] - output.shape[1]
+        if difference > 0:
+            x = x[:, :-difference]
+        return x + output
+
+
+class ArkttsEncoderBlock(nn.Module):
+    def __init__(self, dim: int, stride: int, transformer_layers: int):
+        super().__init__()
+        modules = [
+            ArkttsResidualUnit(dim // 2, 1),
+            ArkttsResidualUnit(dim // 2, 3),
+            ArkttsResidualUnit(dim // 2, 9),
+            ArkttsSnake1d(dim // 2),
+            ArkttsCausalConv1d(dim // 2, dim, kernel_size=2 * stride, stride=stride),
+        ]
+        if transformer_layers:
+            config = ArkttsCodecTransformerConfig(
+                n_layer=transformer_layers,
+                n_head=dim // 64,
+                dim=dim,
+                intermediate_size=dim * 3,
+            )
+            modules.append(ArkttsCodecWindowTransformer(config, dim, window_size=512))
+        else:
+            modules.append(nn.Identity())
+        self.block = modules
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for module in self.block:
+            x = module(x)
+        return x
+
+
+class ArkttsEncoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        dim = 64
+        modules = [ArkttsCausalConv1d(1, dim, kernel_size=7)]
+        for stride, transformer_layers in zip((2, 4, 8, 8), (0, 0, 0, 4)):
+            dim *= 2
+            modules.append(ArkttsEncoderBlock(dim, stride, transformer_layers))
+        modules.extend((ArkttsSnake1d(dim), ArkttsCausalConv1d(dim, 1024, kernel_size=3)))
+        self.block = modules
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for module in self.block:
+            x = module(x)
+        return x
+
+
+class ArkttsDecoderBlock(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, stride: int):
+        super().__init__()
+        self.block = [
+            ArkttsSnake1d(input_dim),
+            ArkttsCausalConvTranspose1d(input_dim, output_dim, kernel_size=2 * stride, stride=stride),
+            ArkttsResidualUnit(output_dim, 1),
+            ArkttsResidualUnit(output_dim, 3),
+            ArkttsResidualUnit(output_dim, 9),
+        ]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for module in self.block:
+            x = module(x)
+        return x
+
+
+class ArkttsDecoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        channels = 1536
+        modules = [ArkttsCausalConv1d(1024, channels, kernel_size=7)]
+        for index, stride in enumerate((8, 8, 4, 2)):
+            input_dim = channels // (2**index)
+            output_dim = channels // (2 ** (index + 1))
+            modules.append(ArkttsDecoderBlock(input_dim, output_dim, stride))
+        modules.extend(
+            (ArkttsSnake1d(output_dim), ArkttsCausalConv1d(output_dim, 1, kernel_size=7))
+        )
+        self.model = modules
+
+    def __call__(self, x: mx.array) -> mx.array:
+        for module in self.model:
+            x = module(x)
+        return mx.tanh(x)
+
+
+class ArkttsVectorQuantizer(nn.Module):
+    def __init__(self, input_dim: int, codebook_size: int, codebook_dim: int):
+        super().__init__()
+        self.codebook_size = int(codebook_size)
+        self.codebook_dim = int(codebook_dim)
+        # 1x1 convs in the reference; stored transposed to (O, 1, I) MLX layout
+        self.in_proj = nn.Conv1d(input_dim, codebook_dim, kernel_size=1)
+        self.out_proj = nn.Conv1d(codebook_dim, input_dim, kernel_size=1)
+        self.codebook = nn.Embedding(codebook_size, codebook_dim)
+
+    def decode_code(self, indices: mx.array) -> mx.array:
+        # (B, T) -> (B, T, D); the reference returns channels-first, we stay (B, T, D)
+        return self.codebook(indices)
+
+    def decode_latents(self, latents: mx.array):
+        batch, length, _ = latents.shape
+        flattened = latents.reshape(batch * length, -1)
+        flattened = flattened / mx.maximum(
+            mx.linalg.norm(flattened, axis=-1, keepdims=True), 1e-12
+        )
+        codebook = self.codebook.weight
+        codebook = codebook / mx.maximum(
+            mx.linalg.norm(codebook, axis=-1, keepdims=True), 1e-12
+        )
+        distances = (
+            mx.sum(mx.square(flattened), axis=1, keepdims=True)
+            - 2 * flattened @ codebook.T
+            + mx.sum(mx.square(codebook), axis=1, keepdims=True).T
+        )
+        indices = mx.argmax(-distances, axis=1).reshape(batch, length)
+        return self.decode_code(indices), indices
+
+    def __call__(self, z: mx.array):
+        projected = self.in_proj(z)
+        quantized, indices = self.decode_latents(projected)
+        return self.out_proj(quantized), indices, projected
+
+
+class ArkttsResidualQuantizer(nn.Module):
+    def __init__(self, input_dim: int, n_codebooks: int, codebook_size: int, codebook_dim: int):
+        super().__init__()
+        self.n_codebooks = int(n_codebooks)
+        self.codebook_size = int(codebook_size)
+        self.quantizers = [
+            ArkttsVectorQuantizer(input_dim, codebook_size, codebook_dim)
+            for _ in range(n_codebooks)
+        ]
+
+    def __call__(self, z: mx.array):
+        quantized_sum = 0.0
+        residual = z
+        codes = []
+        for quantizer in self.quantizers:
+            quantized, indices, _ = quantizer(residual)
+            quantized_sum = quantized_sum + quantized
+            residual = residual - quantized
+            codes.append(indices)
+        return quantized_sum, mx.stack(codes, axis=1)
+
+    def from_codes(self, codes: mx.array) -> mx.array:
+        output = 0.0
+        for index in range(codes.shape[1]):
+            projected = self.quantizers[index].decode_code(codes[:, index])
+            output = output + self.quantizers[index].out_proj(projected)
+        return output
+
+
+class ArkttsConvNeXtBlock(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dwconv = ArkttsCausalConv1d(dim, dim, kernel_size=7, groups=dim)
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.pwconv1 = nn.Linear(dim, 4 * dim)
+        self.pwconv2 = nn.Linear(4 * dim, dim)
+        self.gamma = 1e-6 * mx.ones((dim,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        residual = x
+        x = self.dwconv(x)
+        x = self.pwconv2(nn.gelu(self.pwconv1(self.norm(x))))
+        return residual + self.gamma * x
+
+
+class ArkttsDownsampleQuantizer(nn.Module):
+    def __init__(self, config=None):
+        super().__init__()
+        self.semantic_quantizer = ArkttsResidualQuantizer(1024, 1, 4096, 8)
+        self.quantizer = ArkttsResidualQuantizer(1024, 9, 1024, 8)
+        self.downsample = [
+            [ArkttsCausalConv1d(1024, 1024, kernel_size=2, stride=2), ArkttsConvNeXtBlock(1024)],
+            [ArkttsCausalConv1d(1024, 1024, kernel_size=2, stride=2), ArkttsConvNeXtBlock(1024)],
+        ]
+        self.upsample = [
+            [ArkttsCausalConvTranspose1d(1024, 1024, kernel_size=2, stride=2), ArkttsConvNeXtBlock(1024)],
+            [ArkttsCausalConvTranspose1d(1024, 1024, kernel_size=2, stride=2), ArkttsConvNeXtBlock(1024)],
+        ]
+        pre_transformer_config = ArkttsCodecTransformerConfig(
+            n_layer=8, n_head=16, dim=1024, intermediate_size=3072
+        )
+        post_transformer_config = ArkttsCodecTransformerConfig(
+            n_layer=int(getattr(config, "codec_post_n_layer", 8)),
+            n_head=int(getattr(config, "codec_post_n_head", 16)),
+            n_local_heads=int(getattr(config, "codec_post_n_local_heads", 8)),
+            dim=1024,
+            intermediate_size=int(getattr(config, "codec_post_intermediate_size", 1216)),
+        )
+        self.pre_module = ArkttsCodecWindowTransformer(pre_transformer_config, 1024, window_size=128)
+        self.post_module = ArkttsCodecWindowTransformer(post_transformer_config, 1024, window_size=128)
+
+    def _run(self, stages, x: mx.array) -> mx.array:
+        for stage in stages:
+            for module in stage:
+                x = module(x)
+        return x
+
+    def __call__(self, z: mx.array):
+        original_length = z.shape[1]
+        z = self.pre_module(self._run(self.downsample, z))
+        semantic, semantic_codes = self.semantic_quantizer(z)
+        residual, residual_codes = self.quantizer(z - semantic)
+        z = self._run(self.upsample, self.post_module(semantic + residual))
+        difference = original_length - z.shape[1]
+        if difference > 0:
+            z = mx.pad(z, ((0, 0), (difference, 0), (0, 0)))
+        elif difference < 0:
+            z = z[:, -difference:]
+        return z, mx.concatenate((semantic_codes, residual_codes), axis=1)
+
+    def decode(self, indices: mx.array) -> mx.array:
+        semantic_indices = mx.clip(indices[:, :1], 0, self.semantic_quantizer.codebook_size - 1)
+        residual_indices = mx.clip(indices[:, 1:], 0, self.quantizer.codebook_size - 1)
+        semantic = self.semantic_quantizer.from_codes(semantic_indices)
+        residual = self.quantizer.from_codes(residual_indices)
+        return self._run(self.upsample, self.post_module(semantic + residual))
+
+
+class ArkttsCodec(nn.Module):
+    sample_rate = 44100
+    hop_length = 512
+    frame_length = 2048
+
+    def __init__(self, config=None):
+        super().__init__()
+        self.encoder = ArkttsEncoder()
+        self.quantizer = ArkttsDownsampleQuantizer(config)
+        self.decoder = ArkttsDecoder()
+
+    def encode(self, audio: mx.array, audio_lengths: mx.array | None = None):
+        """audio: (B, samples) or (B, samples, 1) mono waveform in [-1, 1]."""
+        if audio.ndim == 2:
+            audio = audio[..., None]
+        if audio.ndim != 3 or audio.shape[-1] != 1:
+            raise ValueError("audio must have shape [B, samples, 1]")
+        original_length = audio.shape[1]
+        right = math.ceil(original_length / self.frame_length) * self.frame_length - original_length
+        if right:
+            audio = mx.pad(audio, ((0, 0), (0, right), (0, 0)))
+        if audio_lengths is None:
+            audio_lengths = mx.full((audio.shape[0],), original_length, dtype=mx.int64)
+        encoded = self.encoder(audio)
+        _, codes = self.quantizer(encoded)
+        codes = codes.astype(mx.int64)
+        code_lengths = mx.ceil(audio_lengths.astype(mx.float32) / self.frame_length).astype(mx.int64)
+        max_codes = codes.shape[-1]
+        frame_positions = mx.arange(max_codes)[None, None, :]
+        valid = frame_positions < code_lengths[:, None, None]
+        padded = mx.where(valid, codes, -1)
+        return padded, mx.minimum(code_lengths, max_codes)
+
+    def decode(self, codes: mx.array) -> mx.array:
+        """codes: (B, num_codebooks, T) -> waveform (B, samples)."""
+        return self.decoder(self.quantizer.decode(codes.astype(mx.int64)))[..., 0]

--- a/mlx_audio/tts/tests/test_arktts.py
+++ b/mlx_audio/tts/tests/test_arktts.py
@@ -82,15 +82,28 @@ class TestArkttsSanitize(unittest.TestCase):
                 "encoder.block.1.block.0.block.0.alpha": mx.zeros((1, 64, 1)),
             },
         )
-        self.assertEqual(out["codec.decoder.model.1.block.1.conv.weight"].shape, (8, 4, 16))
-        self.assertEqual(out["codec.quantizer.upsample.0.0.conv.weight"].shape, (8, 2, 16))
-        self.assertEqual(out["codec.quantizer.upsample.0.1.dwconv.conv.weight"].shape, (16, 7, 1))
-        self.assertEqual(out["codec.quantizer.downsample.0.0.conv.weight"].shape, (16, 2, 16))
-        self.assertEqual(out["codec.encoder.block.1.block.0.block.0.alpha"].shape, (1, 1, 64))
+        self.assertEqual(
+            out["codec.decoder.model.1.block.1.conv.weight"].shape, (8, 4, 16)
+        )
+        self.assertEqual(
+            out["codec.quantizer.upsample.0.0.conv.weight"].shape, (8, 2, 16)
+        )
+        self.assertEqual(
+            out["codec.quantizer.upsample.0.1.dwconv.conv.weight"].shape, (16, 7, 1)
+        )
+        self.assertEqual(
+            out["codec.quantizer.downsample.0.0.conv.weight"].shape, (16, 2, 16)
+        )
+        self.assertEqual(
+            out["codec.encoder.block.1.block.0.block.0.alpha"].shape, (1, 1, 64)
+        )
 
     def test_idempotent_on_converted_weights(self):
         model = Model.__new__(Model)
-        converted = {"model.embeddings.weight": mx.zeros((8, 4)), "codec.x": mx.zeros((2,))}
+        converted = {
+            "model.embeddings.weight": mx.zeros((8, 4)),
+            "codec.x": mx.zeros((2,)),
+        }
         out = Model.sanitize(model, converted)
         self.assertEqual(set(out), set(converted))
         self.assertEqual(out["model.embeddings.weight"].shape, (8, 4))
@@ -107,7 +120,9 @@ class TestArkttsTinyModel(unittest.TestCase):
         lm = ArkttsModel(config)
         mx.eval(lm.parameters())
         batch, width = 1, 12
-        prompt = np.random.randint(0, 255, size=(batch, config.num_codebooks + 1, width))
+        prompt = np.random.randint(
+            0, 255, size=(batch, config.num_codebooks + 1, width)
+        )
         prompt[:, 0, -3:] = np.random.randint(
             config.semantic_begin_id, config.semantic_end_id, size=(batch, 3)
         )
@@ -117,9 +132,7 @@ class TestArkttsTinyModel(unittest.TestCase):
 
         prefix = np.arange(5, dtype=np.int64)
         suffix = np.arange(3, dtype=np.int64)
-        codes = lm.generate_codes(
-            [prefix], [suffix], max_new_tokens=4, do_sample=False
-        )
+        codes = lm.generate_codes([prefix], [suffix], max_new_tokens=4, do_sample=False)
         self.assertEqual(codes.shape[0], batch)
         self.assertEqual(codes.shape[1], config.num_codebooks)
         self.assertLessEqual(codes.shape[2], 4)
@@ -130,8 +143,12 @@ class TestArkttsTinyModel(unittest.TestCase):
         mx.eval(lm.parameters())
         prefix = np.arange(5, dtype=np.int64)
         suffix = np.arange(3, dtype=np.int64)
-        a = lm.generate_codes([prefix], [suffix], max_new_tokens=4, do_sample=True, seed=11)
-        b = lm.generate_codes([prefix], [suffix], max_new_tokens=4, do_sample=True, seed=11)
+        a = lm.generate_codes(
+            [prefix], [suffix], max_new_tokens=4, do_sample=True, seed=11
+        )
+        b = lm.generate_codes(
+            [prefix], [suffix], max_new_tokens=4, do_sample=True, seed=11
+        )
         self.assertTrue(np.array_equal(np.asarray(a), np.asarray(b)))
 
 

--- a/mlx_audio/tts/tests/test_arktts.py
+++ b/mlx_audio/tts/tests/test_arktts.py
@@ -1,0 +1,139 @@
+"""Tests for the arktts (Audio8-TTS) model: sanitize contract + tiny-model forward."""
+
+import unittest
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_audio.tts.models.arktts import Model, ModelConfig
+from mlx_audio.tts.models.arktts.arktts import ArkttsModel
+
+
+def tiny_config() -> ModelConfig:
+    return ModelConfig(
+        vocab_size=320,
+        dim=32,
+        n_layer=2,
+        n_head=4,
+        n_local_heads=2,
+        head_dim=8,
+        intermediate_size=64,
+        max_seq_len=64,
+        codebook_size=16,
+        num_codebooks=4,
+        semantic_begin_id=256,
+        semantic_end_id=271,
+        n_fast_layer=2,
+        fast_dim=32,
+        fast_n_head=4,
+        fast_n_local_heads=2,
+        fast_head_dim=8,
+        fast_intermediate_size=64,
+        eos_token_id=300,
+        pad_token_id=301,
+    )
+
+
+class TestArkttsSanitize(unittest.TestCase):
+    def test_weight_norm_folding(self):
+        model = Model.__new__(Model)  # sanitize is self-contained
+        g = mx.array(np.random.randn(4, 1, 1).astype(np.float32) ** 2 + 0.5)
+        v = mx.array(np.random.randn(4, 3, 7).astype(np.float32))
+        weights = {
+            "encoder.block.0.conv.parametrizations.weight.original0": g,
+            "encoder.block.0.conv.parametrizations.weight.original1": v,
+        }
+        out = Model.sanitize(model, weights)
+        key = "codec.encoder.block.0.conv.weight"
+        self.assertIn(key, out)
+        # fold: g * v / ||v||_per_out_channel, then (O, I, K) -> (O, K, I)
+        v_np = np.asarray(v)
+        norm = np.sqrt((v_np.reshape(4, -1) ** 2).sum(axis=1)).reshape(4, 1, 1)
+        expected = (np.asarray(g) * v_np / norm).transpose(0, 2, 1)
+        self.assertTrue(np.allclose(np.asarray(out[key]), expected, atol=1e-6))
+
+    def test_legacy_weight_norm_and_vq_transpose(self):
+        model = Model.__new__(Model)
+        g = mx.ones((5, 1, 1))
+        v = mx.array(np.random.randn(5, 8, 1).astype(np.float32))
+        out = Model.sanitize(
+            model,
+            {
+                "quantizer.quantizer.quantizers.0.in_proj.weight_g": g,
+                "quantizer.quantizer.quantizers.0.in_proj.weight_v": v,
+            },
+        )
+        key = "codec.quantizer.quantizer.quantizers.0.in_proj.weight"
+        self.assertIn(key, out)
+        self.assertEqual(out[key].shape, (5, 1, 8))  # (O, I, 1) -> (O, 1, I)
+
+    def test_transpose_routing(self):
+        model = Model.__new__(Model)
+        out = Model.sanitize(
+            model,
+            {
+                # ConvTranspose sites: torch (I, O, K) -> mlx (O, K, I)
+                "decoder.model.1.block.1.conv.weight": mx.zeros((16, 8, 4)),
+                "quantizer.upsample.0.0.conv.weight": mx.zeros((16, 8, 2)),
+                # regular conv sites: torch (O, I, K) -> mlx (O, K, I)
+                "quantizer.upsample.0.1.dwconv.conv.weight": mx.zeros((16, 1, 7)),
+                "quantizer.downsample.0.0.conv.weight": mx.zeros((16, 16, 2)),
+                # snake alpha: (1, C, 1) -> (1, 1, C)
+                "encoder.block.1.block.0.block.0.alpha": mx.zeros((1, 64, 1)),
+            },
+        )
+        self.assertEqual(out["codec.decoder.model.1.block.1.conv.weight"].shape, (8, 4, 16))
+        self.assertEqual(out["codec.quantizer.upsample.0.0.conv.weight"].shape, (8, 2, 16))
+        self.assertEqual(out["codec.quantizer.upsample.0.1.dwconv.conv.weight"].shape, (16, 7, 1))
+        self.assertEqual(out["codec.quantizer.downsample.0.0.conv.weight"].shape, (16, 2, 16))
+        self.assertEqual(out["codec.encoder.block.1.block.0.block.0.alpha"].shape, (1, 1, 64))
+
+    def test_idempotent_on_converted_weights(self):
+        model = Model.__new__(Model)
+        converted = {"model.embeddings.weight": mx.zeros((8, 4)), "codec.x": mx.zeros((2,))}
+        out = Model.sanitize(model, converted)
+        self.assertEqual(set(out), set(converted))
+        self.assertEqual(out["model.embeddings.weight"].shape, (8, 4))
+
+    def test_rope_buffers_dropped(self):
+        model = Model.__new__(Model)
+        out = Model.sanitize(model, {"freqs_cis": mx.zeros((4, 4, 2))})
+        self.assertEqual(out, {})
+
+
+class TestArkttsTinyModel(unittest.TestCase):
+    def test_prefill_and_greedy_generation_shapes(self):
+        config = tiny_config()
+        lm = ArkttsModel(config)
+        mx.eval(lm.parameters())
+        batch, width = 1, 12
+        prompt = np.random.randint(0, 255, size=(batch, config.num_codebooks + 1, width))
+        prompt[:, 0, -3:] = np.random.randint(
+            config.semantic_begin_id, config.semantic_end_id, size=(batch, 3)
+        )
+        logits, hidden = lm(mx.array(prompt))
+        self.assertEqual(logits.shape, (batch, width, config.vocab_size))
+        self.assertEqual(hidden.shape, (batch, width, config.dim))
+
+        prefix = np.arange(5, dtype=np.int64)
+        suffix = np.arange(3, dtype=np.int64)
+        codes = lm.generate_codes(
+            [prefix], [suffix], max_new_tokens=4, do_sample=False
+        )
+        self.assertEqual(codes.shape[0], batch)
+        self.assertEqual(codes.shape[1], config.num_codebooks)
+        self.assertLessEqual(codes.shape[2], 4)
+
+    def test_sampled_generation_with_seed_is_deterministic(self):
+        config = tiny_config()
+        lm = ArkttsModel(config)
+        mx.eval(lm.parameters())
+        prefix = np.arange(5, dtype=np.int64)
+        suffix = np.arange(3, dtype=np.int64)
+        a = lm.generate_codes([prefix], [suffix], max_new_tokens=4, do_sample=True, seed=11)
+        b = lm.generate_codes([prefix], [suffix], max_new_tokens=4, do_sample=True, seed=11)
+        self.assertTrue(np.array_equal(np.asarray(a), np.asarray(b)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the `arktts` model family — [Audio8/Audio8-TTS-Preview-0.6b](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.6b) (Apache-2.0), a 0.6B multilingual TTS model with zero-shot voice cloning and a bundled 44.1 kHz codec. Architecture is DualAR (Fish S2 Pro-style): a 24-layer slow AR transformer emits one semantic token per frame; a 4-layer fast AR emits the frame's 10 codec codebooks conditioned on the slow hidden state.

## What's included
- `mlx_audio/tts/models/arktts/` — model (`arktts.py`), codec (`codec.py`, DAC-style encoder/decoder + split semantic/residual RVQ + windowed transformer pre/post modules), mirroring the upstream remote-code structure file-for-file
- Reference-exact sampling: semantic-range logit filter, legacy top-k/top-p order (filter before temperature), exponential-race sampling, RAS repetition rescue
- `sanitize()` consumes either raw upstream checkpoints (folds both parametrized and legacy weight norm, transposes conv layouts, reshapes Snake alphas) or the pre-converted mlx repo (idempotent)
- `mlx_audio/tts/tests/test_arktts.py` — sanitize contract + tiny-model forward/generation tests (no weights needed)

## Converted weights
[mlx-community/Audio8-TTS-Preview-0.6b-bf16](https://huggingface.co/mlx-community/Audio8-TTS-Preview-0.6b-bf16) (bf16 LM + fp32 codec), validated by fresh-download → `mlx_audio.tts.utils.load` → voice-clone generation.

## Parity vs PyTorch reference (fp32, CPU stream)
- unit/block outputs: max-abs 1e-6…1e-4
- reference-audio codec encode: **100% code-exact**
- greedy generation: **100% token-exact** over a 102-frame validation utterance
- decoded waveform: max-abs 7.5e-6
- bf16 GPU smoke: healthy audio (−18 dBFS RMS), RTF ~0.8–0.9 on M-series

## Usage
```python
from mlx_audio.tts.utils import load
model = load("mlx-community/Audio8-TTS-Preview-0.6b-bf16")
for r in model.generate(text="Hello from MLX.", ref_audio="ref.wav", ref_text="Reference transcript."):
    ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)