### PR TITLE
Report ndjson streaming inference errors in-band instead of an empty 200 (#875)

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -852,7 +852,9 @@ async def _next_inference_chunk(handle: InferenceHandle) -> InferenceResultChunk
     return await asyncio.to_thread(handle.result_queue.get)
 
 
-async def _stream_inference_results(handle: InferenceHandle, request: Request):
+async def _stream_inference_results(
+    handle: InferenceHandle, request: Request, *, ndjson_errors: bool = False
+):
     try:
         while True:
             chunk = await _next_inference_chunk(handle)
@@ -865,6 +867,14 @@ async def _stream_inference_results(handle: InferenceHandle, request: Request):
             if await request.is_disconnected():
                 handle.cancel()
                 break
+    except Exception as exc:
+        if not ndjson_errors:
+            raise
+        # StreamingResponse has already committed its status, so report the
+        # inference failure in-band rather than raising into the response body.
+        yield json.dumps(
+            {"error": {"message": str(exc), "type": type(exc).__name__}}
+        ) + "\n"
     finally:
         handle.cancel()
 
@@ -1118,7 +1128,7 @@ async def stt_transcriptions(
         return JSONResponse(full)
 
     return StreamingResponse(
-        _stream_inference_results(handle, request),
+        _stream_inference_results(handle, request, ndjson_errors=True),
         media_type="application/x-ndjson",
     )
 

--- a/mlx_audio/tests/test_server.py
+++ b/mlx_audio/tests/test_server.py
@@ -1,5 +1,7 @@
 import functools
 import io
+import json
+import queue
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -16,7 +18,8 @@ pytest.importorskip("multipart", reason="python-multipart is required for server
 
 from fastapi.testclient import TestClient
 
-from mlx_audio.server import app
+from mlx_audio.server import _stream_inference_results, app
+from mlx_audio.server_inference import InferenceResultChunk
 
 
 @pytest.fixture
@@ -891,3 +894,55 @@ def test_stt_word_timestamps_verbose_json_words_passthrough(
     assert len(words) == 2
     assert words[0]["word"] == "Hello"
     assert words[1]["word"] == "world."
+
+
+class _FakeInferenceHandle:
+    def __init__(self, chunks):
+        self.result_queue = queue.Queue()
+        for chunk in chunks:
+            self.result_queue.put(chunk)
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class _ConnectedRequest:
+    async def is_disconnected(self):
+        return False
+
+
+async def test_stream_inference_results_reports_ndjson_error():
+    handle = _FakeInferenceHandle(
+        [
+            InferenceResultChunk(kind="data", payload='{"text": "hello"}\n'),
+            InferenceResultChunk(kind="error", error=ValueError("processor missing")),
+        ]
+    )
+
+    payloads = [
+        payload
+        async for payload in _stream_inference_results(
+            handle, _ConnectedRequest(), ndjson_errors=True
+        )
+    ]
+
+    assert payloads[0] == '{"text": "hello"}\n'
+    assert json.loads(payloads[1]) == {
+        "error": {"message": "processor missing", "type": "ValueError"}
+    }
+    assert handle.cancelled
+
+
+async def test_stream_inference_results_reraises_error_by_default():
+    error = ValueError("processor missing")
+    handle = _FakeInferenceHandle([InferenceResultChunk(kind="error", error=error)])
+
+    with pytest.raises(ValueError, match="processor missing") as exc_info:
+        async for _ in _stream_inference_results(
+            handle, _ConnectedRequest(), ndjson_errors=False
+        ):
+            pass
+
+    assert exc_info.value is error
+    assert handle.cancelled


### PR DESCRIPTION
Fixes the empty-200 behaviour reported in #875.

## The problem

`POST /v1/audio/transcriptions` returns **200 OK with a zero-byte body** when transcription fails during inference. The client records a fast, successful, empty transcription that never happened.

Reproduce on Apple silicon (70MB model, no processor files in its snapshot):

```bash
curl -s -X POST http://127.0.0.1:8899/v1/audio/transcriptions \
  -F "file=@any.wav" -F "model=mlx-community/whisper-tiny" \
  -w "\nHTTP=%{http_code}\n"
```

Before: `HTTP=200`, body length **0**. Server log shows `ValueError: Processor not found. Make sure the model was loaded with a HuggingFace processor.`

## Why it happens

Not a missing preflight — `_preflight_model_load` already runs on this endpoint and succeeds. The model loads; whisper fails later, during decoding, in `get_tokenizer()`.

By then the default `response_format="ndjson"` path has returned a `StreamingResponse`, which commits status and headers **before** the generator body runs. `_stream_inference_results` then does `raise chunk.error` inside that already-committed stream, so it cannot become an HTTP error. The stream just ends with nothing in it.

Worth noting the non-streaming formats are already correct: `text` / `json` / `verbose_json` accumulate chunks and raise *before* responding. The bug is specific to the streaming ndjson path — which is the default, so it is what most callers hit.

## The change

Emit a terminal ndjson error record rather than raising into a committed stream:

```json
{"error": {"message": "Processor not found. ...", "type": "ValueError"}}
```

Gated behind a keyword-only `ndjson_errors: bool = False`. This matters: the same helper streams the TTS response with an `audio/*` media type, and a JSON line injected there would corrupt the audio body. Only the ndjson transcription call site opts in; `/v1/audio/speech` behaviour is byte-for-byte unchanged.

The status stays 200 — that is unavoidable once headers are committed — but the body now says what went wrong instead of being silently empty.

## Verification

Run live against a patched server on Apple silicon (M-series, v0.4.7 line):

| case | before | after |
|---|---|---|
| `whisper-tiny` (inference fails) | 200, **0 bytes** | 200, error record naming `Processor not found` / `ValueError` |
| `parakeet-tdt-0.6b-v3` (works) | normal transcript | unchanged |
| `/v1/audio/speech` Kokoro | valid audio | **still valid binary audio**, not JSON |

Added `tests/test_server_streaming.py` covering both branches (yields an error record when opted in; re-raises by default) with a fake handle, so it needs no model or mlx runtime beyond importing the server module.
