### PR TITLE
fix(dia): decoder discards ~175ms of real audio from every generation

### DIFF
--- a/mlx_audio/tts/models/dia/audio.py
+++ b/mlx_audio/tts/models/dia/audio.py
@@ -264,7 +264,10 @@ def codebook_to_audio(
         precomp=(t_idx_BxTxC, indices_BTCx3),
         T=seq_length,
     )
-    reverted_codebook = reverted_codebook[:, :-30, :]
+    # Only the delay-flush region is not audio, so that is all that is discarded. Matches
+    # the reference implementation (nari-labs/dia, dia/model.py:507).
+    max_delay_pattern = max(delay_pattern)
+    reverted_codebook = reverted_codebook[:, :-max_delay_pattern, :]
 
     codebook = mx.transpose(reverted_codebook, (0, 2, 1))
 


### PR DESCRIPTION
Fixes #890.

`codebook_to_audio` discarded a hardcoded **30** codec frames from the end of every generation. The correct amount is `max(delay_pattern)` — **15** for Dia-1.6B — which is what the reference implementation uses ([nari-labs/dia, `dia/model.py:507`](https://github.com/nari-labs/dia/blob/main/dia/model.py#L507)):

```python
)[:, :-max_delay_pattern, :]
```

At the DAC's ~86 frames/sec the extra 15 frames are **~175 ms of real speech**, reliably the last syllable of the last word.

## Measurement

One generation, one seed, decoded three ways varying only the trim constant:

| trim | duration | RMS of final 60 ms |
|---:|---:|---:|
| 30 (before) | 4.04 s | **−23.7 dBFS** — still at speaking level, cut mid-sound |
| **15 (after)** | 4.22 s | **−54.8 dBFS** — decays to silence |
| 8 | 4.30 s | −34.0 dBFS — post-EOS padding returning |

RMS over the final 400 ms of an affected generation, 40 ms steps:

```
-25.1  -29.4  -26.0  -26.4  -30.4  -25.0  -20.7  -18.4  -18.0  -18.1  dBFS
```

The signal is **rising** when the file ends. Speech that finishes decays.

## Why it went unnoticed

All three decodes **transcribe identically** — Whisper reconstructs the clipped word from a partial utterance, so speech-to-text verification passes on all of them. It is only visible in the waveform, and audible as clipped word endings.

Found on a 43-chunk podcast render where 20 of 43 chunks ended at speaking level rather than decaying, after a listener reported cut-off sentences that four transcript-based checks had cleared.

## Note

`extra_steps_after_eos = 30` in `dia.py` may deserve the same look — the reference uses `max_delay_pattern` there too ([`dia/model.py:726`](https://github.com/nari-labs/dia/blob/main/dia/model.py#L726)). I left it alone because generating more post-EOS steps than needed is harmless once the trim is correct.

`delay_pattern` is already a parameter of the function, so no signature change is required and the value stays correct for models with a different pattern.