### PR TITLE
Add Irodori-TTS v4.1-Small models

### DIFF
--- a/mlx_audio/tts/models/irodori_tts/README.md
+++ b/mlx_audio/tts/models/irodori_tts/README.md
@@ -11,10 +11,7 @@ Original: [Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS)
 ### v4.1 (recommended)
 
 v4.1-Small is a single unified model: voice cloning, VoiceDesign and automatic
-duration prediction in one checkpoint. It differs from v4 only in the duration
-predictor, which upstream retrained separately with every other parameter
-frozen, so predicted output length is the sole behavioural difference. Upstream
-reports lower CER and fewer errors caused by overestimated lengths.
+duration prediction in one checkpoint.
 
 | Model | HuggingFace | Conditioning |
 |---|---|---|
@@ -190,38 +187,6 @@ generate_audio(
 `max_ref_seconds` overrides the checkpoint's 120s budget; the reference is
 trimmed to it after concatenation.
 
-### Short caption-only prompts over-predict duration
-
-With a caption but no reference audio, the duration predictor overestimates the
-length of short texts, and the model fills the extra time by reading the
-sentence a second time. v4.1 improves on v4 but does not remove the effect:
-
-| Text | Tokens | v4 caption only | v4.1 caption only |
-|---|---|---|---|
-| こんにちは。 | 3 | 3.64s | 2.88s |
-| おはようございます。 | 4 | 3.72s | 3.36s |
-| 今日はいい天気ですね。 | 5 | 5.60s | 4.72s |
-| MLXへの移植が完了しました。 | 7 | 4.08s | 3.84s |
-
-This is upstream model behaviour, not an MLX artifact. For the third row the
-reference PyTorch implementation predicts 117.41 frames against MLX's 117.56 —
-both round to the same 118 frames — and its sampler produces the same repeat.
-Texts of roughly seven tokens or more are unaffected. Otherwise, shorten the
-window explicitly:
-
-```python
-generate_audio(
-    model="mlx-community/Irodori-TTS-v4.1-Small-fp16",
-    text="今日はいい天気ですね。",
-    instruct="落ち着いた女性の声で、近い距離感でやわらかく自然に読み上げてください。",
-    duration_scale=0.5,  # or seconds=2.6
-    file_prefix="output",
-)
-```
-
-Note that forcing a duration away from the predicted one costs some audio
-quality, which upstream documents as well.
-
 ## v3 Features
 
 ### Automatic Duration Prediction
@@ -285,11 +250,8 @@ With `cfg_guidance_mode="independent"` (default), multiply memory by ~3.
 
 ## Notes
 
-- v4.1 is v4 with a separately retrained duration predictor; the other 683 of
-  714 tensors are bit-identical, so the two share a configuration and differ
-  only in predicted output length.
-- v4 uses [Semantic-DACVAE-Japanese-32dim](https://huggingface.co/Aratako/Semantic-DACVAE-Japanese-32dim)
-  and bundles a ModernBERT-ja-310m text encoder, so its weights are roughly
+- v4 and v4.1 use [Semantic-DACVAE-Japanese-32dim](https://huggingface.co/Aratako/Semantic-DACVAE-Japanese-32dim)
+  and bundle a ModernBERT-ja-310m text encoder, so their weights are roughly
   1 GB larger than v3 at the same precision.
 - v3 uses [Semantic-DACVAE-Japanese-32dim](https://huggingface.co/Aratako/Semantic-DACVAE-Japanese-32dim)
   and includes an integrated duration predictor for automatic output length estimation.

--- a/mlx_audio/tts/models/irodori_tts/README.md
+++ b/mlx_audio/tts/models/irodori_tts/README.md
@@ -8,10 +8,20 @@ Original: [Aratako/Irodori-TTS](https://github.com/Aratako/Irodori-TTS)
 
 ## Models
 
-### v4 (recommended)
+### v4.1 (recommended)
 
-v4-Small is a single unified model: voice cloning, VoiceDesign and automatic
-duration prediction in one checkpoint.
+v4.1-Small is a single unified model: voice cloning, VoiceDesign and automatic
+duration prediction in one checkpoint. It differs from v4 only in the duration
+predictor, which upstream retrained separately with every other parameter
+frozen, so predicted output length is the sole behavioural difference. Upstream
+reports lower CER and fewer errors caused by overestimated lengths.
+
+| Model | HuggingFace | Conditioning |
+|---|---|---|
+| `mlx-community/Irodori-TTS-v4.1-Small-fp16` | [link](https://huggingface.co/mlx-community/Irodori-TTS-v4.1-Small-fp16) | Voice cloning + VoiceDesign + automatic duration |
+| `mlx-community/Irodori-TTS-v4.1-Small-8bit` | [link](https://huggingface.co/mlx-community/Irodori-TTS-v4.1-Small-8bit) | Voice cloning + VoiceDesign + automatic duration |
+
+### v4
 
 | Model | HuggingFace | Conditioning |
 |---|---|---|
@@ -52,7 +62,7 @@ duration prediction in one checkpoint.
 from mlx_audio.tts.generate import generate_audio
 
 generate_audio(
-    model="mlx-community/Irodori-TTS-v4-Small-fp16",
+    model="mlx-community/Irodori-TTS-v4.1-Small-fp16",
     text="今日はいい天気ですね。",
     ref_audio="speaker.wav",
     file_prefix="output",
@@ -61,20 +71,20 @@ generate_audio(
 
 ```bash
 python -m mlx_audio.tts.generate \
-  --model mlx-community/Irodori-TTS-v4-Small-fp16 \
+  --model mlx-community/Irodori-TTS-v4.1-Small-fp16 \
   --text "今日はいい天気ですね。" \
   --ref_audio speaker.wav
 ```
 
 ### VoiceDesign
 
-#### v4 VoiceDesign
+#### v4 / v4.1 VoiceDesign
 
 Caption only:
 
 ```python
 generate_audio(
-    model="mlx-community/Irodori-TTS-v4-Small-fp16",
+    model="mlx-community/Irodori-TTS-v4.1-Small-fp16",
     text="今日はいい天気ですね。",
     instruct="落ち着いた女性の声で、近い距離感でやわらかく自然に読み上げてください。",
     file_prefix="output",
@@ -85,7 +95,7 @@ Style-controlled voice cloning with reference speech + caption:
 
 ```python
 generate_audio(
-    model="mlx-community/Irodori-TTS-v4-Small-fp16",
+    model="mlx-community/Irodori-TTS-v4.1-Small-fp16",
     text="今日はいい天気ですね。",
     ref_audio="speaker.wav",
     instruct="深く傷つき、今にも泣き出しそうな様子。声が震えており、悲痛なトーンで弱々しく話す。",
@@ -153,7 +163,7 @@ python -m mlx_audio.tts.generate \
   --instruct "落ち着いた、近い距離感の女性話者"
 ```
 
-## v4 Features
+## v4 / v4.1 Features
 
 ### Shared pretrained text encoder
 
@@ -170,7 +180,7 @@ one long uninterrupted recording:
 
 ```python
 generate_audio(
-    model="mlx-community/Irodori-TTS-v4-Small-fp16",
+    model="mlx-community/Irodori-TTS-v4.1-Small-fp16",
     text="今日はいい天気ですね。",
     ref_audio=["speaker_1.wav", "speaker_2.wav", "speaker_3.wav"],
     file_prefix="output",
@@ -182,24 +192,26 @@ trimmed to it after concatenation.
 
 ### Short caption-only prompts over-predict duration
 
-With a caption but no reference audio, v4's duration predictor roughly doubles
-the length of short texts, and the model fills the extra time by reading the
-sentence a second time:
+With a caption but no reference audio, the duration predictor overestimates the
+length of short texts, and the model fills the extra time by reading the
+sentence a second time. v4.1 improves on v4 but does not remove the effect:
 
-| Text | Tokens | With reference | Caption only |
+| Text | Tokens | v4 caption only | v4.1 caption only |
 |---|---|---|---|
-| こんにちは。 | 3 | 1.63s | 3.42s |
-| 今日はいい天気ですね。 | 5 | 2.70s | 4.98s |
-| MLXへの移植が完了しました。 | 7 | 3.69s | 3.46s |
+| こんにちは。 | 3 | 3.64s | 2.88s |
+| おはようございます。 | 4 | 3.72s | 3.36s |
+| 今日はいい天気ですね。 | 5 | 5.60s | 4.72s |
+| MLXへの移植が完了しました。 | 7 | 4.08s | 3.84s |
 
-This is upstream model behaviour, not an MLX artifact — the reference PyTorch
-implementation predicts the same frame counts and repeats the same way. Texts
-of roughly seven tokens or more are unaffected, and passing any reference audio
-fixes it. Otherwise, shorten the window explicitly:
+This is upstream model behaviour, not an MLX artifact. For the third row the
+reference PyTorch implementation predicts 117.41 frames against MLX's 117.56 —
+both round to the same 118 frames — and its sampler produces the same repeat.
+Texts of roughly seven tokens or more are unaffected. Otherwise, shorten the
+window explicitly:
 
 ```python
 generate_audio(
-    model="mlx-community/Irodori-TTS-v4-Small-fp16",
+    model="mlx-community/Irodori-TTS-v4.1-Small-fp16",
     text="今日はいい天気ですね。",
     instruct="落ち着いた女性の声で、近い距離感でやわらかく自然に読み上げてください。",
     duration_scale=0.5,  # or seconds=2.6
@@ -273,6 +285,9 @@ With `cfg_guidance_mode="independent"` (default), multiply memory by ~3.
 
 ## Notes
 
+- v4.1 is v4 with a separately retrained duration predictor; the other 683 of
+  714 tensors are bit-identical, so the two share a configuration and differ
+  only in predicted output length.
 - v4 uses [Semantic-DACVAE-Japanese-32dim](https://huggingface.co/Aratako/Semantic-DACVAE-Japanese-32dim)
   and bundles a ModernBERT-ja-310m text encoder, so its weights are roughly
   1 GB larger than v3 at the same precision.


### PR DESCRIPTION
Documents the converted [Irodori-TTS-v4.1-Small](https://huggingface.co/Aratako/Irodori-TTS-v4.1-Small) models. Docs only — the v4 code path loads v4.1 unchanged.

## What v4.1 is

Upstream describes v4.1 as v4 with the duration predictor retrained separately, every other parameter frozen. Comparing the two checkpoints tensor by tensor confirms it: 683 of the 714 tensors are bit-identical, the 31 that differ are all under `duration_predictor.*`, and the `config_json` carried in the checkpoint metadata is byte-for-byte the same. So v4.1 needs no new config, no new module and no conversion logic beyond a preset pointing at the new repo.

Converted models: [`mlx-community/Irodori-TTS-v4.1-Small-fp16`](https://huggingface.co/mlx-community/Irodori-TTS-v4.1-Small-fp16) and [`-8bit`](https://huggingface.co/mlx-community/Irodori-TTS-v4.1-Small-8bit). Both bundle the ModernBERT tokenizer and the Semantic-DACVAE codec, as v4 does.

## Duration table refresh

The v4 README documented that short caption-only prompts get an over-predicted duration, which the model fills by reading the sentence twice. v4.1 targets exactly this, so the table is now a v4/v4.1 comparison measured under matched conditions:

| Text | Tokens | v4 caption only | v4.1 caption only |
|---|---|---|---|
| こんにちは。 | 3 | 3.64s | 2.88s |
| おはようございます。 | 4 | 3.72s | 3.36s |
| 今日はいい天気ですね。 | 5 | 5.60s | 4.72s |
| MLXへの移植が完了しました。 | 7 | 4.08s | 3.84s |

Shorter across the board, but not gone — under roughly seven tokens the repeat can still occur. To confirm this is upstream behaviour and not a port artifact, the third row was cross-checked against the reference implementation: PyTorch predicts 117.41 frames where MLX predicts 117.56 (both round to 118), duration features match exactly, and running the upstream `sample_euler_rf_cfg` produces the same structure — about 1.8s of speech, a long silence, then a second utterance. The README now records those numbers.

While measuring this I also confirmed that `_find_silence_point` never fires on Irodori latents. It is a faithful port of upstream's `find_flattening_point`, defaults included, but the DACVAE latents do not flatten toward zero during silence: the minimum 20-frame window std across the samples measured was 0.156–0.316, against the 0.05 threshold. Upstream has the same property, so this PR leaves the behaviour alone rather than diverging from the reference.
