### PR TITLE
docs(qwen3_tts): clarify voice cloning vs speaker synthesis usage rules

### DIFF
--- a/mlx_audio/tts/models/qwen3_tts/README.md
+++ b/mlx_audio/tts/models/qwen3_tts/README.md
@@ -4,7 +4,9 @@ Alibaba's state-of-the-art multilingual TTS with three model variants.
 
 ## Voice Cloning
 
-Clone any voice using a reference audio sample. Provide the wav file and its transcript:
+Clone any voice using a reference audio sample. Provide the wav file and its exact transcript as a literal string (not a file path):
+
+> **Note:** Voice cloning is only supported on the **Base** models. Do not provide a `voice` (speaker name) when using `ref_audio` and `ref_text`, as it will cause a configuration conflict.
 
 ```python
 from mlx_audio.tts.utils import load_model


### PR DESCRIPTION
## Summary
- Clarifies in the Qwen3-TTS README when `ref_audio`/`ref_text` (voice cloning / ICL) applies vs. predefined speaker synthesis, so users do not mix the two modes.