### PR TITLE
fix(tests): put ecapa_tdnn models in eval mode before batch=1 forward…

### DIFF
--- a/mlx_audio/codec/tests/test_ecapa_backbone.py
+++ b/mlx_audio/codec/tests/test_ecapa_backbone.py
@@ -157,6 +157,7 @@ class TestEcapaTdnnBackbone(unittest.TestCase):
 
         config = EcapaTdnnConfig()
         model = EcapaTdnnBackbone(config)
+        model.eval()
         x = mx.zeros((1, 100, 60))
         out = model(x)
         mx.eval(out)
@@ -169,6 +170,7 @@ class TestEcapaTdnnBackbone(unittest.TestCase):
             input_size=80, channels=512, embed_dim=192, global_context=True
         )
         model = EcapaTdnnBackbone(config)
+        model.eval()
         x = mx.zeros((1, 200, 80))
         out = model(x)
         mx.eval(out)
@@ -190,6 +192,7 @@ class TestEcapaTdnnBackbone(unittest.TestCase):
 
         config = EcapaTdnnConfig(input_size=60, channels=512, embed_dim=128)
         model = EcapaTdnnBackbone(config)
+        model.eval()
         x = mx.zeros((4, 50, 60))
         out = model(x)
         mx.eval(out)
@@ -215,6 +218,7 @@ class TestBackboneRegressionNumerics(unittest.TestCase):
 
         config = EcapaTdnnConfig(input_size=60, channels=512, embed_dim=128)
         model = EcapaTdnnBackbone(config)
+        model.eval()
         x = mx.random.normal((1, 100, 60))
         out = model(x)
         mx.eval(out)
@@ -225,6 +229,7 @@ class TestBackboneRegressionNumerics(unittest.TestCase):
 
         config = EcapaTdnnConfig(input_size=60, channels=512, embed_dim=128)
         model = EcapaTdnnBackbone(config)
+        model.eval()
         x = mx.random.normal((2, 100, 60))
         out = model(x)
         mx.eval(out)
@@ -235,6 +240,7 @@ class TestBackboneRegressionNumerics(unittest.TestCase):
 
         config = EcapaTdnnConfig(input_size=60, channels=512, embed_dim=128)
         model = EcapaTdnnBackbone(config)
+        model.eval()
         x1 = mx.random.normal((2, 100, 60))
         x2 = mx.random.normal((2, 100, 60))
         out1 = model(x1)
@@ -259,6 +265,7 @@ class TestLidBackboneIntegration(unittest.TestCase):
 
         config = ModelConfig(id2label={str(i): f"{i}: lang_{i}" for i in range(10)})
         model = ECAPA_TDNN(config)
+        model.eval()
         mel = mx.zeros((1, 100, 60))
         out = model(mel)
         mx.eval(out)
@@ -270,6 +277,7 @@ class TestLidBackboneIntegration(unittest.TestCase):
 
         config = ModelConfig(id2label={str(i): f"{i}: lang_{i}" for i in range(10)})
         model = ECAPA_TDNN(config)
+        model.eval()
         audio = mx.random.normal((16000,))
         result = model.predict(audio, top_k=3)
         self.assertEqual(len(result), 3)

--- a/mlx_audio/lid/tests/test_lid.py
+++ b/mlx_audio/lid/tests/test_lid.py
@@ -315,6 +315,7 @@ class TestEcapaTdnnModel(unittest.TestCase):
 
     def test_forward_output_shape(self):
         model = self.Model(self.config)
+        model.eval()
         mel = mx.random.normal((1, 100, 60))
         log_probs = model(mel)
         mx.eval(log_probs)
@@ -323,6 +324,7 @@ class TestEcapaTdnnModel(unittest.TestCase):
 
     def test_forward_log_probs_sum(self):
         model = self.Model(self.config)
+        model.eval()
         mel = mx.random.normal((1, 100, 60))
         log_probs = model(mel)
         probs = mx.exp(log_probs)
@@ -361,6 +363,7 @@ class TestEcapaTdnnModel(unittest.TestCase):
 
     def test_predict_returns_sorted(self):
         model = self.Model(self.config)
+        model.eval()
         labels = {str(i): f"lang_{i}" for i in range(10)}
         model.config.id2label = labels
         model.id2label = {int(k): v for k, v in labels.items()}
@@ -374,6 +377,7 @@ class TestEcapaTdnnModel(unittest.TestCase):
 
     def test_predict_without_id2label(self):
         model = self.Model(self.config)
+        model.eval()
         model.id2label = {}
         audio = mx.random.normal((16000,))
         results = model.predict(audio, top_k=2)


### PR DESCRIPTION
mlx>=0.32 tightened `BatchNorm` to reject training-mode forward passes with a single value per channel, and the Codec/LID test suites construct `EcapaTdnnBackbone`/`ECAPA_TDNN` directly with batch=1 inputs while still in default training mode, so 9 tests now hit that guard (`pyproject.toml`'s unpinned `mlx>=0.31.1` means CI just floats to whatever's newest on PyPI). Production is unaffected — `load_model()` already calls `.eval()` on every real load — so this is a test-only fix. It adds `model.eval()` after each raw model construction that's followed by a forward pass, matching the pattern one test in the same file already used correctly. Verified: 96 tests pass under both mlx 0.31.2 and 0.32.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)