### PR TITLE
fix(qwen3_tts): stop exempting EOS from top-k/top-p sampling filters

### DIFF
--- a/mlx_audio/tts/models/qwen3_tts/continuous_batching.py
+++ b/mlx_audio/tts/models/qwen3_tts/continuous_batching.py
@@ -233,7 +233,6 @@ class Qwen3TTSBatchSession:
             repetition_penalty=self.options.repetition_penalty,
             generated_tokens_per_seq=generated_tokens_per_seq,
             suppress_tokens=self.suppress_tokens,
-            eos_token_id=self.eos_token_id,
         )
 
         code_tokens, all_codes = self.model._predict_code_tokens(

--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -811,7 +811,6 @@ class Model(nn.Module):
         repetition_penalty: float = 1.05,
         generated_tokens: Optional[List[int]] = None,
         suppress_tokens: Optional[List[int]] = None,
-        eos_token_id: Optional[int] = None,
         min_p: float = 0.0,
     ) -> mx.array:
 
@@ -852,18 +851,10 @@ class Model(nn.Module):
         if temperature != 1.0:
             logits = logits / temperature
 
-        eos_logit = None
-        if eos_token_id is not None and eos_token_id < logits.shape[-1]:
-            eos_logit = logits[:, eos_token_id : eos_token_id + 1]
-
         if top_k > 0 and top_k < logits.shape[-1]:
             logits = apply_top_k(logits, top_k)
 
         logits = _apply_probability_filters(logits, top_p, min_p)
-
-        if eos_logit is not None:
-            eos_idx = mx.array([[eos_token_id]], dtype=mx.int32)
-            logits = mx.put_along_axis(logits, eos_idx, eos_logit, axis=-1)
 
         token = categorical_sampling(logits, 1.0)
         return token[:, None]
@@ -877,7 +868,6 @@ class Model(nn.Module):
         repetition_penalty: float = 1.05,
         generated_tokens_per_seq: Optional[List[List[int]]] = None,
         suppress_tokens: Optional[List[int]] = None,
-        eos_token_id: Optional[int] = None,
         min_p: float = 0.0,
     ) -> mx.array:
         """Batched sampling from [batch, seq_len, vocab] logits. Returns [batch, 1]."""
@@ -926,20 +916,10 @@ class Model(nn.Module):
         if temperature != 1.0:
             logits = logits / temperature
 
-        # Preserve EOS logit before filtering
-        eos_logit = None
-        if eos_token_id is not None and eos_token_id < logits.shape[-1]:
-            eos_logit = logits[:, eos_token_id : eos_token_id + 1]  # [batch, 1]
-
         if top_k > 0 and top_k < logits.shape[-1]:
             logits = apply_top_k(logits, top_k)
 
         logits = _apply_probability_filters(logits, top_p, min_p)
-
-        # Restore EOS logit
-        if eos_logit is not None:
-            eos_idx = mx.full((logits.shape[0], 1), eos_token_id, dtype=mx.int32)
-            logits = mx.put_along_axis(logits, eos_idx, eos_logit, axis=-1)
 
         tokens = categorical_sampling(logits, 1.0)  # [batch]
         return tokens[:, None]  # [batch, 1]
@@ -1342,7 +1322,6 @@ class Model(nn.Module):
                         generated_token_ids if generated_token_ids else None
                     ),
                     suppress_tokens=suppress_tokens,
-                    eos_token_id=eos_token_id,
                 )
 
                 # Lazy EOS check — defer sync to batch with input_embeds eval
@@ -1880,7 +1859,6 @@ class Model(nn.Module):
                 repetition_penalty=repetition_penalty,
                 generated_tokens_per_seq=generated_token_ids,
                 suppress_tokens=suppress_tokens,
-                eos_token_id=eos_token_id,
             )  # [batch, 1]
 
             # Mask finished sequences to EOS (vectorized, no sync)
@@ -2287,7 +2265,6 @@ class Model(nn.Module):
                 repetition_penalty=repetition_penalty,
                 generated_tokens=(generated_token_ids if generated_token_ids else None),
                 suppress_tokens=suppress_tokens,
-                eos_token_id=eos_token_id,
             )
 
             # Lazy EOS check — defer sync to batch with input_embeds eval
