### PR TITLE
Ignore unknown decode options in Whisper generate

### DIFF
--- a/mlx_audio/stt/models/whisper/whisper.py
+++ b/mlx_audio/stt/models/whisper/whisper.py
@@ -6,7 +6,7 @@ import json
 import math
 import sys
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
@@ -31,6 +31,16 @@ from .decoding import decode as decode_function
 from .decoding import detect_language as detect_language_function
 from .timing import add_word_timestamps
 from .tokenizer import LANGUAGES, TO_LANGUAGE_CODE
+
+_DECODING_OPTION_NAMES = frozenset(field.name for field in fields(DecodingOptions))
+
+
+def _filter_decode_options(decode_options):
+    return {
+        key: value
+        for key, value in decode_options.items()
+        if key in _DECODING_OPTION_NAMES
+    }
 
 
 class HFTokenizerWrapper:
@@ -889,8 +899,7 @@ class Model(nn.Module):
         if word_timestamps:
             return_timestamps = True
 
-        decode_options.pop("max_tokens", None)
-        decode_options.pop("generation_stream", None)
+        decode_options = _filter_decode_options(decode_options)
         decode_options["without_timestamps"] = not return_timestamps
         # Use shared audio preparation
         mel, content_frames = self._prepare_audio(audio)

--- a/tests/test_whisper_decode_options.py
+++ b/tests/test_whisper_decode_options.py
@@ -1,0 +1,58 @@
+import unittest
+from dataclasses import fields
+
+from mlx_audio.stt.models.whisper.decoding import DecodingOptions
+from mlx_audio.stt.models.whisper.whisper import (
+    _DECODING_OPTION_NAMES,
+    _filter_decode_options,
+)
+
+
+class TestWhisperDecodeOptionFiltering(unittest.TestCase):
+    def test_names_match_decoding_options(self):
+        self.assertEqual(
+            _DECODING_OPTION_NAMES, {field.name for field in fields(DecodingOptions)}
+        )
+
+    def test_known_options_are_preserved(self):
+        options = {
+            "language": "en",
+            "task": "transcribe",
+            "prefix": "Hello",
+            "sample_len": 200,
+            "suppress_blank": False,
+            "fp16": True,
+        }
+        self.assertEqual(_filter_decode_options(options), options)
+
+    def test_unknown_options_are_dropped(self):
+        filtered = _filter_decode_options(
+            {
+                "language": "en",
+                "frame_threshold": 25,
+                "prefill_step_size": 2048,
+                "max_tokens": 1024,
+                "generation_stream": False,
+                "not_a_real_option": object(),
+            }
+        )
+        self.assertEqual(filtered, {"language": "en"})
+
+    def test_filtered_options_construct_decoding_options(self):
+        filtered = _filter_decode_options(
+            {"language": "en", "frame_threshold": 25, "prefill_step_size": 2048}
+        )
+        self.assertEqual(DecodingOptions(**filtered).language, "en")
+
+    def test_empty_and_all_unknown(self):
+        self.assertEqual(_filter_decode_options({}), {})
+        self.assertEqual(_filter_decode_options({"frame_threshold": 25}), {})
+
+    def test_input_is_not_mutated(self):
+        options = {"language": "en", "frame_threshold": 25}
+        _filter_decode_options(options)
+        self.assertEqual(options, {"language": "en", "frame_threshold": 25})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Whisper's generate() takes **decode_options and splats them straight into DecodingOptions, so any caller-supplied kwarg the dataclass does not declare raises TypeError. Every other STT model in the tree tolerates extra kwargs, which makes Whisper the odd one out for generic callers that pass a shared set of generation parameters.

The existing code already worked around this by popping max_tokens and generation_stream by hand, an allowlist maintained as a blacklist. Derive the accepted names from fields(DecodingOptions) instead so the filter cannot drift from the dataclass.
