### PR TITLE
fix(qwen3_tts): reject unsupported voice on Base models instead of silently ignoring it

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,26 +69,28 @@ pip install -e ".[dev, server]"
 
 ```bash
 # Basic TTS generation
-mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit --text 'Hello, world!' --voice Chelsie
+mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit --text 'Hello, world!' --voice Vivian
 
 # With a different voice and language hint
-mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit --text 'Welcome to MLX-Audio!' --voice Ethan --lang_code English
+mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit --text 'Welcome to MLX-Audio!' --voice Ryan --lang_code English
 
 # Play audio immediately
-mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit --text 'Hello!' --voice Chelsie --play
+mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit --text 'Hello!' --voice Vivian --play
 
 # Save to a specific directory
-mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit --text 'Hello!' --voice Chelsie --output_path ./my_audio
+mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit --text 'Hello!' --voice Vivian --output_path ./my_audio
 
 # Stream audio during generation
-mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit --text 'Hello!' --voice Chelsie --stream
+mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit --text 'Hello!' --voice Vivian --stream
 
 # Stream audio during generation and save it to disk
-mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit --text 'Hello!' --voice Chelsie --stream --save
+mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit --text 'Hello!' --voice Vivian --stream --save
 
 # Join multiple generated segments into one file
-mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit --text $'Hello!\nHow are you?' --voice Chelsie --join_audio
+mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit --text $'Hello!\nHow are you?' --voice Vivian --join_audio
 ```
+
+Note: `--voice` picks a preset speaker and only works with **CustomVoice** models — the Qwen3-TTS **Base** models have no preset voices; clone a voice with them instead by passing `ref_audio` + `ref_text` (see the [Qwen3-TTS README](mlx_audio/tts/models/qwen3_tts/README.md)).
 
 By default, when generation yields multiple segments, mlx-audio saves numbered files such as `audio_000.wav` and `audio_001.wav`. Use `--join_audio` to save one combined file instead. When using `--stream`, add `--save` to write the streamed audio to disk.
 
@@ -98,12 +100,12 @@ By default, when generation yields multiple segments, mlx-audio saves numbered f
 from mlx_audio.tts.utils import load_model
 
 # Load model
-model = load_model("mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit")
+model = load_model("mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit")
 
 # Generate speech
 for result in model.generate(
     "Hello from MLX-Audio!",
-    voice="Chelsie",
+    voice="Vivian",
     lang_code="English",
 ):
     print(f"Generated {result.audio.shape[0]} samples")
@@ -194,10 +196,10 @@ Alibaba's state-of-the-art multilingual TTS with voice cloning, emotion control,
 ```python
 from mlx_audio.tts.utils import load_model
 
-model = load_model("mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16")
-results = list(model.generate(
+model = load_model("mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-bf16")
+results = list(model.generate_custom_voice(
     text="Hello, welcome to MLX-Audio!",
-    voice="Chelsie",
+    speaker="Vivian",
     language="English",
 ))
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bi
 mlx_audio.tts.generate --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit --text $'Hello!\nHow are you?' --voice Vivian --join_audio
 ```
 
-Note: `--voice` picks a preset speaker and only works with **CustomVoice** models — the Qwen3-TTS **Base** models have no preset voices; clone a voice with them instead by passing `ref_audio` + `ref_text` (see the [Qwen3-TTS README](mlx_audio/tts/models/qwen3_tts/README.md)).
 
 By default, when generation yields multiple segments, mlx-audio saves numbered files such as `audio_000.wav` and `audio_001.wav`. Use `--join_audio` to save one combined file instead. When using `--stream`, add `--save` to write the streamed audio to disk.
 

--- a/docs/getting-started/quickstart-cli.md
+++ b/docs/getting-started/quickstart-cli.md
@@ -5,7 +5,10 @@ mlx-audio provides command-line tools for both text-to-speech generation and spe
 ## Text-to-Speech
 
 !!! note