@@ -2595,7 +2572,6 @@ class Model(nn.Module):
                 repetition_penalty=repetition_penalty,
                 generated_tokens=(generated_token_ids if generated_token_ids else None),
                 suppress_tokens=suppress_tokens,
-                eos_token_id=eos_token_id,
             )
 
             # Lazy EOS check — defer sync to batch with input_embeds eval

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -3175,8 +3175,8 @@ class TestQwen3TTSGenerateICL(unittest.TestCase):
         cb0_count = [0]
 
         def controlled_sample(*args, **kwargs):
-            # CB0 calls have eos_token_id set
-            if kwargs.get("eos_token_id") is not None:
+            # CB0 calls pass suppress_tokens; code predictor calls don't
+            if kwargs.get("suppress_tokens") is not None:
                 cb0_count[0] += 1
                 if cb0_count[0] <= 2:
                     return mx.array([[5]])  # non-EOS token

--- a/mlx_audio/tts/tests/test_qwen3_tts.py
+++ b/mlx_audio/tts/tests/test_qwen3_tts.py
@@ -593,6 +593,72 @@ class TestQwen3TTSSamplingFilters(unittest.TestCase):
         self.assertEqual(captured["temperature"], 1.0)
 
 
+class TestQwen3TTSNoEosFilterBypass(unittest.TestCase):
+    """Regression tests for mlx-audio#882.
+
+    _sample_token/_sample_token_batch used to splice a token's pre-filter
+    logit back in after top_k/top_p filtering when it matched eos_token_id,
+    giving it nonzero sampling probability even when top_k/top_p had ranked
+    it out of the surviving candidate set. That let EOS fire before the
+    model's true completion point, truncating audio mid-utterance. Every
+    token, including EOS, must now be filtered identically.
+    """
+
+    def test_low_ranked_token_never_sampled_under_top_k(self):
+        model = Model.__new__(Model)
+        # Last token sits far below the top-2 cutoff; a correct top_k filter
+        # must exclude it from every draw.
+        logits = mx.array([[[10.0, 9.0, 8.0, 7.0, -100.0]]], dtype=mx.float32)
+
+        sampled = set()
+        for _ in range(200):
+            token = Model._sample_token(
+                model,
+                logits,
+                temperature=1.0,
+                top_k=2,
+                top_p=1.0,
+                repetition_penalty=1.0,
+            )
+            sampled.add(int(token[0, 0]))
+
+        self.assertNotIn(4, sampled)
+
+    def test_low_ranked_token_never_sampled_under_top_k_batched(self):
+        model = Model.__new__(Model)
+        logits = mx.array(
+            [
+                [[10.0, 9.0, 8.0, 7.0, -100.0]],
+                [[7.0, 8.0, 9.0, 10.0, -100.0]],
+            ],
+            dtype=mx.float32,
+        )
+
+        sampled = set()
+        for _ in range(200):
+            tokens = Model._sample_token_batch(
+                model,
+                logits,
+                temperature=1.0,
+                top_k=2,
+                top_p=1.0,
+                repetition_penalty=1.0,
+            )
+            sampled.update(int(t) for t in tokens[:, 0].tolist())
+
+        self.assertNotIn(4, sampled)
+
+    def test_sample_token_no_longer_accepts_eos_token_id(self):
+        model = Model.__new__(Model)
+        logits = mx.array([[[1.0, 0.0]]], dtype=mx.float32)
+
+        with self.assertRaises(TypeError):
+            Model._sample_token(model, logits, eos_token_id=1)
+
+        with self.assertRaises(TypeError):
+            Model._sample_token_batch(model, logits, eos_token_id=1)
+
+
 class TestQwen3TTSMaxTokens(unittest.TestCase):
     def test_generate_with_instruct_honors_explicit_max_tokens(self):
         model = _make_generation_test_model(text_token_count=10)


### PR DESCRIPTION
`_sample_token`/`_sample_token_batch` used to capture the EOS logit before top-k/top-p filtering and splice it back in afterward.

This fixes it and I verified a tokens ranked outside top-k are now correctly excluded (0/200 draws) while a legitimate/dominant EOS still reliably terminates generation, all test suits green

Fixes #882