### PR TITLE
Voxtral: stop on <pad> (11), not on the text token 32000

### DIFF
--- a/mlx_audio/stt/models/voxtral/voxtral.py
+++ b/mlx_audio/stt/models/voxtral/voxtral.py
@@ -15,9 +15,17 @@ from mlx_audio.stt.utils import get_model_path, wired_limit
 from ..base import STTOutput
 from .config import AudioConfig, ModelConfig
 
-# Voxtral's three EOS-equivalent token ids. Used as the default when a
-# loaded tokenizer has no `eos_token_ids` populated.
-_VOXTRAL_EOS_TOKEN_IDS = [2, 4, 32000]
+# Voxtral's three EOS-equivalent token ids: </s>, [/INST] and <pad>. Used as
+# the default when a loaded tokenizer has no `eos_token_ids` populated, which
+# is the normal case for a `transformers` tokenizer (it carries the singular
+# `eos_token_id`).
+#
+# <pad> is id 11. It is emphatically NOT 32000: Voxtral's Tekken vocabulary has
+# 131072 entries of which only the first 1000 are control tokens, and 32000 is
+# the ordinary text token " Capital". Stopping on it truncates any transcript
+# containing that word -- silently, because what comes back is clean prose that
+# merely ends early, so nothing downstream can tell it from a short utterance.
+_VOXTRAL_EOS_TOKEN_IDS = [2, 4, 11]
 
 
 def _ensure_eos_token_ids_list(tokenizer, default=_VOXTRAL_EOS_TOKEN_IDS):
@@ -28,7 +36,7 @@ def _ensure_eos_token_ids_list(tokenizer, default=_VOXTRAL_EOS_TOKEN_IDS):
     collapse any missing `*_id` / `*_ids` attribute lookup to the
     corresponding single-token id (`eos_token_id` etc.), and overrides
     `__setattr__` to reject non-string values for those keys. Together
-    these make `tok.eos_token_ids = [2, 4, 32000]` either silently
+    these make `tok.eos_token_ids = [2, 4, 11]` either silently
     return the wrong value on read-back, or raise on assignment.
 
     Bypass both by writing through the instance `__dict__` directly:

--- a/mlx_audio/stt/tests/test_voxtral_eos_token_ids.py
+++ b/mlx_audio/stt/tests/test_voxtral_eos_token_ids.py
@@ -58,15 +58,36 @@ class TestBaselineMagic(unittest.TestCase):
         tok = _make_tokenizer()
         # The default list is NEVER returned, regardless of magic on
         # `_ids`-suffixed attribute access:
-        result = getattr(tok, "eos_token_ids", [2, 4, 32000])
+        result = getattr(tok, "eos_token_ids", [2, 4, 11])
         self.assertIsInstance(result, int)
         self.assertEqual(result, tok.eos_token_id)
-        self.assertNotEqual(result, [2, 4, 32000])
+        self.assertNotEqual(result, [2, 4, 11])
 
     def test_setattr_rejects_non_string_eos_token_ids(self):
         tok = _make_tokenizer()
         with self.assertRaises(ValueError):
-            tok.eos_token_ids = [2, 4, 32000]
+            tok.eos_token_ids = [2, 4, 11]
+
+
+class TestDefaultEosTokenIds(unittest.TestCase):
+    """Pins the constant itself.
+
+    Voxtral's Tekken vocabulary has 131072 entries of which only the first
+    1000 are control tokens: `</s>` is 2, `[/INST]` is 4 and `<pad>` is 11.
+    32000 is outside that range entirely -- it is the ordinary text token
+    `" Capital"`, and stopping on it truncates any transcript containing that
+    word. The truncation is silent, because what comes back is clean prose
+    that merely ends early.
+    """
+
+    def test_pins_the_default(self):
+        self.assertEqual(_VOXTRAL_EOS_TOKEN_IDS, [2, 4, 11])
+
+    def test_does_not_stop_on_a_text_token(self):
+        # 32000 decodes to " Capital" in Voxtral's vocabulary.
+        self.assertNotIn(32000, _VOXTRAL_EOS_TOKEN_IDS)
+        # Nothing in the set may fall outside the control-token range.
+        self.assertTrue(all(i < 1000 for i in _VOXTRAL_EOS_TOKEN_IDS))
 
 
 class TestEnsureEosTokenIdsList(unittest.TestCase):


### PR DESCRIPTION
Fixes #900.

`_VOXTRAL_EOS_TOKEN_IDS` listed 32000 as Voxtral's padding token. It is not one —
it is the ordinary text token `" Capital"`, so generation stopped at the first
occurrence of that word and dropped the rest of the audio.

| id | special token | decodes to |
|---:|---|---|
| 2 | `</s>` | `''` |
| 4 | `[/INST]` | `''` |
| 11 | `<pad>` | `''` |
| 32000 | — none — | `' Capital'` |

Voxtral's Tekken vocabulary has 131072 entries of which only the first 1000 are
control tokens, so 32000 is outside that range entirely.

```python
from mistral_common.tokens.tokenizers.tekken import Tekkenizer
tk = Tekkenizer.from_file("tekken.json")

tk.decode([32000])
# ' Capital'

tk.encode("Venture Capital ist wichtig.", bos=False, eos=False)
# [1086, 105982, 32000, 3444, 46206, 1046]
#              ^^^^^ mid-sentence, generation stopped here
```

### Why this is the normal path, not a rare fallback

`_ensure_eos_token_ids_list` installs the default whenever `eos_token_ids` is
absent from the tokenizer's `__dict__`. A `transformers` tokenizer never has it —
it carries the singular `eos_token_id`, which is exactly the attribute magic that
helper's own docstring describes. So every `AutoProcessor.from_pretrained` load in
`post_load_hook` gets the default.

### Why it is easy to miss

The truncation is silent. What comes back is clean, well-formed prose that simply
ends early — no exception, no warning, and nothing downstream can tell it apart
from a short utterance. It is also invisible to a differential test between two
code paths inside the library, since both share the default and truncate
identically; it only shows up against the reference implementation or against the
vocabulary itself.

### Changes

* `_VOXTRAL_EOS_TOKEN_IDS = [2, 4, 11]`, with a comment explaining why 32000 must
  not be there.
* A test pinning the constant: 32000 absent, and every id inside the
  control-token range.
* The two `[2, 4, 32000]` placeholder literals in `TestBaselineMagic`, and the
  same example in `_ensure_eos_token_ids_list`'s docstring, become `[2, 4, 11]`.
  They only ever stood in for "some list", but leaving them would read as the
  real EOS set.

`mlx_audio/stt/tests/test_voxtral_eos_token_ids.py` passes, 11 tests.

The streaming sibling already reads `self.config.eos_token_id` rather than
hard-coding ids — only the offline model carried the literal, so nothing else
needed touching.

### Where this came from

We hit it building a Voxtral transcription engine for
[noScribe](https://github.com/kaixxx/noScribe), an offline interview-transcription
app. The equivalent fix has been reviewed and merged there and in use since July —
it reads the ids off the processor and falls back to `(2, 4, 11)`.