-    These TTS quickstart examples use `mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit`.
+    These TTS quickstart examples use `mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit`,
+    which supports preset voices via `--voice`. The Qwen3-TTS **Base** models (e.g.
+    `Qwen3-TTS-12Hz-1.7B-Base-8bit`) have no preset voices — see
+    [Voice Cloning](#voice-cloning-csm) below for how to use them with a reference audio clip instead.
 
 ### Basic Generation
 
@@ -13,9 +16,9 @@ Generate speech from text with a single command:
 
 ```bash
 mlx_audio.tts.generate \
-    --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit \
+    --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit \
     --text "Hello, world!" \
-    --voice Chelsie \
+    --voice Vivian \
     --lang_code English
 ```
 
@@ -25,9 +28,9 @@ Add `--play` to hear the result without saving:
 
 ```bash
 mlx_audio.tts.generate \
-    --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit \
+    --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit \
     --text "Hello, world!" \
-    --voice Chelsie \
+    --voice Vivian \
     --lang_code English \
     --play
 ```
@@ -38,9 +41,9 @@ Choose a voice preset and provide a language hint:
 
 ```bash
 mlx_audio.tts.generate \
-    --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit \
+    --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit \
     --text "Welcome to MLX-Audio!" \
-    --voice Ethan \
+    --voice Ryan \
     --lang_code English
 ```
 
@@ -48,9 +51,9 @@ mlx_audio.tts.generate \
 
 ```bash
 mlx_audio.tts.generate \
-    --model mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit \
+    --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit \
     --text "Hello!" \
-    --voice Chelsie \
+    --voice Vivian \
     --lang_code English \
     --output_path ./my_audio
 ```
@@ -123,7 +126,7 @@ python -m mlx_audio.stt.generate \
 | `--model` | Hugging Face model ID or local path |
 | `--text` | Input text for TTS generation |
 | `--audio` | Input audio file for STT transcription |
-| `--voice` | Voice preset name (e.g., `Chelsie`, `Ethan`, `casual_male`) |
+| `--voice` | Voice preset name (e.g., `Vivian`, `Ryan`, `casual_male`); CustomVoice models only |
 | `--speed` | Speech speed multiplier (default: `1.0`) |
 | `--lang_code` | Language hint (e.g., `English`, `Chinese`, or `auto`) |
 | `--play` | Play audio immediately after generation |

--- a/docs/getting-started/quickstart-python.md
+++ b/docs/getting-started/quickstart-python.md
@@ -5,7 +5,10 @@ Use the mlx-audio Python API to generate speech, transcribe audio, and process a
 ## Text-to-Speech
 
 !!! note
-    These TTS quickstart examples use `mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit`.
+    These TTS quickstart examples use `mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit`,
+    which supports preset voices. The Qwen3-TTS **Base** models (e.g.
+    `Qwen3-TTS-12Hz-1.7B-Base-8bit`) have no preset voices — clone a voice with them
+    instead by passing `ref_audio` + `ref_text` to `generate()`.
 
 ### Basic Generation
 
@@ -13,13 +16,13 @@ Use the mlx-audio Python API to generate speech, transcribe audio, and process a
 from mlx_audio.tts.utils import load_model
 
 # Load a TTS model
-model = load_model("mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit")
+model = load_model("mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit")
 
 # Generate speech
-for result in model.generate(
+for result in model.generate_custom_voice(
     "Hello from MLX-Audio!",
-    voice="Chelsie",
-    lang_code="English",
+    speaker="Vivian",
+    language="English",
 ):
     print(f"Generated {result.audio.shape[0]} samples")
     # result.audio contains the waveform as mx.array
@@ -30,18 +33,18 @@ for result in model.generate(
 ```python
 from mlx_audio.tts.utils import load_model
 
-model = load_model("mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit")
+model = load_model("mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit")
 
-for result in model.generate(
+for result in model.generate_custom_voice(
     text="Welcome to MLX-Audio!",
-    voice="Ethan",
-    lang_code="English",
+    speaker="Ryan",
+    language="English",
 ):
     audio = result.audio
 ```
 
-!!! tip "Qwen3-TTS Base Model"
-    Pass `voice` to pick a preset speaker and `lang_code` to hint the language, for example `voice="Chelsie"` and `lang_code="English"`.
+!!! tip "Qwen3-TTS CustomVoice Model"
+    Pass `speaker` to pick a preset voice and `language` to hint the language, for example `speaker="Vivian"` and `language="English"`. Call `model.get_supported_speakers()` to list the voices available on a given checkpoint.
 
 ### Voxtral TTS
 
@@ -59,11 +62,11 @@ for result in model.generate(text="Hello, how are you today?", voice="casual_mal
 ```python
 from mlx_audio.tts.utils import load_model
 
-model = load_model("mlx-community/Qwen3-TTS-12Hz-1.7B-Base-8bit")
-results = list(model.generate(
+model = load_model("mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit")
+results = list(model.generate_custom_voice(
     text="Hello, welcome to MLX-Audio!",
-    voice="Chelsie",
-    lang_code="English",
+    speaker="Vivian",
+    language="English",
 ))
 
 audio = results[0].audio  # mx.array

--- a/docs/models/tts/qwen3-tts.md
+++ b/docs/models/tts/qwen3-tts.md
@@ -6,8 +6,8 @@ Alibaba's state-of-the-art multilingual TTS with three model variants covering v
 
 | Model | Method | Description | HuggingFace |
 |-------|--------|-------------|-------------|
-| `mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16` | `generate()` | Fast, predefined voices | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16) |
-| `mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16` | `generate()` | Higher quality | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16) |
+| `mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16` | `generate()` | Fast voice cloning (ref_audio + ref_text); no preset voices | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16) |
+| `mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16` | `generate()` | Higher-quality voice cloning; no preset voices | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16) |
 | `mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-bf16` | `generate_custom_voice()` | Voices + emotion | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-bf16) |
 | `mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16` | `generate_custom_voice()` | Better emotion control | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16) |
 | `mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16` | `generate_voice_design()` | Create any voice from description | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16) |
@@ -20,9 +20,9 @@ Alibaba's state-of-the-art multilingual TTS with three model variants covering v
 
     ```bash
     mlx_audio.tts.generate \
-        --model mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16 \
+        --model mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-bf16 \
         --text "Hello, welcome to MLX-Audio!" \
-        --voice Chelsie
+        --voice Vivian
     ```
 
 === "Python"
@@ -30,15 +30,20 @@ Alibaba's state-of-the-art multilingual TTS with three model variants covering v
     ```python
     from mlx_audio.tts.utils import load_model
 
-    model = load_model("mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16")
-    results = list(model.generate(
+    model = load_model("mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-bf16")
+    results = list(model.generate_custom_voice(
         text="Hello, welcome to MLX-Audio!",
-        voice="Chelsie",
+        speaker="Vivian",
         language="English",
     ))
 
     audio = results[0].audio  # mx.array
     ```
+
+!!! note
+    `--voice`/`speaker` picks a preset voice and only works with **CustomVoice** models.
+    **Base** models have no preset voices — see [Voice Cloning](#voice-cloning) below to
+    use them with `ref_audio` + `ref_text`.
 
 ### Voice Cloning
 

--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -473,7 +473,7 @@ def parse_args():
         "--voice",
         type=str,
         default=None,
-        help="Voice/speaker name (e.g., Chelsie, Ethan, Vivian for Qwen3-TTS)",
+        help="Voice/speaker name (e.g., Vivian, Ryan for Qwen3-TTS CustomVoice models)",
     )
     parser.add_argument(
         "--prompt",

--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -1165,11 +1165,13 @@ class Model(nn.Module):
         Automatically routes to the appropriate generation method based on model type:
         - voice_design: Uses generate_voice_design() with instruct as voice description
         - custom_voice: Uses generate_custom_voice() with voice as speaker and optional instruct
-        - base: Uses standard generation with voice as speaker
+        - base: Uses ref_audio + ref_text for voice cloning; has no preset voices
 
         Args:
             text: Input text to synthesize
-            voice: Speaker name (for multi-speaker models, e.g., 'Chelsie', 'Ethan')
+            voice: Speaker name (CustomVoice models only, e.g. 'Vivian', 'Ryan';
+                see model.get_supported_speakers()). Base models have no preset
+                voices — use ref_audio + ref_text to clone a voice instead.
             instruct: Instruction for emotion/style (CustomVoice) or voice description (VoiceDesign)
             temperature: Sampling temperature
             speed: Speech speed factor (not directly supported yet)
@@ -1220,7 +1222,7 @@ class Model(nn.Module):
             if not voice:
                 raise ValueError(
                     "CustomVoice model requires 'voice' (speaker name) "
-                    "(e.g., 'Chelsie', 'Ethan', 'Vivian')"
+                    f"(e.g., {self.supported_speakers})"
                 )
             yield from self.generate_custom_voice(
                 text=text,
@@ -1268,6 +1270,20 @@ class Model(nn.Module):
                 streaming_interval=streaming_interval,
             )
             return
+
+        if voice is not None and voice.lower() not in [
+            s.lower() for s in self.supported_speakers
+        ]:
+            raise ValueError(
+                f"Voice '{voice}' is not supported by this Base model. "
+                "Base models have no built-in preset voices — clone a voice by "
+                "passing ref_audio and ref_text instead."
+                + (
+                    f" Available preset voices: {self.supported_speakers}"
+                    if self.supported_speakers
+                    else ""
+                )
+            )
 
         # Split text into segments
         if split_pattern:

--- a/mlx_audio/tts/tests/test_qwen3_tts.py
+++ b/mlx_audio/tts/tests/test_qwen3_tts.py
@@ -496,7 +496,7 @@ def _make_generation_test_model(text_token_count: int = 10):
     model.talker = _FakeTalker(hidden_size=hidden_size, vocab_size=vocab_size)
     model.speech_tokenizer = _FakeSpeechTokenizer()
     model.tokenizer = SimpleNamespace(encode=lambda text: list(range(text_token_count)))
-    model._prepare_generation_inputs = lambda **kwargs: (
+    model._prepare_generation_inputs = lambda *args, **kwargs: (
         mx.zeros((1, 1, hidden_size), dtype=mx.float32),
         mx.zeros((1, 1, hidden_size), dtype=mx.float32),
         mx.zeros((1, 1, hidden_size), dtype=mx.float32),
@@ -635,6 +635,36 @@ class TestQwen3TTSMaxTokens(unittest.TestCase):
         )
 
         self.assertEqual(results[-1].token_count, 120)
+
+
+class TestQwen3TTSBaseVoiceValidation(unittest.TestCase):
+    """Regression tests for mlx-audio#892: passing an unsupported `voice` to a
+    Base model (which has no preset speakers) used to silently no-op instead
+    of erroring, producing unconditioned/random-sounding audio on every call.
+    """
+
+    def test_generate_rejects_unsupported_voice_on_base_model(self):
+        model = _make_generation_test_model()
+        model.supported_speakers = []
+
+        with self.assertRaises(ValueError):
+            next(model.generate(text="Hello", voice="Chelsie"))
+
+    def test_generate_allows_no_voice_on_base_model(self):
+        model = _make_generation_test_model()
+        model.supported_speakers = []
+
+        results = list(model.generate(text="Hello", voice=None, max_tokens=1))
+
+        self.assertTrue(results)
+
+    def test_generate_allows_supported_voice_case_insensitively(self):
+        model = _make_generation_test_model()
+        model.supported_speakers = ["Vivian"]
+
+        results = list(model.generate(text="Hello", voice="vivian", max_tokens=1))
+
+        self.assertTrue(results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #892. `Qwen3-TTS` **Base** checkpoints ship an empty `spk_id` table, voice conditioning for them only works via `ref_audio` + `ref_text` cloning (this matches the original `Qwen/Qwen3-TTS-*-Base` upstream config, not just the mlx-community conversion). But `generate()` never validated `voice` on the Base-model code path, so e.g. `--voice Chelsie` silently fell through to `speaker_embed=None`, producing fully unconditioned, different-sounding audio on every call exactly the "voice selector not working" behavior reported in #892.

- Added a validation check in `generate()`'s Base-model branch, mirroring the check `generate_custom_voice()` already does: raises `ValueError` naming the unsupported voice and pointing to `ref_audio`/`ref_text` cloning instead of silently no-oping.
- Fixed the misleading docs/examples that told users to pass `--voice Chelsie`/`Ethan` to **Base** models in `README.md`, `docs/getting-started/quickstart-cli.md`, `docs/getting-started/quickstart-python.md`, and `docs/models/tts/qwen3-tts.md`, those aren't even real Qwen3-TTS speaker names (Chelsie/Ethan are Qwen-Omni voices, unrelated to this model family). Swapped the flagship examples to a CustomVoice model with real preset speakers (`Vivian`, `Ryan`).
- Fixed the same wrong names in the `generate()`/`generate_custom_voice()` docstrings and the `--voice` CLI `--help` text in `generate.py`.
- Added 3 regression tests to `test_qwen3_tts.py`: reject an unsupported voice on a Base model, allow `voice=None` to proceed normally, and allow a case-insensitive match against `supported_speakers`.

