### PR TITLE
server: bound ModelProvider's model cache with LRU eviction

### DIFF
--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -16,6 +16,7 @@ import subprocess
 import time
 import uuid
 import webbrowser
+from collections import OrderedDict
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass, is_dataclass
 from pathlib import Path
@@ -89,21 +90,54 @@ def sanitize_for_json(obj: Any) -> Any:
         return obj
 
 
+DEFAULT_MAX_LOADED_MODELS = 2
+
+
 class ModelProvider:
+    """Caches loaded models, keeping at most ``max_models`` of them resident.
+
+    Every distinct model path used to stay in memory for the lifetime of the
+    process, so a server handling several voices grew without bound. The cache
+    is now an LRU bounded by ``MLX_AUDIO_MAX_LOADED_MODELS`` (default
+    ``DEFAULT_MAX_LOADED_MODELS``, which keeps a TTS and an STT model resident
+    at the same time).
+    """
+
     def __init__(self):
-        self.models: Dict[str, Dict[str, Any]] = {}
+        self.models: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+        raw_max_models = os.getenv("MLX_AUDIO_MAX_LOADED_MODELS", str(DEFAULT_MAX_LOADED_MODELS))
+        try:
+            self.max_models = max(1, int(raw_max_models))
+        except ValueError:
+            self.max_models = DEFAULT_MAX_LOADED_MODELS
         self.lock = asyncio.Lock()
 
     def load_model(self, model_name: str):
-        if model_name not in self.models:
-            self.models[model_name] = load_model(model_name)
+        if model_name in self.models:
+            self.models.move_to_end(model_name)
+            return self.models[model_name]
 
-        return self.models[model_name]
+        model = load_model(model_name)
+        self.models[model_name] = model
+        self._evict_until_within_limit()
+
+        return model
+
+    def _evict_until_within_limit(self) -> None:
+        """Drop least recently used models until the cache fits the limit."""
+        evicted = False
+        while len(self.models) > self.max_models:
+            self.models.popitem(last=False)
+            evicted = True
+
+        if evicted:
+            mx.clear_cache()
 
     async def remove_model(self, model_name: str) -> bool:
         async with self.lock:
             if model_name in self.models:
                 del self.models[model_name]
+                mx.clear_cache()
                 return True
             return False
 

--- a/mlx_audio/tests/test_server.py
+++ b/mlx_audio/tests/test_server.py
@@ -891,3 +891,87 @@ def test_stt_word_timestamps_verbose_json_words_passthrough(
     assert len(words) == 2
     assert words[0]["word"] == "Hello"
     assert words[1]["word"] == "world."
+
+
+def _provider(monkeypatch, max_models=None):
+    """Build a ModelProvider whose load_model returns a cheap sentinel."""
+    from mlx_audio import server as server_module
+
+    if max_models is None:
+        monkeypatch.delenv("MLX_AUDIO_MAX_LOADED_MODELS", raising=False)
+    else:
+        monkeypatch.setenv("MLX_AUDIO_MAX_LOADED_MODELS", str(max_models))
+
+    loaded = []
+
+    def fake_load_model(name):
+        loaded.append(name)
+        return {"name": name}
+
+    monkeypatch.setattr(server_module, "load_model", fake_load_model)
+    return server_module.ModelProvider(), loaded
+
+
+def test_model_provider_caches_without_reloading(monkeypatch):
+    provider, loaded = _provider(monkeypatch, max_models=2)
+
+    first = provider.load_model("a")
+    again = provider.load_model("a")
+
+    assert first is again
+    assert loaded == ["a"]
+
+
+def test_model_provider_evicts_least_recently_used(monkeypatch):
+    provider, _ = _provider(monkeypatch, max_models=2)
+
+    provider.load_model("a")
+    provider.load_model("b")
+    provider.load_model("c")
+
+    # "a" is the least recently used, so it is the one that goes.
+    assert list(provider.models.keys()) == ["b", "c"]
+
+
+def test_model_provider_use_refreshes_recency(monkeypatch):
+    provider, _ = _provider(monkeypatch, max_models=2)
+
+    provider.load_model("a")
+    provider.load_model("b")
+    provider.load_model("a")  # "a" becomes most recently used
+    provider.load_model("c")
+
+    assert list(provider.models.keys()) == ["a", "c"]
+
+
+def test_model_provider_respects_env_limit(monkeypatch):
+    provider, loaded = _provider(monkeypatch, max_models=1)
+
+    provider.load_model("a")
+    provider.load_model("b")
+
+    assert list(provider.models.keys()) == ["b"]
+    assert provider.max_models == 1
+
+    # "a" was evicted, so asking for it again reloads it.
+    provider.load_model("a")
+    assert loaded == ["a", "b", "a"]
+
+
+def test_model_provider_invalid_env_falls_back_to_default(monkeypatch):
+    from mlx_audio.server import DEFAULT_MAX_LOADED_MODELS
+
+    provider, _ = _provider(monkeypatch, max_models="not-a-number")
+
+    assert provider.max_models == DEFAULT_MAX_LOADED_MODELS
+
+
+def test_model_provider_default_limit_is_bounded(monkeypatch):
+    from mlx_audio.server import DEFAULT_MAX_LOADED_MODELS
+
+    provider, _ = _provider(monkeypatch)
+
+    for i in range(DEFAULT_MAX_LOADED_MODELS + 3):
+        provider.load_model(f"model-{i}")
+
+    assert len(provider.models) == DEFAULT_MAX_LOADED_MODELS


### PR DESCRIPTION
Fixes #835.

`ModelProvider` cached every model it ever loaded in an unbounded dict and never evicted anything on its own. `remove_model()` exists but only the `DELETE /v1/models` endpoint calls it, so a server used with several voices kept each one resident until the process was restarted.

## Change

The cache is now an `OrderedDict` used as an LRU:

- a cache hit moves the entry to the most-recently-used end
- after a miss loads a new model, the least recently used entries are dropped until the cache is within its limit
- the limit comes from `MLX_AUDIO_MAX_LOADED_MODELS`, parsed the same way as the existing `MLX_AUDIO_TTS_MAX_BATCH_SIZE` (invalid values fall back to the default)
- eviction and `remove_model()` both call `mx.clear_cache()`, matching how the generation loops already release memory

## The default

I set `DEFAULT_MAX_LOADED_MODELS = 2` so a mixed server can keep one TTS and one STT model hot, which seems like the common case for this server. That is the one judgement call in the patch — say the word and I will change it to 1, to a larger number, or to unbounded-unless-configured if you would rather not alter current behaviour by default.

## Not included

`load_model()` is synchronous and does not take `self.lock`, so two concurrent requests for the same uncached model can still both load it. That predates this change and fixing it means making the method async and touching all six call sites, so I left it alone rather than widening the diff. Happy to do it separately if you want it.

## Tests

Six tests in `mlx_audio/tests/test_server.py` cover cache hits not reloading, LRU eviction order, use refreshing recency, the env limit, invalid env falling back to the default, and the default staying bounded.

```
mlx_audio/tests/test_server.py     master: 11 failed, 17 passed
                                this branch: 11 failed, 23 passed
```

The 11 failures are identical on both and are unrelated to this change — they reproduce on a clean checkout in my environment (Python 3.14, macOS 26.5, M4 Pro).
