### PR TITLE
Add Irodori-TTS v4 support

### DIFF
--- a/mlx_audio/tts/models/irodori_tts/README.md
+++ b/mlx_audio/tts/models/irodori_tts/README.md
@@ -180,6 +180,36 @@ generate_audio(
 `max_ref_seconds` overrides the checkpoint's 120s budget; the reference is
 trimmed to it after concatenation.
 
+### Short caption-only prompts over-predict duration
+
+With a caption but no reference audio, v4's duration predictor roughly doubles
+the length of short texts, and the model fills the extra time by reading the
+sentence a second time:
+
+| Text | Tokens | With reference | Caption only |
+|---|---|---|---|
+| こんにちは。 | 3 | 1.63s | 3.42s |
+| 今日はいい天気ですね。 | 5 | 2.70s | 4.98s |
+| MLXへの移植が完了しました。 | 7 | 3.69s | 3.46s |
+
+This is upstream model behaviour, not an MLX artifact — the reference PyTorch
+implementation predicts the same frame counts and repeats the same way. Texts
+of roughly seven tokens or more are unaffected, and passing any reference audio
+fixes it. Otherwise, shorten the window explicitly:
+
+```python
+generate_audio(
+    model="mlx-community/Irodori-TTS-v4-Small-fp16",
+    text="今日はいい天気ですね。",
+    instruct="落ち着いた女性の声で、近い距離感でやわらかく自然に読み上げてください。",
+    duration_scale=0.5,  # or seconds=2.6
+    file_prefix="output",
+)
+```
+
+Note that forcing a duration away from the predicted one costs some audio
+quality, which upstream documents as well.
+
 ## v3 Features
 
 ### Automatic Duration Prediction

--- a/mlx_audio/tts/models/irodori_tts/README.md
+++ b/mlx_audio/tts/models/irodori_tts/README.md
@@ -8,7 +8,17 @@ Original: [Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS)
 
 ## Models
 
-### v3 (recommended)
+### v4 (recommended)
+
+v4-Small is a single unified model: voice cloning, VoiceDesign and automatic
+duration prediction in one checkpoint.
+
+| Model | HuggingFace | Conditioning |
+|---|---|---|
+| `mlx-community/Irodori-TTS-v4-Small-fp16` | [link](https://huggingface.co/mlx-community/Irodori-TTS-v4-Small-fp16) | Voice cloning + VoiceDesign + automatic duration |
+| `mlx-community/Irodori-TTS-v4-Small-8bit` | [link](https://huggingface.co/mlx-community/Irodori-TTS-v4-Small-8bit) | Voice cloning + VoiceDesign + automatic duration |
+
+### v3
 
 | Model | HuggingFace | Conditioning |
 |---|---|---|
@@ -42,7 +52,7 @@ Original: [Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS)
 from mlx_audio.tts.generate import generate_audio
 
 generate_audio(
-    model="mlx-community/Irodori-TTS-500M-v3-fp16",
+    model="mlx-community/Irodori-TTS-v4-Small-fp16",
     text="今日はいい天気ですね。",
     ref_audio="speaker.wav",
     file_prefix="output",
@@ -51,12 +61,37 @@ generate_audio(
 
 ```bash
 python -m mlx_audio.tts.generate \
-  --model mlx-community/Irodori-TTS-500M-v3-fp16 \
+  --model mlx-community/Irodori-TTS-v4-Small-fp16 \
   --text "今日はいい天気ですね。" \
   --ref_audio speaker.wav
 ```
 
 ### VoiceDesign
+
+#### v4 VoiceDesign
+
+Caption only:
+
+```python
+generate_audio(
+    model="mlx-community/Irodori-TTS-v4-Small-fp16",
+    text="今日はいい天気ですね。",
+    instruct="落ち着いた女性の声で、近い距離感でやわらかく自然に読み上げてください。",
+    file_prefix="output",
+)
+```
+
+Style-controlled voice cloning with reference speech + caption:
+
+```python
+generate_audio(
+    model="mlx-community/Irodori-TTS-v4-Small-fp16",
+    text="今日はいい天気ですね。",
+    ref_audio="speaker.wav",
+    instruct="深く傷つき、今にも泣き出しそうな様子。声が震えており、悲痛なトーンで弱々しく話す。",
+    file_prefix="output",
+)
+```
 
 #### v3 VoiceDesign
 
@@ -117,6 +152,33 @@ python -m mlx_audio.tts.generate \
   --text "今日はいい天気ですね。" \
   --instruct "落ち着いた、近い距離感の女性話者"
 ```
+
+## v4 Features
+
+### Shared pretrained text encoder
+
+v4 replaces the two scratch-trained text/caption encoders with a single
+pretrained [ModernBERT-ja-310m](https://huggingface.co/sbintuitions/modernbert-ja-310m)
+backbone feeding separate projectors. The backbone weights and its tokenizer are
+bundled in the converted model, so no extra download happens at inference time.
+
+### Multi-clip reference audio (up to 120s)
+
+v4 was trained with up to 120 seconds of reference audio. Passing a list encodes
+each clip separately and concatenates them, which matches training better than
+one long uninterrupted recording:
+
+```python
+generate_audio(
+    model="mlx-community/Irodori-TTS-v4-Small-fp16",
+    text="今日はいい天気ですね。",
+    ref_audio=["speaker_1.wav", "speaker_2.wav", "speaker_3.wav"],
+    file_prefix="output",
+)
+```
+
+`max_ref_seconds` overrides the checkpoint's 120s budget; the reference is
+trimmed to it after concatenation.
 
 ## v3 Features
 
@@ -181,6 +243,9 @@ With `cfg_guidance_mode="independent"` (default), multiply memory by ~3.
 
 ## Notes
 
+- v4 uses [Semantic-DACVAE-Japanese-32dim](https://huggingface.co/Aratako/Semantic-DACVAE-Japanese-32dim)
+  and bundles a ModernBERT-ja-310m text encoder, so its weights are roughly
+  1 GB larger than v3 at the same precision.
 - v3 uses [Semantic-DACVAE-Japanese-32dim](https://huggingface.co/Aratako/Semantic-DACVAE-Japanese-32dim)
   and includes an integrated duration predictor for automatic output length estimation.
 - v2 uses [Semantic-DACVAE-Japanese-32dim](https://huggingface.co/Aratako/Semantic-DACVAE-Japanese-32dim)

--- a/mlx_audio/tts/models/irodori_tts/config.py
+++ b/mlx_audio/tts/models/irodori_tts/config.py
@@ -28,6 +28,15 @@ class IrodoriDiTConfig(BaseModelArgs):
     text_layers: int = 10
     text_heads: int = 8
 
+    # Pretrained text encoder (v4): a shared ModernBERT backbone feeds separate
+    # text/caption projectors instead of the two scratch-trained encoders.
+    text_encoder_type: str = "scratch"
+    text_encoder_revision: Optional[str] = None
+    text_encoder_config: Optional[dict] = None
+    pretrained_projector_type: str = "linear"
+    pretrained_projector_hidden_ratio: float = 2.0
+    pretrained_projector_dropout: float = 0.0
+
     # Speaker (reference latent) encoder
     speaker_dim: int = 768
     speaker_layers: int = 8
@@ -62,6 +71,10 @@ class IrodoriDiTConfig(BaseModelArgs):
     duration_speaker_fusion: str = "adarn_zero"
     duration_caption_fusion: str = "adarn_zero"
     duration_caption_pooling: str = "masked_mean"
+
+    @property
+    def use_pretrained_text_encoder(self) -> bool:
+        return str(self.text_encoder_type).strip().lower() == "pretrained"
 
     @property
     def use_speaker_condition_resolved(self) -> bool:
@@ -172,6 +185,9 @@ class ModelConfig(BaseModelArgs):
     max_text_length: int = 256
     max_caption_length: int = 512
     max_speaker_latent_length: int = 6400
+    # Recommended cap on total reference audio duration. v4 was trained with
+    # up to 120s of (optionally multi-clip) reference; earlier versions used 30s.
+    ref_max_seconds: float = 30.0
     # DACVAE hop_length = 2*8*10*12 = 1920 (48kHz)
     audio_downsample_factor: int = 1920
 
@@ -189,6 +205,7 @@ class ModelConfig(BaseModelArgs):
             max_text_length=config.get("max_text_length", 256),
             max_caption_length=config.get("max_caption_length", 512),
             max_speaker_latent_length=config.get("max_speaker_latent_length", 6400),
+            ref_max_seconds=config.get("ref_max_seconds", 30.0),
             audio_downsample_factor=config.get("audio_downsample_factor", 1920),
             dacvae_repo=config.get(
                 "dacvae_repo", "Aratako/Semantic-DACVAE-Japanese-32dim"

--- a/mlx_audio/tts/models/irodori_tts/irodori_tts.py
+++ b/mlx_audio/tts/models/irodori_tts/irodori_tts.py
@@ -45,6 +45,7 @@ class Model(nn.Module):
         self.dacvae: DACVAE | None = None
         self._tokenizer = None
         self._caption_tokenizer = None
+        self._model_path: Path | None = None
 
     # ------------------------------------------------------------------
     # Properties
@@ -94,6 +95,8 @@ class Model(nn.Module):
 
         from mlx_audio.codec.models.dacvae import DACVAEConfig
 
+        model._model_path = Path(model_path)
+
         local_dacvae = Path(model_path) / "dacvae"
         try:
             if local_dacvae.is_dir():
@@ -121,25 +124,32 @@ class Model(nn.Module):
     # Tokenisation
     # ------------------------------------------------------------------
 
+    def _load_tokenizer(self, repo: str):
+        """Prefer a tokenizer bundled with the converted weights (v4 ships one)
+        so inference does not depend on the upstream repo staying available."""
+        from transformers import AutoTokenizer
+
+        if self._model_path is not None:
+            bundled = self._model_path / "tokenizer"
+            if (bundled / "tokenizer_config.json").is_file():
+                return AutoTokenizer.from_pretrained(str(bundled))
+        return AutoTokenizer.from_pretrained(
+            repo, revision=self.config.dit.text_encoder_revision
+        )
+
     def _get_tokenizer(self):
         if self._tokenizer is None:
-            from transformers import AutoTokenizer
-
-            self._tokenizer = AutoTokenizer.from_pretrained(
-                self.config.dit.text_tokenizer_repo
-            )
+            self._tokenizer = self._load_tokenizer(self.config.dit.text_tokenizer_repo)
         return self._tokenizer
 
     def _get_caption_tokenizer(self):
         if self._caption_tokenizer is None:
-            from transformers import AutoTokenizer
-
             repo = self.config.dit.caption_tokenizer_repo_resolved
             # Reuse text tokenizer if repo is the same
             if repo == self.config.dit.text_tokenizer_repo:
                 self._caption_tokenizer = self._get_tokenizer()
             else:
-                self._caption_tokenizer = AutoTokenizer.from_pretrained(repo)
+                self._caption_tokenizer = self._load_tokenizer(repo)
         return self._caption_tokenizer
 
     def _prepare_text(
@@ -177,37 +187,102 @@ class Model(nn.Module):
     # Reference audio encoding
     # ------------------------------------------------------------------
 
-    def _encode_ref_audio(self, audio: mx.array) -> tuple[mx.array, mx.array]:
+    def _load_ref_waveform(self, ref: str | mx.array) -> mx.array:
+        """Load a reference clip as mono (1, samples) at the model sample rate."""
+        audio = (
+            load_audio_any(ref, sample_rate=self.sample_rate)
+            if isinstance(ref, str)
+            else ref
+        )
+        if audio.ndim == 1:
+            audio = audio[None, :]
+        elif audio.ndim == 2 and audio.shape[0] > 1:
+            audio = mx.mean(audio, axis=0, keepdims=True)
+        return audio
+
+    def _max_ref_latent_steps(self, max_ref_seconds: Optional[float] = None) -> int:
+        """Latent-step budget for the reference, from ref_max_seconds and the
+        hard max_speaker_latent_length cap."""
+        seconds = (
+            self.config.ref_max_seconds
+            if max_ref_seconds is None
+            else float(max_ref_seconds)
+        )
+        limit = self.config.max_speaker_latent_length
+        if seconds > 0:
+            steps = int(
+                seconds * self.config.sample_rate / self.config.audio_downsample_factor
+            )
+            limit = min(limit, max(1, steps))
+        return limit
+
+    def _encode_ref_audio(
+        self,
+        audio: mx.array,
+        max_ref_seconds: Optional[float] = None,
+    ) -> tuple[mx.array, mx.array]:
         """
-        Encode reference waveform with DACVAE.
+        Encode a single reference waveform with DACVAE.
         audio: (1, samples) at config.sample_rate
-        Returns (latent, mask): latent (1, T, 128), mask (1, T) bool
+        Returns (latent, mask): latent (1, T, latent_dim), mask (1, T) bool
         """
         assert self.dacvae is not None, "DACVAE not loaded"
 
-        max_samples = (
-            self.config.max_speaker_latent_length * self.config.audio_downsample_factor
-        )
-        audio = audio[:, :max_samples]
+        max_steps = self._max_ref_latent_steps(max_ref_seconds)
+        audio = audio[:, : max_steps * self.config.audio_downsample_factor]
 
         # DACVAE encode expects (B, L, 1)
         audio_in = audio[:, :, None]  # (1, L, 1)
-        latent = self.dacvae.encode(audio_in)  # (1, 128, T) channels-first
-        latent = mx.transpose(latent, (0, 2, 1))  # (1, T, 128) sequence-first
+        latent = self.dacvae.encode(audio_in)  # (1, latent_dim, T) channels-first
+        latent = mx.transpose(latent, (0, 2, 1))  # (1, T, latent_dim) sequence-first
 
         actual_t = int(audio.shape[1]) // self.config.audio_downsample_factor
         actual_t = min(actual_t, latent.shape[1])
         latent = latent[:, :actual_t]
-        mask = mx.ones((1, actual_t), dtype=mx.bool_)
 
-        # Align to speaker_patch_size
+        return latent, mx.ones((1, actual_t), dtype=mx.bool_)
+
+    def _encode_ref_audios(
+        self,
+        audios: list[mx.array],
+        max_ref_seconds: Optional[float] = None,
+    ) -> tuple[mx.array, mx.array]:
+        """
+        Encode reference clips independently and concatenate them in input order,
+        then trim to the reference budget. v4 was trained on multiple shorter
+        clips from the same speaker rather than one long recording.
+        """
+        max_steps = self._max_ref_latent_steps(max_ref_seconds)
+
+        pieces: list[mx.array] = []
+        total = 0
+        for audio in audios:
+            latent, _ = self._encode_ref_audio(audio, max_ref_seconds=max_ref_seconds)
+            if latent.shape[1] == 0:
+                continue
+            pieces.append(latent)
+            total += int(latent.shape[1])
+            if total >= max_steps:
+                break
+        if not pieces:
+            raise ValueError("Reference audio produced an empty latent.")
+
+        latent = mx.concatenate(pieces, axis=1)[:, :max_steps]
+        steps = int(latent.shape[1])
+
+        # Align to speaker_patch_size so no partial patch is dropped silently
         p = self.config.dit.speaker_patch_size
-        if p > 1 and actual_t % p != 0:
-            trim = (actual_t // p) * p
-            latent = latent[:, :trim]
-            mask = mask[:, :trim]
+        if p > 1 and steps % p != 0:
+            steps = (steps // p) * p
+            latent = latent[:, :steps]
+        if steps == 0:
+            raise ValueError(
+                f"Reference audio is too short: at least {p} latent frames "
+                f"({p * self.config.audio_downsample_factor / self.config.sample_rate:.2f}s) "
+                "are required."
+            )
 
-        return latent, mask
+        return latent, mx.ones((1, steps), dtype=mx.bool_)
 
     # ------------------------------------------------------------------
     # Latent generation (sampling)
@@ -241,13 +316,29 @@ class Model(nn.Module):
 
         if self.config.dit.use_speaker_condition_resolved:
             if ref_latent is None:
-                ref_latent = mx.zeros((1, 1, self.config.dit.latent_dim))
+                ref_latent = mx.zeros(
+                    # At least one full speaker patch, otherwise patching
+                    # yields an empty sequence (v4 uses speaker_patch_size=4).
+                    (
+                        1,
+                        self.config.dit.speaker_patch_size,
+                        self.config.dit.latent_dim,
+                    )
+                )
             if ref_mask is None:
                 ref_mask = mx.zeros((1, ref_latent.shape[1]), dtype=mx.bool_)
         elif not self.config.dit.use_caption_condition:
             # legacy speaker-only (use_speaker_condition=None, use_caption_condition=False)
             if ref_latent is None:
-                ref_latent = mx.zeros((1, 1, self.config.dit.latent_dim))
+                ref_latent = mx.zeros(
+                    # At least one full speaker patch, otherwise patching
+                    # yields an empty sequence (v4 uses speaker_patch_size=4).
+                    (
+                        1,
+                        self.config.dit.speaker_patch_size,
+                        self.config.dit.latent_dim,
+                    )
+                )
             if ref_mask is None:
                 ref_mask = mx.zeros((1, ref_latent.shape[1]), dtype=mx.bool_)
 
@@ -364,7 +455,7 @@ class Model(nn.Module):
         self,
         text: str,
         voice: str | None = None,
-        ref_audio: str | mx.array | None = None,
+        ref_audio: str | mx.array | list[str | mx.array] | None = None,
         caption: str | None = None,
         stream: bool = False,
         **kwargs,
@@ -384,20 +475,16 @@ class Model(nn.Module):
         text_input_ids, _ = self._prepare_text(text)
         token_count = int(text_input_ids.shape[1])
 
-        # Encode reference audio if provided
+        # Encode reference audio if provided. A list/tuple encodes each clip
+        # separately and concatenates them (v4 multi-clip cloning).
         ref_latent = None
         ref_mask = None
         if ref_audio is not None:
-            audio = (
-                load_audio_any(ref_audio, sample_rate=self.sample_rate)
-                if isinstance(ref_audio, str)
-                else ref_audio
+            refs = ref_audio if isinstance(ref_audio, (list, tuple)) else [ref_audio]
+            audios = [self._load_ref_waveform(r) for r in refs]
+            ref_latent, ref_mask = self._encode_ref_audios(
+                audios, max_ref_seconds=kwargs.get("max_ref_seconds")
             )
-            if audio.ndim == 1:
-                audio = audio[None, :]
-            elif audio.ndim == 2 and audio.shape[0] > 1:
-                audio = mx.mean(audio, axis=0, keepdims=True)
-            ref_latent, ref_mask = self._encode_ref_audio(audio)
 
         # Run diffusion sampler
         latent_out, latent_steps = self.generate_latents(
@@ -424,6 +511,7 @@ class Model(nn.Module):
                     "duration_scale",
                     "min_seconds",
                     "max_seconds",
+                    "max_ref_seconds",
                 )
             },
         )

--- a/mlx_audio/tts/models/irodori_tts/irodori_tts.py
+++ b/mlx_audio/tts/models/irodori_tts/irodori_tts.py
@@ -313,6 +313,11 @@ class Model(nn.Module):
         if self.config.dit.use_caption_condition:
             cap = caption or ""
             caption_input_ids, caption_mask = self._prepare_caption(cap)
+            if not cap.strip():
+                # An empty caption still tokenizes to a BOS token. Leaving it
+                # unmasked would present it as a real caption to the DiT and to
+                # the duration predictor, so mask it out entirely.
+                caption_mask = mx.zeros_like(caption_mask)
 
         if self.config.dit.use_speaker_condition_resolved:
             if ref_latent is None:
@@ -526,12 +531,16 @@ class Model(nn.Module):
         audio_out = audio_out[:, :, 0]  # (1, L)
         mx.eval(audio_out)
 
-        # Trim trailing silence
-        silence_t = _find_silence_point(latent_out[0])
-        trim_samples = silence_t * self.config.audio_downsample_factor
-        # Also clamp to the predicted/manual duration
+        # Clamp to the predicted/manual duration, then trim trailing silence.
+        # A silence point of 0 means the heuristic flagged the very first
+        # window, which must not collapse the output to nothing.
         target_samples = latent_steps * self.config.audio_downsample_factor
-        trim_samples = min(trim_samples, target_samples)
+        trim_samples = target_samples
+        silence_samples = (
+            _find_silence_point(latent_out[0]) * self.config.audio_downsample_factor
+        )
+        if silence_samples > 0:
+            trim_samples = min(trim_samples, silence_samples)
         audio_out = audio_out[:, :trim_samples]
 
         audio = audio_out[0]  # (L,)

--- a/mlx_audio/tts/models/irodori_tts/irodori_tts.py
+++ b/mlx_audio/tts/models/irodori_tts/irodori_tts.py
@@ -163,7 +163,8 @@ class Model(nn.Module):
         if max_length is None:
             max_length = self.config.max_text_length
 
-        text = normalize_text(text)
+        # Upstream tokenizes normalize_text(raw).strip().
+        text = normalize_text(text).strip()
         return encode_text(
             text,
             tokenizer=self._get_tokenizer(),
@@ -311,9 +312,10 @@ class Model(nn.Module):
         caption_mask: Optional[mx.array] = None
 
         if self.config.dit.use_caption_condition:
-            cap = caption or ""
+            # Upstream strips the caption but does not run normalize_text on it.
+            cap = "" if caption is None else str(caption).strip()
             caption_input_ids, caption_mask = self._prepare_caption(cap)
-            if not cap.strip():
+            if not cap:
                 # An empty caption still tokenizes to a BOS token. Leaving it
                 # unmasked would present it as a real caption to the DiT and to
                 # the duration predictor, so mask it out entirely.
@@ -357,7 +359,7 @@ class Model(nn.Module):
             )
         elif self.config.dit.use_duration_predictor:
             # Predict duration using the integrated predictor
-            text_for_features = normalize_text(text)
+            text_for_features = normalize_text(text).strip()
             token_count = int(text_mask.sum())
             has_speaker = bool(ref_mask is not None and mx.any(ref_mask))
 
@@ -477,8 +479,9 @@ class Model(nn.Module):
             )
 
         start_time = time.perf_counter()
-        text_input_ids, _ = self._prepare_text(text)
-        token_count = int(text_input_ids.shape[1])
+        # Report real tokens, not the padded width.
+        _, text_token_mask = self._prepare_text(text)
+        token_count = int(text_token_mask.sum())
 
         # Encode reference audio if provided. A list/tuple encodes each clip
         # separately and concatenates them (v4 multi-clip cloning).

--- a/mlx_audio/tts/models/irodori_tts/model.py
+++ b/mlx_audio/tts/models/irodori_tts/model.py
@@ -499,8 +499,10 @@ class PretrainedConditionProjector(nn.Module):
         input_ids: mx.array,
         mask: Optional[mx.array],
     ) -> mx.array:
+        # No dtype coercion against self.projector.weight here: once quantized
+        # that weight is packed uint32, and casting activations to it would
+        # truncate them to integers.
         state = backbone(input_ids, mask)
-        state = state.astype(self.projector.weight.dtype)
         projected = self.projector(state)
         if self.projector_type == "residual_mlp":
             residual = nn.silu(self.residual_up(self.residual_norm(state)))

--- a/mlx_audio/tts/models/irodori_tts/model.py
+++ b/mlx_audio/tts/models/irodori_tts/model.py
@@ -7,6 +7,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from .config import IrodoriDiTConfig
+from .modernbert import ModernBertConfig, ModernBertEncoder
 
 RotaryCache = Tuple[mx.array, mx.array]
 KVCache = Tuple[mx.array, mx.array]
@@ -440,6 +441,73 @@ class TextEncoder(nn.Module):
             for block in self.blocks:
                 x = block(x, mask=None, freqs_cis=freqs_cis)
             return x
+
+
+class PretrainedTextBackbone(nn.Module):
+    """
+    Thin wrapper around the pretrained encoder shared by the text and caption
+    projectors (v4). Keeps the checkpoint's `pretrained_text_backbone.backbone.*`
+    key layout.
+    """
+
+    def __init__(self, config: ModernBertConfig):
+        super().__init__()
+        self.backbone = ModernBertEncoder(config)
+        self.hidden_size = config.hidden_size
+
+    def __call__(self, input_ids: mx.array, mask: Optional[mx.array]) -> mx.array:
+        state = self.backbone(input_ids, mask)
+        if mask is None:
+            return state
+        return state * mask[..., None].astype(state.dtype)
+
+
+class PretrainedConditionProjector(nn.Module):
+    """
+    Projects the shared pretrained backbone output into a condition space (v4).
+
+    `linear` is a plain projection; `residual_mlp` adds a zero-initialised
+    gated residual branch on top of it.
+    """
+
+    def __init__(
+        self,
+        backbone_dim: int,
+        output_dim: int,
+        projector_type: str = "linear",
+        hidden_ratio: float = 2.0,
+        norm_eps: float = 1e-5,
+    ):
+        super().__init__()
+        projector_type = str(projector_type).strip().lower()
+        if projector_type not in {"linear", "residual_mlp"}:
+            raise ValueError(
+                "pretrained projector type must be 'linear' or 'residual_mlp', "
+                f"got {projector_type!r}"
+            )
+        self.projector_type = projector_type
+        self.projector = nn.Linear(backbone_dim, output_dim, bias=True)
+        if projector_type == "residual_mlp":
+            hidden_dim = max(1, int(round(output_dim * float(hidden_ratio))))
+            self.residual_norm = RMSNorm(backbone_dim, eps=norm_eps)
+            self.residual_up = nn.Linear(backbone_dim, hidden_dim, bias=True)
+            self.residual_down = nn.Linear(hidden_dim, output_dim, bias=True)
+
+    def __call__(
+        self,
+        backbone: PretrainedTextBackbone,
+        input_ids: mx.array,
+        mask: Optional[mx.array],
+    ) -> mx.array:
+        state = backbone(input_ids, mask)
+        state = state.astype(self.projector.weight.dtype)
+        projected = self.projector(state)
+        if self.projector_type == "residual_mlp":
+            residual = nn.silu(self.residual_up(self.residual_norm(state)))
+            projected = projected + self.residual_down(residual)
+        if mask is None:
+            return projected
+        return projected * mask[..., None].astype(projected.dtype)
 
 
 class ReferenceLatentEncoder(nn.Module):
@@ -1155,14 +1223,32 @@ class IrodoriDiT(nn.Module):
         self.cfg = cfg
         self.head_dim = cfg.model_dim // cfg.num_heads
 
-        self.text_encoder = TextEncoder(
-            vocab_size=cfg.text_vocab_size,
-            dim=cfg.text_dim,
-            heads=cfg.text_heads,
-            num_layers=cfg.text_layers,
-            mlp_ratio=cfg.text_mlp_ratio_resolved,
-            norm_eps=cfg.norm_eps,
-        )
+        self.pretrained_text_backbone = None
+        if cfg.use_pretrained_text_encoder:
+            if not cfg.text_encoder_config:
+                raise ValueError(
+                    "text_encoder_type='pretrained' requires text_encoder_config "
+                    "in the model config."
+                )
+            self.pretrained_text_backbone = PretrainedTextBackbone(
+                ModernBertConfig.from_dict(cfg.text_encoder_config)
+            )
+            self.text_encoder = PretrainedConditionProjector(
+                self.pretrained_text_backbone.hidden_size,
+                cfg.text_dim,
+                projector_type=cfg.pretrained_projector_type,
+                hidden_ratio=cfg.pretrained_projector_hidden_ratio,
+                norm_eps=cfg.norm_eps,
+            )
+        else:
+            self.text_encoder = TextEncoder(
+                vocab_size=cfg.text_vocab_size,
+                dim=cfg.text_dim,
+                heads=cfg.text_heads,
+                num_layers=cfg.text_layers,
+                mlp_ratio=cfg.text_mlp_ratio_resolved,
+                norm_eps=cfg.norm_eps,
+            )
         self.text_norm = RMSNorm(cfg.text_dim, eps=cfg.norm_eps)
 
         speaker_ctx_dim: Optional[int] = None
@@ -1181,14 +1267,30 @@ class IrodoriDiT(nn.Module):
             speaker_ctx_dim = cfg.speaker_dim
 
         if cfg.use_caption_condition:
-            self.caption_encoder = TextEncoder(
-                vocab_size=cfg.caption_vocab_size_resolved,
-                dim=cfg.caption_dim_resolved,
-                heads=cfg.caption_heads_resolved,
-                num_layers=cfg.caption_layers_resolved,
-                mlp_ratio=cfg.caption_mlp_ratio_resolved,
-                norm_eps=cfg.norm_eps,
-            )
+            if cfg.use_pretrained_text_encoder:
+                if cfg.caption_tokenizer_repo_resolved != cfg.text_tokenizer_repo:
+                    raise ValueError(
+                        "A shared pretrained text/caption encoder requires identical "
+                        "tokenizer repositories: "
+                        f"text={cfg.text_tokenizer_repo!r}, "
+                        f"caption={cfg.caption_tokenizer_repo_resolved!r}."
+                    )
+                self.caption_encoder = PretrainedConditionProjector(
+                    self.pretrained_text_backbone.hidden_size,
+                    cfg.caption_dim_resolved,
+                    projector_type=cfg.pretrained_projector_type,
+                    hidden_ratio=cfg.pretrained_projector_hidden_ratio,
+                    norm_eps=cfg.norm_eps,
+                )
+            else:
+                self.caption_encoder = TextEncoder(
+                    vocab_size=cfg.caption_vocab_size_resolved,
+                    dim=cfg.caption_dim_resolved,
+                    heads=cfg.caption_heads_resolved,
+                    num_layers=cfg.caption_layers_resolved,
+                    mlp_ratio=cfg.caption_mlp_ratio_resolved,
+                    norm_eps=cfg.norm_eps,
+                )
             self.caption_norm = RMSNorm(cfg.caption_dim_resolved, eps=cfg.norm_eps)
             caption_ctx_dim = cfg.caption_dim_resolved
 
@@ -1248,6 +1350,16 @@ class IrodoriDiT(nn.Module):
     # Condition encoding (text + speaker/caption) — cached across steps
     # ------------------------------------------------------------------
 
+    def _encode_text(self, input_ids: mx.array, mask: mx.array) -> mx.array:
+        if self.pretrained_text_backbone is None:
+            return self.text_encoder(input_ids, mask)
+        return self.text_encoder(self.pretrained_text_backbone, input_ids, mask)
+
+    def _encode_caption(self, input_ids: mx.array, mask: mx.array) -> mx.array:
+        if self.pretrained_text_backbone is None:
+            return self.caption_encoder(input_ids, mask)
+        return self.caption_encoder(self.pretrained_text_backbone, input_ids, mask)
+
     def encode_conditions(
         self,
         text_input_ids: mx.array,
@@ -1261,7 +1373,7 @@ class IrodoriDiT(nn.Module):
         Encode text and context (speaker latent or caption) into conditioning states.
         Returns (text_state, text_mask, context_state, context_mask).
         """
-        text_state = self.text_norm(self.text_encoder(text_input_ids, text_mask))
+        text_state = self.text_norm(self._encode_text(text_input_ids, text_mask))
 
         if self.cfg.use_speaker_condition_resolved:
             assert ref_latent is not None and ref_mask is not None
@@ -1275,7 +1387,7 @@ class IrodoriDiT(nn.Module):
         else:
             assert caption_input_ids is not None and caption_mask is not None
             context_state = self.caption_norm(
-                self.caption_encoder(caption_input_ids, caption_mask)
+                self._encode_caption(caption_input_ids, caption_mask)
             )
             context_mask = caption_mask
 
@@ -1301,7 +1413,7 @@ class IrodoriDiT(nn.Module):
         Encode all conditions including both speaker and caption states.
         Returns (text_state, text_mask, speaker_state, speaker_mask, caption_state, caption_mask).
         """
-        text_state = self.text_norm(self.text_encoder(text_input_ids, text_mask))
+        text_state = self.text_norm(self._encode_text(text_input_ids, text_mask))
 
         speaker_state = None
         speaker_mask = None
@@ -1330,7 +1442,7 @@ class IrodoriDiT(nn.Module):
         if self.cfg.use_caption_condition:
             if caption_input_ids is not None and caption_mask is not None:
                 out_caption_state = self.caption_norm(
-                    self.caption_encoder(caption_input_ids, caption_mask)
+                    self._encode_caption(caption_input_ids, caption_mask)
                 )
                 out_caption_mask = caption_mask
 

--- a/mlx_audio/tts/models/irodori_tts/model.py
+++ b/mlx_audio/tts/models/irodori_tts/model.py
@@ -466,8 +466,8 @@ class PretrainedConditionProjector(nn.Module):
     """
     Projects the shared pretrained backbone output into a condition space (v4).
 
-    `linear` is a plain projection; `residual_mlp` adds a zero-initialised
-    gated residual branch on top of it.
+    `linear` is a plain projection; `residual_mlp` adds a SiLU residual branch
+    on top of it. Dropout is training-only and therefore not modelled here.
     """
 
     def __init__(

--- a/mlx_audio/tts/models/irodori_tts/modernbert.py
+++ b/mlx_audio/tts/models/irodori_tts/modernbert.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_audio.tts.models.base import BaseModelArgs
+
+# ---------------------------------------------------------------------------
+# ModernBERT encoder (MLX port of transformers' ModernBertModel).
+#
+# Irodori-TTS v4 conditions on a frozen-architecture pretrained encoder
+# (sbintuitions/modernbert-ja-310m) whose weights are bundled in the
+# checkpoint, so only the bidirectional encoder stack is needed here.
+# Parameter names mirror the HuggingFace module tree to keep conversion
+# a straight rename.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ModernBertConfig(BaseModelArgs):
+    vocab_size: int = 102400
+    hidden_size: int = 768
+    intermediate_size: int = 3072
+    num_hidden_layers: int = 25
+    num_attention_heads: int = 12
+    hidden_activation: str = "gelu"
+    norm_eps: float = 1e-5
+    norm_bias: bool = False
+    attention_bias: bool = False
+    mlp_bias: bool = False
+    global_attn_every_n_layers: int = 3
+    local_attention: int = 128
+    global_rope_theta: float = 160000.0
+    local_rope_theta: float = 10000.0
+    max_position_embeddings: int = 8192
+    pad_token_id: int = 3
+    bos_token_id: int = 1
+    eos_token_id: int = 2
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "ModernBertConfig":
+        params = dict(params)
+        # transformers >= 5 nests the per-layer-type RoPE settings; earlier
+        # releases exposed flat global_/local_rope_theta keys.
+        rope_parameters = params.pop("rope_parameters", None)
+        if isinstance(rope_parameters, dict):
+            full = rope_parameters.get("full_attention")
+            if isinstance(full, dict) and "rope_theta" in full:
+                params.setdefault("global_rope_theta", full["rope_theta"])
+            sliding = rope_parameters.get("sliding_attention")
+            if isinstance(sliding, dict) and "rope_theta" in sliding:
+                params.setdefault("local_rope_theta", sliding["rope_theta"])
+        return super().from_dict(params)
+
+    def is_global_layer(self, layer_idx: int) -> bool:
+        if not self.global_attn_every_n_layers:
+            return True
+        return layer_idx % self.global_attn_every_n_layers == 0
+
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_attention_heads
+
+
+# ---------------------------------------------------------------------------
+# Layers
+# ---------------------------------------------------------------------------
+
+
+class LayerNorm(nn.Module):
+    """LayerNorm with optional bias, accumulating in float32."""
+
+    def __init__(self, dims: int, eps: float, bias: bool = False):
+        super().__init__()
+        self.eps = eps
+        self.weight = mx.ones((dims,))
+        self.use_bias = bias
+        if bias:
+            self.bias = mx.zeros((dims,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x_dtype = x.dtype
+        x = x.astype(mx.float32)
+        mean = mx.mean(x, axis=-1, keepdims=True)
+        var = mx.var(x, axis=-1, keepdims=True)
+        x = (x - mean) * mx.rsqrt(var + self.eps)
+        x = x * self.weight.astype(mx.float32)
+        if self.use_bias:
+            x = x + self.bias.astype(mx.float32)
+        return x.astype(x_dtype)
+
+
+def rope_cos_sin(
+    head_dim: int, seq_len: int, theta: float
+) -> Tuple[mx.array, mx.array]:
+    """HuggingFace-style (rotate_half) RoPE tables of shape (seq_len, head_dim)."""
+    inv_freq = 1.0 / (
+        theta ** (mx.arange(0, head_dim, 2, dtype=mx.float32) / float(head_dim))
+    )
+    positions = mx.arange(seq_len, dtype=mx.float32)
+    freqs = mx.outer(positions, inv_freq)
+    emb = mx.concatenate([freqs, freqs], axis=-1)
+    return mx.cos(emb), mx.sin(emb)
+
+
+def _rotate_half(x: mx.array) -> mx.array:
+    half = x.shape[-1] // 2
+    return mx.concatenate([-x[..., half:], x[..., :half]], axis=-1)
+
+
+def _apply_rope(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    """x: (B, H, S, D); cos/sin: (S, D)."""
+    cos = cos[None, None].astype(x.dtype)
+    sin = sin[None, None].astype(x.dtype)
+    return x * cos + _rotate_half(x) * sin
+
+
+class ModernBertAttention(nn.Module):
+    def __init__(self, config: ModernBertConfig):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+        self.Wqkv = nn.Linear(
+            config.hidden_size, 3 * config.hidden_size, bias=config.attention_bias
+        )
+        self.Wo = nn.Linear(
+            config.hidden_size, config.hidden_size, bias=config.attention_bias
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        cos: mx.array,
+        sin: mx.array,
+        attn_mask: Optional[mx.array],
+    ) -> mx.array:
+        bsz, seq_len = x.shape[:2]
+        qkv = self.Wqkv(x).reshape(bsz, seq_len, 3, self.num_heads, self.head_dim)
+        # (B, S, 3, H, D) -> (3, B, H, S, D)
+        qkv = mx.transpose(qkv, (2, 0, 3, 1, 4))
+        q, k, v = qkv[0], qkv[1], qkv[2]
+
+        q = _apply_rope(q, cos, sin)
+        k = _apply_rope(k, cos, sin)
+
+        out = mx.fast.scaled_dot_product_attention(
+            q=q, k=k, v=v, scale=self.scale, mask=attn_mask
+        )
+        out = mx.transpose(out, (0, 2, 1, 3)).reshape(bsz, seq_len, -1)
+        return self.Wo(out)
+
+
+class ModernBertMLP(nn.Module):
+    """GeGLU MLP with a single fused input projection (Wi -> 2 * intermediate)."""
+
+    def __init__(self, config: ModernBertConfig):
+        super().__init__()
+        self.Wi = nn.Linear(
+            config.hidden_size, 2 * config.intermediate_size, bias=config.mlp_bias
+        )
+        self.Wo = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=config.mlp_bias
+        )
+        activation = str(config.hidden_activation).lower()
+        if activation not in ("gelu", "gelu_new", "gelu_pytorch_tanh"):
+            raise ValueError(
+                f"Unsupported ModernBERT hidden_activation={config.hidden_activation!r}"
+            )
+        self.exact_gelu = activation == "gelu"
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gated = self.Wi(x)
+        half = gated.shape[-1] // 2
+        act = nn.gelu if self.exact_gelu else nn.gelu_approx
+        return self.Wo(act(gated[..., :half]) * gated[..., half:])
+
+
+class ModernBertEncoderLayer(nn.Module):
+    def __init__(self, config: ModernBertConfig, layer_idx: int):
+        super().__init__()
+        # The first layer consumes the already-normalised embedding output.
+        self.attn_norm = (
+            nn.Identity()
+            if layer_idx == 0
+            else LayerNorm(
+                config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
+            )
+        )
+        self.attn = ModernBertAttention(config)
+        self.mlp_norm = LayerNorm(
+            config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
+        )
+        self.mlp = ModernBertMLP(config)
+
+    def __call__(
+        self,
+        x: mx.array,
+        cos: mx.array,
+        sin: mx.array,
+        attn_mask: Optional[mx.array],
+    ) -> mx.array:
+        x = x + self.attn(self.attn_norm(x), cos, sin, attn_mask)
+        return x + self.mlp(self.mlp_norm(x))
+
+
+class ModernBertEmbeddings(nn.Module):
+    def __init__(self, config: ModernBertConfig):
+        super().__init__()
+        self.tok_embeddings = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.norm = LayerNorm(
+            config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
+        )
+
+    def __call__(self, input_ids: mx.array) -> mx.array:
+        return self.norm(self.tok_embeddings(input_ids))
+
+
+class ModernBertEncoder(nn.Module):
+    """Bidirectional ModernBERT encoder returning last_hidden_state."""
+
+    def __init__(self, config: ModernBertConfig):
+        super().__init__()
+        self.config = config
+        self.embeddings = ModernBertEmbeddings(config)
+        self.layers = [
+            ModernBertEncoderLayer(config, i) for i in range(config.num_hidden_layers)
+        ]
+        self.final_norm = LayerNorm(
+            config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
+        )
+
+    def _attention_masks(
+        self, mask: Optional[mx.array], seq_len: int, dtype: mx.Dtype
+    ) -> Tuple[Optional[mx.array], mx.array]:
+        """Return (global_mask, local_mask) as additive (B, 1, S, S) masks."""
+        window = self.config.local_attention // 2
+        positions = mx.arange(seq_len)
+        distance = mx.abs(positions[:, None] - positions[None, :])
+        within_window = distance <= window
+
+        if mask is None:
+            global_mask = None
+            local_bool = mx.broadcast_to(
+                within_window[None, None], (1, 1, seq_len, seq_len)
+            )
+        else:
+            key_mask = mask.astype(mx.bool_)[:, None, None, :]
+            global_bool = mx.broadcast_to(
+                key_mask, (mask.shape[0], 1, seq_len, seq_len)
+            )
+            global_mask = _additive_mask(global_bool, dtype)
+            # A padding query far from every real token would otherwise have an
+            # all-masked row, whose softmax is NaN and would poison later layers.
+            # Always leaving the diagonal open keeps those rows finite without
+            # changing any non-padding output.
+            local_bool = (global_bool & within_window[None, None]) | (distance == 0)
+
+        return global_mask, _additive_mask(local_bool, dtype)
+
+    def __call__(
+        self, input_ids: mx.array, mask: Optional[mx.array] = None
+    ) -> mx.array:
+        x = self.embeddings(input_ids)
+        seq_len = input_ids.shape[1]
+
+        global_cos, global_sin = rope_cos_sin(
+            self.config.head_dim, seq_len, self.config.global_rope_theta
+        )
+        local_cos, local_sin = rope_cos_sin(
+            self.config.head_dim, seq_len, self.config.local_rope_theta
+        )
+        global_mask, local_mask = self._attention_masks(mask, seq_len, x.dtype)
+
+        for i, layer in enumerate(self.layers):
+            if self.config.is_global_layer(i):
+                x = layer(x, global_cos, global_sin, global_mask)
+            else:
+                x = layer(x, local_cos, local_sin, local_mask)
+
+        return self.final_norm(x)
+
+
+def _additive_mask(bool_mask: mx.array, dtype: mx.Dtype) -> mx.array:
+    """Additive attention mask in the attention compute dtype. Uses a finite
+    floor (as transformers does with ``finfo.min``) rather than -inf."""
+    return mx.where(
+        bool_mask,
+        mx.zeros(bool_mask.shape, dtype=dtype),
+        mx.full(bool_mask.shape, mx.finfo(dtype).min, dtype=dtype),
+    )

--- a/mlx_audio/tts/models/irodori_tts/sampling.py
+++ b/mlx_audio/tts/models/irodori_tts/sampling.py
@@ -135,7 +135,14 @@ def sample_euler_cfg(
     batch_size = text_input_ids.shape[0]
     has_text_cfg = cfg_scale_text > 0
     has_speaker_cfg = cfg_scale_speaker > 0 and use_spk
-    has_caption_cfg = cfg_scale_caption > 0 and use_cap
+    # A fully masked caption makes the caption-uncond bundle identical to the
+    # conditional one, so its guidance term is zero: skip it as upstream does.
+    has_caption_cfg = (
+        cfg_scale_caption > 0
+        and use_cap
+        and caption_mask is not None
+        and bool(mx.any(caption_mask))
+    )
     # For single-context backward compat
     if not is_dual:
         has_context_cfg = cfg_scale_context > 0
@@ -330,7 +337,9 @@ def sample_euler_cfg(
         t = float(t_schedule[i])
         t_next = float(t_schedule[i + 1])
         t_arr = mx.full((batch_size,), t, dtype=mx.float32)
-        use_cfg = (has_text_cfg or has_speaker_cfg) and (cfg_min_t <= t <= cfg_max_t)
+        use_cfg = (has_text_cfg or has_speaker_cfg or has_caption_cfg) and (
+            cfg_min_t <= t <= cfg_max_t
+        )
 
         if use_cfg:
             if cfg_guidance_mode == "independent":

--- a/mlx_audio/tts/models/irodori_tts/text.py
+++ b/mlx_audio/tts/models/irodori_tts/text.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 from typing import Optional
 
 import mlx.core as mx
@@ -11,77 +12,88 @@ import numpy as np
 # Ported from Irodori-TTS/irodori_tts/text_normalization.py (pure Python).
 # ---------------------------------------------------------------------------
 
-_REPLACE_MAP: dict[str, str] = {
-    r"\t": "",
+_SIMPLE_REPLACE_MAP: dict[str, str] = {
+    "\t": "",
+    "[n]": "",
     r"\[n\]": "",
-    r" ": "",  # narrow no-break space (U+202F) / ideographic space handled below
-    r"　": "",  # ideographic space
-    r"[;▼♀♂《》≪≫①②③④⑤⑥]": "",
-    r"[\u02d7\u2010-\u2015\u2043\u2212\u23af\u23e4\u2500\u2501\u2e3a\u2e3b]": "",
-    r"[\uff5e\u301C]": "ー",
-    r"？": "?",
-    r"！": "!",
-    r"[●◯〇]": "○",
-    r"♥": "♡",
+    "\u3000": "",  # ideographic space
+    "？": "?",
+    "！": "!",
+    "♥": "♡",
+    "●": "○",
+    "◯": "○",
+    "〇": "○",
 }
 
-# Fullwidth A-Z a-z → halfwidth
-_FULLWIDTH_ALPHA_TO_HALFWIDTH = str.maketrans(
-    {
-        chr(full): chr(half)
-        for full, half in zip(
-            list(range(0xFF21, 0xFF3B)) + list(range(0xFF41, 0xFF5B)),
-            list(range(0x41, 0x5B)) + list(range(0x61, 0x7B)),
-        )
-    }
-)
+_REGEX_REPLACE_MAP: dict[re.Pattern[str], str] = {
+    re.compile(r"[;▼♀♂《》≪≫①②③④⑤⑥]"): "",
+    re.compile(
+        r"[\u02d7\u2010-\u2015\u2043\u2212\u23af\u23e4\u2500\u2501\u2e3a\u2e3b]"
+    ): "",
+    re.compile(r"[\uff5e\u301C]"): "ー",
+    re.compile(r"…{3,}"): "……",
+}
 
-# Fullwidth 0-9 → halfwidth
-_FULLWIDTH_DIGITS_TO_HALFWIDTH = str.maketrans(
-    {
-        chr(full): chr(half)
-        for full, half in zip(range(0xFF10, 0xFF1A), range(0x30, 0x3A))
-    }
-)
+_BRACKET_PAIRS = {"「": "」", "『": "』", "（": "）", "【": "】", "(": ")"}
 
-# Halfwidth katakana → fullwidth katakana
-_HW_KANA = "ｦｧｨｩｪｫｬｭｮｯｰｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝ"
-_FW_KANA = "ヲァィゥェォャュョッーアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワン"
-_HALFWIDTH_KANA_TO_FULLWIDTH = str.maketrans(_HW_KANA, _FW_KANA)
+
+def strip_outer_brackets(text: str) -> str:
+    """
+    Remove bracket pairs that enclose the whole string, repeatedly.
+
+    Depth tracking matters: in 「前半」と「後半」 the leading 「 closes before the
+    end, so nothing is stripped.
+    """
+    while True:
+        if len(text) < 2:
+            break
+
+        start_char = text[0]
+        end_char = text[-1]
+
+        if start_char in _BRACKET_PAIRS and _BRACKET_PAIRS[start_char] == end_char:
+            depth = 0
+            is_enclosing_all = True
+
+            for i, char in enumerate(text):
+                if char == start_char:
+                    depth += 1
+                elif char == end_char:
+                    depth -= 1
+
+                if depth == 0 and i < len(text) - 1:
+                    is_enclosing_all = False
+                    break
+
+            if is_enclosing_all and depth == 0:
+                text = text[1:-1]
+                continue
+
+        break
+
+    return text
 
 
 def normalize_text(text: str) -> str:
     """
     Normalise Japanese text for TTS input.
-    - Removes noise characters (tabs, special symbols, etc.)
-    - Converts fullwidth alphanumerics and digits to halfwidth
-    - Converts halfwidth katakana to fullwidth
-    - Strips surrounding brackets and trailing punctuation
+
+    Mirrors Irodori-TTS/irodori_tts/text_normalization.py step for step,
+    including the NFKC pass that folds fullwidth alphanumerics, halfwidth
+    kana and characters such as ㈱ or Ⅲ.
     """
-    for pattern, replacement in _REPLACE_MAP.items():
-        text = re.sub(pattern, replacement, text)
+    for old, new in _SIMPLE_REPLACE_MAP.items():
+        text = text.replace(old, new)
 
-    text = text.translate(_FULLWIDTH_ALPHA_TO_HALFWIDTH)
-    text = text.translate(_FULLWIDTH_DIGITS_TO_HALFWIDTH)
-    text = text.translate(_HALFWIDTH_KANA_TO_FULLWIDTH)
+    for pattern, replacement in _REGEX_REPLACE_MAP.items():
+        text = pattern.sub(replacement, text)
 
-    # Collapse runs of 3+ ellipses to double
-    text = re.sub(r"…{3,}", "……", text)
+    text = strip_outer_brackets(text)
 
-    # Strip surrounding bracket pairs
-    for open_br, close_br in [
-        ("「", "」"),
-        ("『", "』"),
-        ("（", "）"),
-        ("【", "】"),
-        ("(", ")"),
-    ]:
-        if text.startswith(open_br) and text.endswith(close_br):
-            text = text[1:-1]
+    text = unicodedata.normalize("NFKC", text)
 
-    # Strip trailing Japanese sentence-ending punctuation
-    if text.endswith(("。", "、")):
-        text = text.rstrip("。、")
+    text = text.replace("...", "…")
+    text = text.replace("..", "…")
 
     return text
 

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -5276,6 +5276,78 @@ class TestIrodoriV4Shapes(unittest.TestCase):
         self.assertEqual(tuple(out.shape), (B, S, self.cfg.patched_latent_dim))
 
 
+class TestIrodoriCaptionAndTailTrim(unittest.TestCase):
+    """Behaviour shared by every caption-conditioned checkpoint (v2 VD, v3 VD, v4)."""
+
+    def _make_model(self):
+        from mlx_audio.tts.models.irodori_tts.irodori_tts import Model
+
+        cfg = _small_irodori_model_config_v4()
+        model = Model(cfg)
+        model.dacvae = _FakeDACVAE(
+            latent_dim=cfg.dit.latent_dim,
+            downsample_factor=cfg.audio_downsample_factor,
+        )
+        model._tokenizer = _MockTokenizer()
+        model._caption_tokenizer = _MockTokenizer()
+        return model
+
+    def _captured_caption_mask(self, caption):
+        model = self._make_model()
+        seen = {}
+        original = model.model.encode_conditions_full
+
+        def spy(*args, **kwargs):
+            seen["mask"] = kwargs.get("caption_mask")
+            return original(*args, **kwargs)
+
+        model.model.encode_conditions_full = spy
+        hop = model.config.audio_downsample_factor
+        list(
+            model.generate(
+                "こんにちは",
+                ref_audio=mx.zeros((1, hop * 8), dtype=mx.float32),
+                caption=caption,
+                rng_seed=0,
+            )
+        )
+        return seen["mask"]
+
+    def test_empty_caption_is_fully_masked(self):
+        """An empty caption still tokenizes to BOS; it must not read as a caption."""
+        mask = self._captured_caption_mask(None)
+        self.assertIsNotNone(mask)
+        self.assertFalse(bool(mx.any(mask)))
+
+    def test_blank_caption_is_fully_masked(self):
+        mask = self._captured_caption_mask("   ")
+        self.assertFalse(bool(mx.any(mask)))
+
+    def test_real_caption_is_not_masked(self):
+        mask = self._captured_caption_mask("穏やかな声")
+        self.assertTrue(bool(mx.any(mask)))
+
+    def test_zero_silence_point_does_not_empty_the_output(self):
+        from mlx_audio.tts.models import irodori_tts as irodori_pkg
+
+        model = self._make_model()
+        module = irodori_pkg.irodori_tts
+        original = module._find_silence_point
+        module._find_silence_point = lambda *a, **k: 0
+        try:
+            hop = model.config.audio_downsample_factor
+            result = list(
+                model.generate(
+                    "こんにちは",
+                    ref_audio=mx.zeros((1, hop * 8), dtype=mx.float32),
+                    rng_seed=0,
+                )
+            )[0]
+        finally:
+            module._find_silence_point = original
+        self.assertGreater(result.samples, 0)
+
+
 class TestIrodoriV4Quantization(unittest.TestCase):
     def test_projector_survives_quantization(self):
         """A quantized Linear stores packed uint32 weights, so the projector

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -4256,11 +4256,25 @@ class TestIrodoriNormalizeText(unittest.TestCase):
         import importlib.util
         import os
 
-        upstream = os.path.expanduser(
-            "~/ghq/github.com/Aratako/Irodori-TTS/irodori_tts/text_normalization.py"
+        root = os.environ.get("IRODORI_TTS_UPSTREAM")
+        candidates = [root] if root else []
+        candidates.append(os.path.expanduser("~/ghq/github.com/Aratako/Irodori-TTS"))
+        upstream = next(
+            (
+                path
+                for path in (
+                    os.path.join(c, "irodori_tts", "text_normalization.py")
+                    for c in candidates
+                )
+                if os.path.isfile(path)
+            ),
+            None,
         )
-        if not os.path.isfile(upstream):
-            self.skipTest("upstream Irodori-TTS checkout not available")
+        if upstream is None:
+            self.skipTest(
+                "upstream Irodori-TTS checkout not available "
+                "(set IRODORI_TTS_UPSTREAM to its root)"
+            )
 
         from mlx_audio.tts.models.irodori_tts.text import normalize_text
 

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -5097,6 +5097,242 @@ class TestIrodoriV3VoiceDesignGenerate(unittest.TestCase):
         self.assertGreater(results[0].samples, 0)
 
 
+# ---------------------------------------------------------------------------
+# Irodori-TTS v4: shared pretrained (ModernBERT) text/caption encoder
+# ---------------------------------------------------------------------------
+
+
+def _small_modernbert_config():
+    return dict(
+        model_type="modernbert",
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        hidden_activation="gelu",
+        norm_eps=1e-5,
+        norm_bias=False,
+        attention_bias=False,
+        mlp_bias=False,
+        global_attn_every_n_layers=3,
+        local_attention=8,
+        global_rope_theta=160000.0,
+        local_rope_theta=10000.0,
+        pad_token_id=3,
+    )
+
+
+def _small_irodori_dit_config_v4(**overrides):
+    defaults = dict(
+        text_encoder_type="pretrained",
+        text_encoder_config=_small_modernbert_config(),
+        pretrained_projector_type="residual_mlp",
+        pretrained_projector_hidden_ratio=2.0,
+        text_vocab_size=64,
+        caption_vocab_size=64,
+        speaker_patch_size=4,
+    )
+    defaults.update(overrides)
+    return _small_irodori_dit_config_v3_voicedesign(**defaults)
+
+
+def _small_irodori_model_config_v4(**sampler_overrides):
+    from mlx_audio.tts.models.irodori_tts.config import ModelConfig, SamplerConfig
+
+    sampler_defaults = dict(
+        num_steps=1,
+        cfg_scale_text=1.0,
+        cfg_scale_speaker=1.0,
+        cfg_scale_caption=1.0,
+        sequence_length=4,
+    )
+    sampler_defaults.update(sampler_overrides)
+    return ModelConfig(
+        dit=_small_irodori_dit_config_v4(),
+        sampler=SamplerConfig(**sampler_defaults),
+        ref_max_seconds=120.0,
+    )
+
+
+class TestIrodoriModernBert(unittest.TestCase):
+    def test_layer_types_alternate(self):
+        from mlx_audio.tts.models.irodori_tts.modernbert import ModernBertConfig
+
+        cfg = ModernBertConfig.from_dict(_small_modernbert_config())
+        self.assertEqual(
+            [cfg.is_global_layer(i) for i in range(4)],
+            [True, False, False, True],
+        )
+
+    def test_rope_parameters_nested_form(self):
+        """transformers>=5 nests the per-layer-type RoPE settings."""
+        from mlx_audio.tts.models.irodori_tts.modernbert import ModernBertConfig
+
+        raw = _small_modernbert_config()
+        raw.pop("global_rope_theta")
+        raw.pop("local_rope_theta")
+        raw["rope_parameters"] = {
+            "full_attention": {"rope_type": "default", "rope_theta": 160000.0},
+            "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0},
+        }
+        cfg = ModernBertConfig.from_dict(raw)
+        self.assertEqual(cfg.global_rope_theta, 160000.0)
+        self.assertEqual(cfg.local_rope_theta, 10000.0)
+
+    def test_encoder_output_shape_and_finite(self):
+        from mlx_audio.tts.models.irodori_tts.modernbert import (
+            ModernBertConfig,
+            ModernBertEncoder,
+        )
+
+        cfg = ModernBertConfig.from_dict(_small_modernbert_config())
+        enc = ModernBertEncoder(cfg)
+        # Long padded tail: sliding-window layers see fully masked query rows,
+        # which must not turn into NaNs.
+        ids = mx.zeros((1, 40), dtype=mx.int32)
+        mask = mx.concatenate(
+            [mx.ones((1, 5), dtype=mx.bool_), mx.zeros((1, 35), dtype=mx.bool_)],
+            axis=1,
+        )
+        out = enc(ids, mask)
+        mx.eval(out)
+        self.assertEqual(tuple(out.shape), (1, 40, cfg.hidden_size))
+        self.assertTrue(bool(mx.all(mx.isfinite(out))))
+
+
+class TestIrodoriV4Shapes(unittest.TestCase):
+    def setUp(self):
+        from mlx_audio.tts.models.irodori_tts.model import IrodoriDiT
+
+        self.cfg = _small_irodori_dit_config_v4()
+        self.model = IrodoriDiT(self.cfg)
+
+    def test_shared_backbone_is_built(self):
+        self.assertTrue(self.cfg.use_pretrained_text_encoder)
+        self.assertIsNotNone(self.model.pretrained_text_backbone)
+
+    def test_projectors_replace_scratch_encoders(self):
+        from mlx_audio.tts.models.irodori_tts.model import (
+            PretrainedConditionProjector,
+        )
+
+        self.assertIsInstance(self.model.text_encoder, PretrainedConditionProjector)
+        self.assertIsInstance(self.model.caption_encoder, PretrainedConditionProjector)
+
+    def test_scratch_config_still_uses_text_encoder(self):
+        from mlx_audio.tts.models.irodori_tts.model import IrodoriDiT, TextEncoder
+
+        model = IrodoriDiT(_small_irodori_dit_config_v3_voicedesign())
+        self.assertIsNone(model.pretrained_text_backbone)
+        self.assertIsInstance(model.text_encoder, TextEncoder)
+
+    def test_encode_conditions_full_shapes(self):
+        B = 1
+        text_ids = mx.zeros((B, 6), dtype=mx.int32)
+        text_mask = mx.ones((B, 6), dtype=mx.bool_)
+        ref_latent = mx.random.normal((B, 8, self.cfg.latent_dim))
+        ref_mask = mx.ones((B, 8), dtype=mx.bool_)
+        cap_ids = mx.zeros((B, 6), dtype=mx.int32)
+        cap_mask = mx.ones((B, 6), dtype=mx.bool_)
+
+        text_state, _, spk_state, spk_mask, cap_state, _ = (
+            self.model.encode_conditions_full(
+                text_ids, text_mask, ref_latent, ref_mask, cap_ids, cap_mask
+            )
+        )
+        mx.eval(text_state, spk_state, cap_state)
+        self.assertEqual(tuple(text_state.shape), (B, 6, self.cfg.text_dim))
+        self.assertEqual(tuple(cap_state.shape), (B, 6, self.cfg.caption_dim_resolved))
+        # speaker_patch_size=4 collapses 8 reference frames into 2 patches
+        self.assertEqual(tuple(spk_state.shape[:2]), (B, 2))
+        self.assertEqual(tuple(spk_mask.shape), (B, 2))
+
+    def test_forward_with_conditions(self):
+        B, S = 1, 4
+        text_ids = mx.zeros((B, 6), dtype=mx.int32)
+        text_mask = mx.ones((B, 6), dtype=mx.bool_)
+        ref_latent = mx.zeros((B, 8, self.cfg.latent_dim))
+        ref_mask = mx.ones((B, 8), dtype=mx.bool_)
+        cap_ids = mx.zeros((B, 6), dtype=mx.int32)
+        cap_mask = mx.ones((B, 6), dtype=mx.bool_)
+
+        text_state, t_mask, spk_state, spk_mask, cap_state, c_mask = (
+            self.model.encode_conditions_full(
+                text_ids, text_mask, ref_latent, ref_mask, cap_ids, cap_mask
+            )
+        )
+        out = self.model.forward_with_conditions(
+            mx.random.normal((B, S, self.cfg.patched_latent_dim)),
+            mx.array([0.5], dtype=mx.float32),
+            text_state,
+            t_mask,
+            spk_state,
+            spk_mask,
+            caption_state=cap_state,
+            caption_mask=c_mask,
+        )
+        mx.eval(out)
+        self.assertEqual(tuple(out.shape), (B, S, self.cfg.patched_latent_dim))
+
+
+class TestIrodoriV4Reference(unittest.TestCase):
+    def _make_model(self):
+        from mlx_audio.tts.models.irodori_tts.irodori_tts import Model
+
+        cfg = _small_irodori_model_config_v4()
+        model = Model(cfg)
+        model.dacvae = _FakeDACVAE(
+            latent_dim=cfg.dit.latent_dim,
+            downsample_factor=cfg.audio_downsample_factor,
+        )
+        model._tokenizer = _MockTokenizer()
+        model._caption_tokenizer = _MockTokenizer()
+        return model
+
+    def test_multi_clip_reference_is_concatenated(self):
+        model = self._make_model()
+        hop = model.config.audio_downsample_factor
+        clips = [mx.zeros((1, hop * 8), dtype=mx.float32) for _ in range(3)]
+        latent, mask = model._encode_ref_audios(clips)
+        mx.eval(latent, mask)
+        self.assertEqual(int(latent.shape[1]), 24)
+        self.assertEqual(tuple(mask.shape), (1, 24))
+
+    def test_reference_trimmed_to_max_ref_seconds(self):
+        model = self._make_model()
+        hop = model.config.audio_downsample_factor
+        rate = model.config.sample_rate
+        # 4 seconds of budget => 100 latent frames at 25 Hz
+        clips = [mx.zeros((1, hop * 80), dtype=mx.float32) for _ in range(3)]
+        latent, _ = model._encode_ref_audios(clips, max_ref_seconds=4.0)
+        mx.eval(latent)
+        self.assertEqual(int(latent.shape[1]), int(4.0 * rate / hop))
+
+    def test_reference_aligned_to_speaker_patch_size(self):
+        model = self._make_model()
+        hop = model.config.audio_downsample_factor
+        # 10 frames is not a multiple of speaker_patch_size=4 -> trimmed to 8
+        latent, mask = model._encode_ref_audios(
+            [mx.zeros((1, hop * 10), dtype=mx.float32)]
+        )
+        mx.eval(latent, mask)
+        self.assertEqual(int(latent.shape[1]) % model.config.dit.speaker_patch_size, 0)
+        self.assertEqual(int(latent.shape[1]), 8)
+
+    def test_generate_with_multiple_reference_clips(self):
+        model = self._make_model()
+        hop = model.config.audio_downsample_factor
+        clips = [mx.zeros((1, hop * 8), dtype=mx.float32) for _ in range(2)]
+        results = list(
+            model.generate(
+                "こんにちは", ref_audio=clips, caption="穏やかな声", rng_seed=0
+            )
+        )
+        self.assertEqual(len(results), 1)
+        self.assertGreater(results[0].samples, 0)
+
+
 class TestKugelAudioModel(unittest.TestCase):
     def _make_model(self):
         from mlx_audio.tts.models.kugelaudio.config import ModelConfig

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -4201,23 +4201,83 @@ class TestIrodoriNormalizeText(unittest.TestCase):
 
         self.assertEqual(normalize_text("ー〜ー"), "ーーー")
 
-    def test_trailing_kuten_stripped(self):
+    def test_trailing_kuten_is_kept(self):
+        """Sentence-final punctuation is prosodically meaningful; upstream keeps it."""
         from mlx_audio.tts.models.irodori_tts.text import normalize_text
 
-        result = normalize_text("こんにちは。")
-        self.assertFalse(result.endswith("。"))
-        self.assertEqual(result, "こんにちは")
+        self.assertEqual(normalize_text("こんにちは。"), "こんにちは。")
+        self.assertEqual(normalize_text("元気ですか、"), "元気ですか、")
+
+    def test_ascii_space_is_kept(self):
+        from mlx_audio.tts.models.irodori_tts.text import normalize_text
+
+        self.assertEqual(normalize_text("hello world"), "hello world")
+
+    def test_ideographic_space_removed(self):
+        from mlx_audio.tts.models.irodori_tts.text import normalize_text
+
+        self.assertEqual(normalize_text("全角　スペース"), "全角スペース")
+
+    def test_dots_become_ellipsis(self):
+        from mlx_audio.tts.models.irodori_tts.text import normalize_text
+
+        self.assertEqual(normalize_text("え...まさか"), "え…まさか")
+        self.assertEqual(normalize_text("本当に..そう"), "本当に…そう")
+
+    def test_nfkc_folding(self):
+        from mlx_audio.tts.models.irodori_tts.text import normalize_text
+
+        self.assertEqual(normalize_text("㈱とかⅢとか"), "(株)とかIIIとか")
 
     def test_surrounding_brackets_stripped(self):
         from mlx_audio.tts.models.irodori_tts.text import normalize_text
 
         self.assertEqual(normalize_text("「こんにちは」"), "こんにちは")
 
+    def test_nested_enclosing_brackets_stripped_repeatedly(self):
+        from mlx_audio.tts.models.irodori_tts.text import normalize_text
+
+        self.assertEqual(normalize_text("（(二重括弧)）"), "二重括弧")
+
+    def test_non_enclosing_brackets_are_kept(self):
+        """「前半」と「後半」 opens and closes twice, so nothing encloses the whole."""
+        from mlx_audio.tts.models.irodori_tts.text import normalize_text
+
+        self.assertEqual(normalize_text("「前半」と「後半」"), "「前半」と「後半」")
+
     def test_no_change_for_plain_text(self):
         from mlx_audio.tts.models.irodori_tts.text import normalize_text
 
         text = "こんにちは"
         self.assertEqual(normalize_text(text), text)
+
+    def test_matches_upstream_reference(self):
+        """Differential check against Irodori-TTS/irodori_tts/text_normalization.py."""
+        import importlib.util
+        import os
+
+        upstream = os.path.expanduser(
+            "~/ghq/github.com/Aratako/Irodori-TTS/irodori_tts/text_normalization.py"
+        )
+        if not os.path.isfile(upstream):
+            self.skipTest("upstream Irodori-TTS checkout not available")
+
+        from mlx_audio.tts.models.irodori_tts.text import normalize_text
+
+        spec = importlib.util.spec_from_file_location("_up_tn", upstream)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        import random
+
+        alphabet = "あいうテスト。、！？…・「」（）ＡＢ12ｱｲ　 ~〜㈱Ⅲ()[]n\t♥●"
+        random.seed(0)
+        cases = ["", "。", "a", "「あ」「い」", "テスト。。", "hello world"] + [
+            "".join(random.choice(alphabet) for _ in range(random.randint(0, 14)))
+            for _ in range(500)
+        ]
+        for case in cases:
+            self.assertEqual(normalize_text(case), module.normalize_text(case), case)
 
 
 class TestIrodoriEncodeText(unittest.TestCase):

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -5276,6 +5276,42 @@ class TestIrodoriV4Shapes(unittest.TestCase):
         self.assertEqual(tuple(out.shape), (B, S, self.cfg.patched_latent_dim))
 
 
+class TestIrodoriV4Quantization(unittest.TestCase):
+    def test_projector_survives_quantization(self):
+        """A quantized Linear stores packed uint32 weights, so the projector
+        must not coerce its activations to the projection weight's dtype."""
+        import mlx.nn as nn
+
+        from mlx_audio.tts.models.irodori_tts.model import IrodoriDiT
+
+        cfg = _small_irodori_dit_config_v4()
+        model = IrodoriDiT(cfg)
+        ids = mx.zeros((1, 6), dtype=mx.int32)
+        mask = mx.ones((1, 6), dtype=mx.bool_)
+
+        before = model.text_encoder(model.pretrained_text_backbone, ids, mask)
+        mx.eval(before)
+
+        nn.quantize(
+            model,
+            group_size=64,
+            bits=8,
+            class_predicate=lambda _path, m: (
+                isinstance(m, nn.Linear)
+                and m.weight.shape[-1] >= 64
+                and m.weight.shape[-1] % 64 == 0
+            ),
+        )
+        after = model.text_encoder(model.pretrained_text_backbone, ids, mask)
+        mx.eval(after)
+
+        self.assertTrue(bool(mx.all(mx.isfinite(after))))
+        scale_before = float(mx.mean(mx.abs(before)))
+        scale_after = float(mx.mean(mx.abs(after)))
+        self.assertGreater(scale_before, 0.0)
+        self.assertLess(abs(scale_after - scale_before) / scale_before, 0.15)
+
+
 class TestIrodoriV4Reference(unittest.TestCase):
     def _make_model(self):
         from mlx_audio.tts.models.irodori_tts.irodori_tts import Model

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -5287,9 +5287,7 @@ class TestIrodoriV4Shapes(unittest.TestCase):
         self.assertIsNotNone(self.model.pretrained_text_backbone)
 
     def test_projectors_replace_scratch_encoders(self):
-        from mlx_audio.tts.models.irodori_tts.model import (
-            PretrainedConditionProjector,
-        )
+        from mlx_audio.tts.models.irodori_tts.model import PretrainedConditionProjector
 
         self.assertIsInstance(self.model.text_encoder, PretrainedConditionProjector)
         self.assertIsInstance(self.model.caption_encoder, PretrainedConditionProjector)


### PR DESCRIPTION
Adds support for [Irodori-TTS v4-Small](https://huggingface.co/Aratako/Irodori-TTS-v4-Small), and fixes several divergences from the reference implementation that were found while validating it.

## v4 support

v4-Small unifies the previous base and VoiceDesign models into one checkpoint. Compared to v3 the architecture change is narrow: the two scratch-trained text/caption encoders are replaced by a single pretrained [ModernBERT-ja-310m](https://huggingface.co/sbintuitions/modernbert-ja-310m) backbone feeding separate projectors, and `speaker_patch_size` goes from 1 to 4. The DiT, adaLN, speaker encoder and duration predictor are unchanged.

- New `modernbert.py`: MLX port of ModernBERT — fused `Wqkv`, GeGLU MLP, alternating global / sliding-window attention with per-layer-type RoPE theta, and layer 0's identity `attn_norm`.
- `PretrainedTextBackbone` + `PretrainedConditionProjector`, used when `text_encoder_type` is `"pretrained"`. v1–v3 keep the scratch encoders.
- The tokenizer bundled with the converted weights is preferred over the upstream repo, so inference needs no extra download.
- Multi-clip reference audio: clips are encoded separately and concatenated, then trimmed to the checkpoint's `ref_max_seconds` (120s for v4, 30s before). This matches how v4 was trained.

Converted models: [`mlx-community/Irodori-TTS-v4-Small-fp16`](https://huggingface.co/mlx-community/Irodori-TTS-v4-Small-fp16) and [`-8bit`](https://huggingface.co/mlx-community/Irodori-TTS-v4-Small-8bit).

## Fixes that also change v1–v3 behaviour

Validating v4 against the reference implementation surfaced pre-existing bugs. **`normalize_text` had drifted in ways that change what the model is asked to read**, so existing checkpoints will sound different (closer to the reference):

- Sentence-final `。` and `、` were stripped. Upstream keeps them, and they carry prosody — dropping the `。` shortened predicted durations and clipped endings.
- ASCII spaces (U+0020) were removed, so `"hello world"` became `"helloworld"`. Only the ideographic space U+3000 should go.
- `..` / `...` were not folded to `…`.
- NFKC normalization was missing, leaving `㈱` or `Ⅲ` untouched.
- Outer-bracket stripping ran once and ignored nesting depth, so `「前半」と「後半」` lost its outer quotes.

Also fixed, affecting every caption-conditioned checkpoint (v2 VD, v3 VD, v4):

- An absent caption still tokenizes to a BOS token and its mask was left set, so the DiT and duration predictor saw a one-token caption instead of none. Upstream zeroes the mask.
- The trailing-silence trim was applied unconditionally, so a silence point of 0 would have produced zero-length audio.
- `use_cfg` ignored `has_caption_cfg`, and `has_caption_cfg` did not check that the caption mask is non-empty.

And one v4-only bug: `PretrainedConditionProjector` coerced its input to `self.projector.weight.dtype`. After `nn.quantize` that weight is packed uint32, so activations were truncated to integers — a no-op in fp16, but it put the 8-bit projector output 79% off.

## Verification

Each stage was compared against the reference PyTorch implementation on the real v4 checkpoint:

| Stage | Agreement |
|---|---|
| ModernBERT encoder (fp32, random weights, vs `transformers`) | 4.8e-7 |
| `normalize_text` (3035 strings incl. 3000 fuzz) | exact |
| Tokenization (text/caption, truncation, padding) | exact |
| Duration features (14-dim) | exact |
| Duration prediction | exact (0.0000%) |
| `text_state` (backbone + projector + norm) | 0.09% |
| DiT forward (`v_pred`) | 0.46% |

The two non-exact rows are fp16-vs-fp32 weight error.

## Known model behaviour (not a port issue)

With a caption but no reference audio, v4 roughly doubles the predicted duration for short texts (under ~7 tokens) and reads the sentence twice to fill the window. Running the reference PyTorch sampler produces the same frame counts and the same repetition, so this is upstream model behaviour. It is documented in the model README along with the workarounds (pass reference audio, or set `duration_scale` / `seconds`).

## Tests

79 Irodori tests pass (13 new for v4, 4 for caption/tail-trim handling, 8 for normalization including a differential check against a local upstream checkout when present). Full `test_models.py`: 441 passed, 1 pre-existing unrelated failure (`TestSparkTTSModel::test_init`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
