### PR TITLE
Implement Breeze-TTS-2

### DIFF
--- a/docs/models/tts/breeze-tts.md
+++ b/docs/models/tts/breeze-tts.md
@@ -1,9 +1,18 @@
 # Breeze TTS 2
 
-[Breeze TTS 2](https://huggingface.co/BreezeBlue/breeze-tts-2) is an
+[Breeze TTS 2](https://huggingface.co/BreezeBlue/Breeze-TTS-2) is an
 English/Chinese text-to-speech model for voice design, voice cloning, and voice
 direction. The MLX implementation loads the publisher's original checkpoint,
 including its bundled Qwen3-TTS audio codec, and emits 24 kHz mono audio.
+
+## Model Variants
+
+| Model | Format | Size | HuggingFace |
+|-------|--------|------|-------------|
+| `mlx-community/Breeze-TTS-2-mlx` | MLX bfloat16 | ~7.6 GB | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Breeze-TTS-2-mlx) |
+| `mlx-community/Breeze-TTS-2-mlx-8bit` | MLX 8-bit | ~4.6 GB | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Breeze-TTS-2-mlx-8bit) |
+| `mlx-community/Breeze-TTS-2-mlx-4bit` | MLX 4-bit | ~3.0 GB | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/Breeze-TTS-2-mlx-4bit) |
+| `BreezeBlue/Breeze-TTS-2` | PyTorch (original) | ~7.7 GB | [:octicons-link-external-16: Model Card](https://huggingface.co/BreezeBlue/Breeze-TTS-2) |
 
 ## Install and load
 
@@ -12,14 +21,14 @@ pip install -U mlx-audio
 ```
 
 The publisher's checkpoint ships PyTorch safetensors that MLX cannot load
-directly, so the examples use an [unofficial MLX conversion quantized to
-4-bit](https://huggingface.co/LunaFox/Breeze-TTS-2-mlx-4bit). The model is
+directly, so the examples use the
+[mlx-community MLX conversion](https://huggingface.co/mlx-community/Breeze-TTS-2-mlx). The model is
 registered under `breeze`, `breeze-tts`, and `breeze_tts`:
 
 ```python
 from mlx_audio.tts import load
 
-model = load("LunaFox/Breeze-TTS-2-mlx-4bit")
+model = load("mlx-community/Breeze-TTS-2-mlx")
 ```
 
 ## Voice design
@@ -30,7 +39,7 @@ the established MLX spellings `--instruct` and `--cfg_scale` are equivalent.
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --text "(sigh) Welcome aboard. Your journey begins now." \
   --instruction "A warm, thoughtful young woman with a clear voice and a calm, reflective delivery." \
   --cfg-scale 4 \
@@ -46,7 +55,7 @@ reference aliases `--ref-audio` and `--ref-text` are equivalent to
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --ref-audio reference_en.wav \
   --ref-text "This is the exact transcript of the English reference audio." \
   --text "(sigh) It is good to hear your voice again after all this time." \
@@ -65,7 +74,7 @@ while directing tone, emotion, pace, or delivery:
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --ref_audio reference.wav \
   --ref_text "This is the exact transcript of the reference audio." \
   --text "(clears throat) We need to discuss what happened last night." \
@@ -87,7 +96,7 @@ Chinese, such as `[笑]`, `[咳嗽]`, `[清嗓子]`, and `[叹气]`:
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --text "[笑] 欢迎来到今晚的故事时间，让我们一起开始吧。" \
   --instruction "一位温柔自信的年轻女性，声音清晰，语气亲切，表达轻快而富有感染力。" \
   --cfg-scale 4 \
@@ -103,7 +112,7 @@ the chunk cadence:
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --ref-audio reference.wav \
   --ref-text "This is the exact transcript of the reference audio." \
   --text "(sigh) This response is streamed as it is generated." \
@@ -119,7 +128,7 @@ The Python API yields `GenerationResult` objects for the same flow:
 ```python
 from mlx_audio.tts import load
 
-model = load("LunaFox/Breeze-TTS-2-mlx-4bit")
+model = load("mlx-community/Breeze-TTS-2-mlx")
 for result in model.generate(
     text="(laugh) Hello from MLX-Audio.",
     instruct="A bright, friendly voice.",
@@ -133,7 +142,17 @@ for result in model.generate(
 
 ## License
 
-The Breeze source code is Apache-2.0, but the model weights, derivatives, and
+The Breeze source code used as a reference is Apache-2.0, but the model weights, derivatives, and
 self-hosted output are governed by BreezeBlue's Research and Non-Commercial
-License. Review the [original model card](https://huggingface.co/BreezeBlue/breeze-tts-2)
+[License](https://huggingface.co/BreezeBlue/Breeze-TTS-2/raw/main/LICENSE).
+Review the [original model card](https://huggingface.co/BreezeBlue/Breeze-TTS-2)
 before use.
+
+Commercial use requires written authorization from RESONIA, INC. Hosted
+BreezeBlue services are governed by their applicable service terms. For
+commercial licensing, contact contact@breeze.blue.
+
+You are responsible for complying with applicable laws and obtaining all
+necessary rights and consents for inputs, reference audio, voices, and outputs.
+Unauthorized voice cloning, impersonation, fraud, and other unlawful or harmful
+uses are prohibited.

--- a/docs/models/tts/breeze-tts.md
+++ b/docs/models/tts/breeze-tts.md
@@ -1,0 +1,137 @@
+# Breeze TTS 2
+
+[Breeze TTS 2](https://huggingface.co/BreezeBlue/breeze-tts-2) is an
+English/Chinese text-to-speech model for voice design, voice cloning, and voice
+direction. The MLX implementation loads the publisher's original checkpoint,
+including its bundled Qwen3-TTS audio codec, and emits 24 kHz mono audio.
+
+## Install and load
+
+```bash
+pip install -U mlx-audio
+```
+
+The model is registered under `breeze`, `breeze-tts`, and `breeze_tts`; the
+publisher's `BreezeBlue/breeze-tts-2` repository resolves automatically:
+
+```python
+from mlx_audio.tts import load
+
+model = load("BreezeBlue/breeze-tts-2")
+```
+
+## Voice design
+
+Create a voice from a natural-language description without reference audio.
+The upstream example flags `--instruction` and `--cfg-scale` are accepted;
+the established MLX spellings `--instruct` and `--cfg_scale` are equivalent.
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --text "(sigh) Welcome aboard. Your journey begins now." \
+  --instruction "A warm, thoughtful young woman with a clear voice and a calm, reflective delivery." \
+  --cfg-scale 4 \
+  --output_path outputs \
+  --file_prefix breeze_design
+```
+
+## Voice clone
+
+Clone one speaker from a clean reference clip and its exact transcript. The
+reference aliases `--ref-audio` and `--ref-text` are equivalent to
+`--ref_audio` and `--ref_text`.
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --ref-audio reference_en.wav \
+  --ref-text "This is the exact transcript of the English reference audio." \
+  --text "(sigh) It is good to hear your voice again after all this time." \
+  --voice S0 \
+  --output_path outputs \
+  --file_prefix breeze_clone
+```
+
+Exactly one reference audio/transcript pair is supported per generation. The
+transcript should match the clip; incomplete pairs are rejected.
+
+## Voice direction
+
+Combine a reference pair with an instruction to preserve speaker identity
+while directing tone, emotion, pace, or delivery:
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --ref_audio reference.wav \
+  --ref_text "This is the exact transcript of the reference audio." \
+  --text "(clears throat) We need to discuss what happened last night." \
+  --instruct "Speak slowly with a restrained, serious tone." \
+  --cfg_scale 4 \
+  --voice S0 \
+  --output_path outputs \
+  --file_prefix breeze_direction
+```
+
+`S0` is Breeze's default speaker tag; pass `--voice S0` explicitly when you
+want the generated prompt to show it.
+
+## Inline vocal events
+
+Events remain inline in `--text`. Use parentheses for English, such as
+`(laugh)`, `(cough)`, `(clears throat)`, and `(sigh)`. Use square brackets for
+Chinese, such as `[笑]`, `[咳嗽]`, `[清嗓子]`, and `[叹气]`:
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --text "[笑] 欢迎来到今晚的故事时间，让我们一起开始吧。" \
+  --instruction "一位温柔自信的年轻女性，声音清晰，语气亲切，表达轻快而富有感染力。" \
+  --cfg-scale 4 \
+  --output_path outputs \
+  --file_prefix breeze_events
+```
+
+## Streaming
+
+Pass `--stream` to play incremental codec-decoded chunks. Add `--save` to
+join them into a WAV file, and set `--streaming_interval` in seconds to choose
+the chunk cadence:
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --ref-audio reference.wav \
+  --ref-text "This is the exact transcript of the reference audio." \
+  --text "(sigh) This response is streamed as it is generated." \
+  --stream \
+  --streaming_interval 1.0 \
+  --save \
+  --output_path outputs \
+  --file_prefix breeze_stream
+```
+
+The Python API yields `GenerationResult` objects for the same flow:
+
+```python
+from mlx_audio.tts import load
+
+model = load("BreezeBlue/breeze-tts-2")
+for result in model.generate(
+    text="(laugh) Hello from MLX-Audio.",
+    instruct="A bright, friendly voice.",
+    cfg_scale=4,
+    stream=True,
+    streaming_interval=1.0,
+):
+    assert result.sample_rate == 24_000
+    assert result.audio.ndim == 1
+```
+
+## License
+
+The Breeze source code is Apache-2.0, but the model weights, derivatives, and
+self-hosted output are governed by BreezeBlue's Research and Non-Commercial
+License. Review the [original model card](https://huggingface.co/BreezeBlue/breeze-tts-2)
+before use.

--- a/docs/models/tts/breeze-tts.md
+++ b/docs/models/tts/breeze-tts.md
@@ -11,13 +11,15 @@ including its bundled Qwen3-TTS audio codec, and emits 24 kHz mono audio.
 pip install -U mlx-audio
 ```
 
-The model is registered under `breeze`, `breeze-tts`, and `breeze_tts`; the
-publisher's `BreezeBlue/breeze-tts-2` repository resolves automatically:
+The publisher's checkpoint ships PyTorch safetensors that MLX cannot load
+directly, so the examples use an [unofficial MLX conversion quantized to
+4-bit](https://huggingface.co/LunaFox/Breeze-TTS-2-mlx-4bit). The model is
+registered under `breeze`, `breeze-tts`, and `breeze_tts`:
 
 ```python
 from mlx_audio.tts import load
 
-model = load("BreezeBlue/breeze-tts-2")
+model = load("LunaFox/Breeze-TTS-2-mlx-4bit")
 ```
 
 ## Voice design
@@ -28,7 +30,7 @@ the established MLX spellings `--instruct` and `--cfg_scale` are equivalent.
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --text "(sigh) Welcome aboard. Your journey begins now." \
   --instruction "A warm, thoughtful young woman with a clear voice and a calm, reflective delivery." \
   --cfg-scale 4 \
@@ -44,7 +46,7 @@ reference aliases `--ref-audio` and `--ref-text` are equivalent to
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --ref-audio reference_en.wav \
   --ref-text "This is the exact transcript of the English reference audio." \
   --text "(sigh) It is good to hear your voice again after all this time." \
@@ -63,7 +65,7 @@ while directing tone, emotion, pace, or delivery:
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --ref_audio reference.wav \
   --ref_text "This is the exact transcript of the reference audio." \
   --text "(clears throat) We need to discuss what happened last night." \
@@ -85,7 +87,7 @@ Chinese, such as `[笑]`, `[咳嗽]`, `[清嗓子]`, and `[叹气]`:
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --text "[笑] 欢迎来到今晚的故事时间，让我们一起开始吧。" \
   --instruction "一位温柔自信的年轻女性，声音清晰，语气亲切，表达轻快而富有感染力。" \
   --cfg-scale 4 \
@@ -101,7 +103,7 @@ the chunk cadence:
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --ref-audio reference.wav \
   --ref-text "This is the exact transcript of the reference audio." \
   --text "(sigh) This response is streamed as it is generated." \
@@ -117,7 +119,7 @@ The Python API yields `GenerationResult` objects for the same flow:
 ```python
 from mlx_audio.tts import load
 
-model = load("BreezeBlue/breeze-tts-2")
+model = load("LunaFox/Breeze-TTS-2-mlx-4bit")
 for result in model.generate(
     text="(laugh) Hello from MLX-Audio.",
     instruct="A bright, friendly voice.",

--- a/docs/models/tts/index.md
+++ b/docs/models/tts/index.md
@@ -9,6 +9,7 @@ MLX-Audio supports a wide range of TTS models optimized for Apple Silicon. Each 
 | [**Kokoro**](kokoro.md) | 82M | EN, JA, ZH, FR, ES, IT, PT, HI | -- | -- | Fast, 54 voice presets, speed control |
 | [**KittenTTS**](https://huggingface.co/collections/mlx-community/kittentts) | 14.6M / 35.5M / 73.8M | EN | -- | -- | KittenTTS 0.8 nano/micro/mini, compact edge-friendly TTS, speed control |
 | [**Qwen3-TTS**](qwen3-tts.md) | 0.6B / 1.7B | ZH, EN, JA, KO, + more | Yes | Yes | Voice cloning, emotion control, voice design, batch generation |
+| [**Breeze TTS 2**](breeze-tts.md) | 1B | EN, ZH | Yes | Yes | Voice design, cloning, direction, and inline vocal events |
 | [**Higgs Audio v3**](higgs_audio_v3.md) | 4B | 100 languages | Yes | -- | Conversational TTS, inline emotion/style/prosody controls, bundled Higgs codec |
 | [**MOSS-TTS**](moss-tts.md) | 8B / 1.7B | 31 languages | Yes | -- | Delay-pattern and local-transformer RVQ generation, full MOSS Audio Tokenizer |
 | [**OmniVoice**](omnivoice.md) | 0.6B backbone + HiggsAudio tokenizer | 646+ languages | Yes | -- | Zero-shot multilingual cloning, nonverbal tags, CMU + pinyin controls |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - models/tts/index.md
       - Kokoro: models/tts/kokoro.md
       - Qwen3-TTS: models/tts/qwen3-tts.md
+      - Breeze TTS 2: models/tts/breeze-tts.md
       - Higgs Audio v3: models/tts/higgs_audio_v3.md
       - MOSS-TTS: models/tts/moss-tts.md
       - Voxtral TTS: models/tts/voxtral-tts.md

--- a/mlx_audio/tts/models/breeze_tts/README.md
+++ b/mlx_audio/tts/models/breeze_tts/README.md
@@ -1,0 +1,113 @@
+# Breeze TTS 2
+
+MLX implementation of [BreezeBlue/Breeze-TTS-2](https://huggingface.co/BreezeBlue/breeze-tts-2).
+The original checkpoint bundles the text encoder and Qwen3-TTS codec used by
+this implementation, so loading it does not require the upstream PyTorch
+runtime.
+
+## Voice design
+
+Install `mlx-audio`, then use the `mlx_audio.tts.generate` command with the
+model repository:
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --text "Welcome aboard. Your journey begins now." \
+  --instruction "A warm, thoughtful young woman with a clear voice." \
+  --cfg-scale 4
+```
+
+The upstream example spellings above are aliases for the established
+underscore options `--instruct` and `--cfg_scale`.
+
+## Voice clone
+
+Provide one clean reference clip and its exact transcript. Inline vocal events
+such as `(sigh)` are kept in the generated text.
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --ref-audio reference.wav \
+  --ref-text "This is the exact transcript of the reference audio." \
+  --text "(sigh) It is good to hear your voice again." \
+  --output_path outputs \
+  --file_prefix breeze_clone
+```
+
+The aliases `--ref-audio` and `--ref-text` are also available as
+`--ref_audio` and `--ref_text`. Breeze accepts one reference pair per
+generation and produces 24 kHz mono audio.
+
+## Voice direction
+
+Combine a reference pair with an instruction to preserve speaker identity
+while directing tone, emotion, pace, or delivery:
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --ref-audio reference.wav \
+  --ref-text "This is the exact transcript of the reference audio." \
+  --text "(clears throat) We need to discuss what happened." \
+  --instruction "Speak slowly with a restrained, serious tone." \
+  --cfg-scale 4 \
+  --voice S0
+```
+
+Voice design works without references. `S0` is the default speaker tag; pass
+`--voice S0` explicitly when making the prompt self-documenting.
+
+## Events and streaming
+
+English events use parentheses, for example `(laugh)`, `(cough)`, and
+`(clears throat)`. Chinese events use square brackets, for example `[笑]` and
+`[叹气]`:
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --text "[笑] 欢迎来到今晚的故事时间，让我们一起开始吧。" \
+  --instruction "一位温柔自信的年轻女性，声音清晰，语气亲切。" \
+  --cfg-scale 4
+```
+
+Use `--stream` for incremental chunks. Add `--save` to join the chunks into a
+WAV file, and adjust `--streaming_interval` (in seconds) for the requested
+cadence:
+
+```bash
+mlx_audio.tts.generate \
+  --model BreezeBlue/breeze-tts-2 \
+  --ref-audio reference.wav \
+  --ref-text "This is the exact transcript of the reference audio." \
+  --text "(sigh) This response is streamed as it is generated." \
+  --stream \
+  --streaming_interval 1.0 \
+  --save \
+  --output_path outputs \
+  --file_prefix breeze_stream
+```
+
+The model API yields `GenerationResult` chunks with `sample_rate == 24000` and
+mono waveforms:
+
+```python
+from mlx_audio.tts import load
+
+model = load("BreezeBlue/breeze-tts-2")
+for chunk in model.generate(
+    text="(laugh) Hello from MLX-Audio.",
+    instruct="A bright, friendly voice.",
+    cfg_scale=4,
+    stream=True,
+    streaming_interval=1.0,
+):
+    assert chunk.sample_rate == 24_000
+    print(chunk.audio.shape)
+```
+
+The model weights, derivatives, and generated outputs are governed by the
+upstream BreezeBlue Research and Non-Commercial License. Review the [original
+model card](https://huggingface.co/BreezeBlue/breeze-tts-2) before use.

--- a/mlx_audio/tts/models/breeze_tts/README.md
+++ b/mlx_audio/tts/models/breeze_tts/README.md
@@ -3,7 +3,9 @@
 MLX implementation of [BreezeBlue/Breeze-TTS-2](https://huggingface.co/BreezeBlue/breeze-tts-2).
 The original checkpoint bundles the text encoder and Qwen3-TTS codec used by
 this implementation, so loading it does not require the upstream PyTorch
-runtime.
+runtime. Its PyTorch safetensors do not load in MLX directly; the examples
+use an [unofficial MLX 4-bit
+conversion](https://huggingface.co/LunaFox/Breeze-TTS-2-mlx-4bit).
 
 ## Voice design
 
@@ -12,7 +14,7 @@ model repository:
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --text "Welcome aboard. Your journey begins now." \
   --instruction "A warm, thoughtful young woman with a clear voice." \
   --cfg-scale 4
@@ -28,7 +30,7 @@ such as `(sigh)` are kept in the generated text.
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --ref-audio reference.wav \
   --ref-text "This is the exact transcript of the reference audio." \
   --text "(sigh) It is good to hear your voice again." \
@@ -47,7 +49,7 @@ while directing tone, emotion, pace, or delivery:
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --ref-audio reference.wav \
   --ref-text "This is the exact transcript of the reference audio." \
   --text "(clears throat) We need to discuss what happened." \
@@ -67,7 +69,7 @@ English events use parentheses, for example `(laugh)`, `(cough)`, and
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --text "[笑] 欢迎来到今晚的故事时间，让我们一起开始吧。" \
   --instruction "一位温柔自信的年轻女性，声音清晰，语气亲切。" \
   --cfg-scale 4
@@ -79,7 +81,7 @@ cadence:
 
 ```bash
 mlx_audio.tts.generate \
-  --model BreezeBlue/breeze-tts-2 \
+  --model LunaFox/Breeze-TTS-2-mlx-4bit \
   --ref-audio reference.wav \
   --ref-text "This is the exact transcript of the reference audio." \
   --text "(sigh) This response is streamed as it is generated." \
@@ -96,7 +98,7 @@ mono waveforms:
 ```python
 from mlx_audio.tts import load
 
-model = load("BreezeBlue/breeze-tts-2")
+model = load("LunaFox/Breeze-TTS-2-mlx-4bit")
 for chunk in model.generate(
     text="(laugh) Hello from MLX-Audio.",
     instruct="A bright, friendly voice.",

--- a/mlx_audio/tts/models/breeze_tts/__init__.py
+++ b/mlx_audio/tts/models/breeze_tts/__init__.py
@@ -1,0 +1,4 @@
+from .breeze_tts import Model
+from .config import ModelConfig
+
+__all__ = ["Model", "ModelConfig"]

--- a/mlx_audio/tts/models/breeze_tts/breeze_tts.py
+++ b/mlx_audio/tts/models/breeze_tts/breeze_tts.py
@@ -1,0 +1,1038 @@
+"""MLX inference implementation for Breeze TTS 2.
+
+Breeze uses an autoregressive Qwen3-style backbone for codebook zero and a
+small depth decoder for the remaining Qwen3-TTS codec codebooks.  The text
+encoder and codec bundled by Breeze are loaded from the original checkpoint;
+no PyTorch or upstream Breeze runtime is required at inference time.
+"""
+
+import json
+import time
+from pathlib import Path
+from typing import Dict, Generator, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+from mlx_audio.lm.models import llama, qwen3
+from mlx_audio.lm.models.base import create_attention_mask, scaled_dot_product_attention
+from mlx_audio.lm.models.cache import KVCache
+from mlx_audio.lm.models.rope_utils import initialize_rope
+from mlx_audio.lm.sample_utils import make_sampler
+from mlx_audio.tts.models.base import GenerationResult
+from mlx_audio.utils import load_audio
+
+from .config import ModelConfig
+
+
+class _AudioEmbedding(nn.Module):
+    """Sum wrapper-level audio codebook embeddings.
+
+    The nested Qwen config describes the text backbone and therefore has a
+    different vocabulary from Breeze's audio wrapper.  Keep the wrapper
+    vocabulary/codebook count explicit here.  ``audio_embeds_projector`` is
+    present only for checkpoints whose embedding width differs from the
+    backbone width, matching ``BreezeBackboneModelEmbeddings`` upstream.
+    """
+
+    def __init__(
+        self,
+        num_codebooks: int,
+        vocab_size: int,
+        hidden_size: int,
+        audio_embed_size: Optional[int] = None,
+    ):
+        super().__init__()
+        self.num_codebooks = int(num_codebooks)
+        self.vocab_size = int(vocab_size)
+        self.audio_embed_size = int(audio_embed_size or hidden_size)
+        self.embed_audio_tokens = nn.Embedding(
+            self.num_codebooks * self.vocab_size, self.audio_embed_size
+        )
+        if self.audio_embed_size != hidden_size:
+            self.audio_embeds_projector = nn.Linear(
+                self.audio_embed_size, hidden_size, bias=False
+            )
+        else:
+            self.audio_embeds_projector = None
+
+    def __call__(self, codebooks: mx.array) -> mx.array:
+        if codebooks.ndim != 3 or codebooks.shape[-1] != self.num_codebooks:
+            raise ValueError(
+                "Breeze audio codebooks must have shape "
+                f"[batch, time, {self.num_codebooks}], got {codebooks.shape}."
+            )
+        offsets = mx.arange(self.num_codebooks, dtype=codebooks.dtype)[
+            None, None, :
+        ] * self.vocab_size
+        hidden = self.embed_audio_tokens(codebooks + offsets)
+        if self.audio_embeds_projector is not None:
+            hidden = self.audio_embeds_projector(hidden)
+        return mx.sum(hidden, axis=-2)
+
+
+class _Backbone(nn.Module):
+    """Qwen3 transformer whose names match ``backbone_model.*`` weights."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        wrapper_num_codebooks = config.wrapper_num_codebooks
+        wrapper_vocab_size = config.wrapper_vocab_size
+        hidden_size = config.backbone_hidden_size
+        args = qwen3.ModelArgs(
+            model_type="qwen3",
+            hidden_size=hidden_size,
+            num_hidden_layers=config.backbone_value(
+                "num_hidden_layers", config.num_hidden_layers
+            ),
+            intermediate_size=config.backbone_value(
+                "intermediate_size", config.intermediate_size
+            ),
+            num_attention_heads=config.backbone_value(
+                "num_attention_heads", config.num_attention_heads
+            ),
+            num_key_value_heads=config.backbone_value(
+                "num_key_value_heads", config.num_key_value_heads
+            ),
+            head_dim=config.backbone_value("head_dim", config.head_dim),
+            rms_norm_eps=config.backbone_value(
+                "rms_norm_eps", config.rms_norm_eps
+            ),
+            # This is metadata for the Qwen args.  The actual embedding below
+            # deliberately uses the wrapper audio vocabulary.
+            vocab_size=config.backbone_value("vocab_size", wrapper_vocab_size),
+            max_position_embeddings=config.backbone_value(
+                "max_position_embeddings", config.max_position_embeddings
+            ),
+            rope_theta=config.backbone_value("rope_theta", config.rope_theta),
+            rope_scaling=config.backbone_value("rope_scaling", config.rope_scaling),
+            tie_word_embeddings=config.backbone_value(
+                "tie_word_embeddings", False
+            ),
+        )
+        self.args = args
+        self.embed_tokens = _AudioEmbedding(
+            wrapper_num_codebooks,
+            wrapper_vocab_size,
+            args.hidden_size,
+            config.wrapper_audio_embed_size,
+        )
+        self.layers = [
+            qwen3.TransformerBlock(args) for _ in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        input_ids: Optional[mx.array] = None,
+        *,
+        input_embeddings: Optional[mx.array] = None,
+        cache: Optional[list[KVCache]] = None,
+    ) -> mx.array:
+        if (input_ids is None) == (input_embeddings is None):
+            raise ValueError("Pass exactly one of input_ids or input_embeddings.")
+        hidden = (
+            input_embeddings
+            if input_embeddings is not None
+            else self.embed_tokens(input_ids)
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(hidden, cache[0])
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden = layer(hidden, mask, layer_cache)
+        return self.norm(hidden)
+
+    def make_cache(self) -> list[KVCache]:
+        return [KVCache() for _ in self.layers]
+
+
+class _TextEmbedding(nn.Module):
+    """T5Gemma2 embedding with Breeze's separate end-of-input embedding."""
+
+    def __init__(self, vocab_size: int, hidden_size: int, eoi_token_index: int):
+        super().__init__()
+        self.weight = mx.zeros((vocab_size, hidden_size))
+        self.eoi_embedding = mx.zeros((hidden_size,))
+        self.eoi_token_index = eoi_token_index
+
+    def __call__(self, input_ids: mx.array) -> mx.array:
+        embeds = self.weight[input_ids] * mx.array(self.weight.shape[-1] ** 0.5)
+        return mx.where(
+            (input_ids == self.eoi_token_index)[..., None], self.eoi_embedding, embeds
+        )
+
+
+class _T5Gemma2RMSNorm(nn.Module):
+    """T5Gemma2's zero-initialized, offset RMS norm."""
+
+    def __init__(self, dims: int, eps: float):
+        super().__init__()
+        self.weight = mx.zeros((dims,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.fast.rms_norm(x, 1.0 + self.weight, self.eps)
+
+
+def _t5gemma2_attention_mask(
+    length: int,
+    layer_type: str,
+    sliding_window: Optional[int],
+    attention_mask: Optional[mx.array] = None,
+) -> Optional[mx.array]:
+    """Build the official non-causal T5Gemma2 attention pattern.
+
+    Full-attention layers are bidirectional.  Sliding layers use the
+    asymmetric-looking but symmetric-around-the-centre window specified by
+    T5Gemma2: ``(window + 1) // 2`` tokens left and ``window // 2 + 1`` right
+    (both include the query position).
+    """
+    if length < 0:
+        raise ValueError(f"Attention length must be non-negative, got {length}")
+    if layer_type not in {"full_attention", "sliding_attention"}:
+        raise ValueError(f"Unsupported T5Gemma2 attention layer: {layer_type}")
+    if layer_type == "sliding_attention" and (
+        sliding_window is None or sliding_window <= 0
+    ):
+        raise ValueError(
+            "T5Gemma2 sliding_attention requires a positive sliding_window"
+        )
+
+    valid_keys = None
+    if attention_mask is not None:
+        valid_keys = mx.array(attention_mask).astype(mx.bool_)
+        if valid_keys.ndim == 1:
+            if valid_keys.shape[0] != length:
+                raise ValueError(
+                    "T5Gemma2 attention_mask length does not match input: "
+                    f"{valid_keys.shape[0]} != {length}."
+                )
+            valid_keys = valid_keys[None, :]
+        elif valid_keys.ndim == 2:
+            if valid_keys.shape[1] != length:
+                raise ValueError(
+                    "T5Gemma2 attention_mask length does not match input: "
+                    f"{valid_keys.shape[1]} != {length}."
+                )
+        else:
+            raise ValueError(
+                "T5Gemma2 attention_mask must have shape [length] or "
+                f"[batch, length], got {valid_keys.shape}."
+            )
+
+    if layer_type == "full_attention":
+        # ``None`` is intentional: MLX interprets this as unconstrained,
+        # bidirectional attention.  A padding mask is broadcast over query
+        # rows while masking invalid key/value positions, matching the
+        # upstream T5Gemma2 eager implementation.
+        if valid_keys is None:
+            return None
+        return valid_keys[:, None, None, :]
+
+    query = mx.arange(length)[:, None]
+    key = mx.arange(length)[None, :]
+    distance = query - key
+    left = (sliding_window + 1) // 2
+    right = sliding_window // 2 + 1
+    local = ((distance >= 0) & (distance < left)) | (
+        (distance < 0) & (-distance < right)
+    )
+    if valid_keys is None:
+        return local
+    return local[None, None, :, :] & valid_keys[:, None, None, :]
+
+
+class _TextAttention(nn.Module):
+    """Bidirectional attention matching the T5Gemma2 text encoder."""
+
+    def __init__(self, config: dict, layer_idx: int):
+        super().__init__()
+        self.n_heads = int(config["num_attention_heads"])
+        self.n_kv_heads = int(config["num_key_value_heads"])
+        self.head_dim = int(config["head_dim"])
+        self.scale = config.get("query_pre_attn_scalar", 256) ** -0.5
+        layer_types = (
+            config.get("layer_types")
+            or ["sliding_attention"] * config["num_hidden_layers"]
+        )
+        if layer_idx >= len(layer_types):
+            raise ValueError(
+                "T5Gemma2 layer_types has fewer entries than num_hidden_layers"
+            )
+        self.layer_type = layer_types[layer_idx]
+        self.sliding_window = (
+            config.get("sliding_window", 512)
+            if self.layer_type == "sliding_attention"
+            else None
+        )
+        dim = int(config["hidden_size"])
+        self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
+        eps = config["rms_norm_eps"]
+        self.q_norm = _T5Gemma2RMSNorm(self.head_dim, eps)
+        self.k_norm = _T5Gemma2RMSNorm(self.head_dim, eps)
+        rope_parameters = config.get("rope_parameters") or {}
+        rope = rope_parameters.get(self.layer_type) or {}
+        self.rope = initialize_rope(
+            self.head_dim,
+            base=rope.get(
+                "rope_theta",
+                10_000.0 if self.layer_type == "sliding_attention" else 1_000_000.0,
+            ),
+            traditional=False,
+            scaling_config=rope if rope.get("rope_type") == "linear" else None,
+            max_position_embeddings=config.get("max_position_embeddings", 32768),
+        )
+
+    def __call__(self, x: mx.array, mask: Optional[mx.array]) -> mx.array:
+        batch, length, _ = x.shape
+        queries = self.q_norm(
+            self.q_proj(x).reshape(batch, length, self.n_heads, self.head_dim)
+        ).transpose(0, 2, 1, 3)
+        keys = self.k_norm(
+            self.k_proj(x).reshape(batch, length, self.n_kv_heads, self.head_dim)
+        ).transpose(0, 2, 1, 3)
+        values = (
+            self.v_proj(x)
+            .reshape(batch, length, self.n_kv_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        output = scaled_dot_product_attention(
+            self.rope(queries), self.rope(keys), values, None, self.scale, mask
+        )
+        return self.o_proj(output.transpose(0, 2, 1, 3).reshape(batch, length, -1))
+
+
+class _TextMLP(nn.Module):
+    def __init__(self, config: dict):
+        super().__init__()
+        dim, intermediate = config["hidden_size"], config["intermediate_size"]
+        self.gate_proj = nn.Linear(dim, intermediate, bias=False)
+        self.up_proj = nn.Linear(dim, intermediate, bias=False)
+        self.down_proj = nn.Linear(intermediate, dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.gelu_approx(self.gate_proj(x)) * self.up_proj(x))
+
+
+class _TextLayer(nn.Module):
+    def __init__(self, config: dict, layer_idx: int):
+        super().__init__()
+        self.self_attn = _TextAttention(config, layer_idx)
+        eps, dim = config["rms_norm_eps"], config["hidden_size"]
+        self.pre_self_attn_layernorm = _T5Gemma2RMSNorm(dim, eps)
+        self.post_self_attn_layernorm = _T5Gemma2RMSNorm(dim, eps)
+        self.mlp = _TextMLP(config)
+        self.pre_feedforward_layernorm = _T5Gemma2RMSNorm(dim, eps)
+        self.post_feedforward_layernorm = _T5Gemma2RMSNorm(dim, eps)
+        self.layer_type = self.self_attn.layer_type
+
+    def __call__(self, x: mx.array, mask: Optional[mx.array]) -> mx.array:
+        hidden = self.self_attn(self.pre_self_attn_layernorm(x), mask)
+        hidden = x + self.post_self_attn_layernorm(hidden)
+        return hidden + self.post_feedforward_layernorm(
+            self.mlp(self.pre_feedforward_layernorm(hidden))
+        )
+
+
+class _TextEncoder(nn.Module):
+    """MLX implementation of Breeze's bidirectional T5Gemma2 text encoder."""
+
+    def __init__(self, config: dict):
+        super().__init__()
+        self.config = config
+        config = self._normalize_config(config)
+        self.config = config
+        self.embed_tokens = _TextEmbedding(
+            config["vocab_size"],
+            config["hidden_size"],
+            config.get("eoi_token_index", 256000),
+        )
+        self.layers = [
+            _TextLayer(config, i) for i in range(config["num_hidden_layers"])
+        ]
+        self.norm = _T5Gemma2RMSNorm(config["hidden_size"], config["rms_norm_eps"])
+
+    @staticmethod
+    def _normalize_config(config: Optional[dict]) -> dict:
+        """Fill only the T5Gemma2 defaults needed by direct MLX callers."""
+        config = dict(ModelConfig._as_mapping(config))
+        defaults = {
+            "vocab_size": 262208,
+            "hidden_size": 2304,
+            "intermediate_size": 9216,
+            "num_hidden_layers": 26,
+            "num_attention_heads": 8,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "rms_norm_eps": 1e-6,
+            "query_pre_attn_scalar": 256,
+            "max_position_embeddings": 131072,
+            "sliding_window": 4096,
+            "eoi_token_index": 256000,
+            "dropout_rate": 0.0,
+            "attention_bias": False,
+        }
+        for key, value in defaults.items():
+            config.setdefault(key, value)
+        if not config.get("layer_types"):
+            pattern = config.pop(
+                "_sliding_window_pattern",
+                config.pop("sliding_window_pattern", 6),
+            )
+            if not isinstance(pattern, int) or pattern <= 0:
+                raise ValueError(
+                    "T5Gemma2 sliding_window_pattern must be a positive integer"
+                )
+            config["layer_types"] = [
+                "sliding_attention"
+                if (idx + 1) % pattern
+                else "full_attention"
+                for idx in range(config["num_hidden_layers"])
+            ]
+        # Keep the upstream defaults for the two attention-specific RoPE
+        # bases, while allowing an explicitly supplied mapping to override
+        # either layer type.
+        rope_parameters = {
+            "sliding_attention": {
+                "rope_type": "default",
+                "rope_theta": 10_000.0,
+            },
+            "full_attention": {
+                "rope_type": "default",
+                "rope_theta": 1_000_000.0,
+            },
+        }
+        provided_rope_parameters = config.get("rope_parameters") or {}
+        for key, value in provided_rope_parameters.items():
+            rope_parameters[key] = dict(value or {})
+        # Older T5Gemma2 exports use the generic ``rope_scaling`` field for
+        # the full-attention stream.  Keep accepting that form while giving
+        # the per-layer ``rope_parameters`` mapping precedence when present.
+        if config.get("rope_scaling") and (
+            "full_attention" not in provided_rope_parameters
+        ):
+            rope_parameters["full_attention"].update(config["rope_scaling"])
+        config["rope_parameters"] = rope_parameters
+        return config
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        hidden = self.embed_tokens(input_ids)
+        masks = {}
+        for layer in self.layers:
+            if layer.layer_type in masks:
+                continue
+            masks[layer.layer_type] = _t5gemma2_attention_mask(
+                hidden.shape[1],
+                layer.layer_type,
+                layer.self_attn.sliding_window,
+                attention_mask,
+            )
+        for layer in self.layers:
+            hidden = layer(hidden, masks[layer.layer_type])
+        return self.norm(hidden)
+
+
+class _DepthModel(nn.Module):
+    """Breeze's codebook-autoregressive depth decoder."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        depth = ModelConfig._as_mapping(config.depth_decoder_config)
+        self.vocab_size = int(depth.get("vocab_size", config.wrapper_vocab_size))
+        self.num_codebooks = int(
+            depth.get("num_codebooks", config.wrapper_num_codebooks)
+        )
+        self.audio_embed_size = int(
+            depth.get("audio_embed_size", config.wrapper_audio_embed_size)
+        )
+        self.backbone_hidden_size = int(
+            depth.get("backbone_hidden_size", config.backbone_hidden_size)
+        )
+        self.hidden_size = int(depth.get("hidden_size", 1024))
+        args = llama.ModelArgs(
+            model_type="llama",
+            hidden_size=self.hidden_size,
+            num_hidden_layers=depth.get("num_hidden_layers", 12),
+            intermediate_size=depth.get("intermediate_size", 8192),
+            num_attention_heads=depth.get("num_attention_heads", 8),
+            num_key_value_heads=depth.get("num_key_value_heads", 2),
+            head_dim=depth.get("head_dim", 128),
+            rms_norm_eps=depth.get("rms_norm_eps", 1e-5),
+            vocab_size=self.num_codebooks * self.vocab_size,
+            max_position_embeddings=depth.get("max_position_embeddings", 33),
+            rope_theta=depth.get("rope_theta", 500000.0),
+            rope_scaling=depth.get("rope_scaling"),
+            tie_word_embeddings=False,
+            rope_traditional=False,
+        )
+        self.embed_tokens = nn.Embedding(args.vocab_size, self.audio_embed_size)
+        if self.backbone_hidden_size != self.audio_embed_size:
+            self.backbone_hidden_state_projector = nn.Linear(
+                self.backbone_hidden_size, self.audio_embed_size, bias=False
+            )
+        else:
+            self.backbone_hidden_state_projector = None
+        self.inputs_embeds_projector = nn.Linear(
+            self.audio_embed_size, self.hidden_size, bias=False
+        )
+        self.layers = [
+            llama.TransformerBlock(args) for _ in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(self.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self, token_ids: mx.array, backbone_hidden_state: mx.array
+    ) -> mx.array:
+        if token_ids.ndim != 2:
+            raise ValueError(
+                f"Depth decoder token_ids must have shape [batch, time], got {token_ids.shape}."
+            )
+        if backbone_hidden_state.ndim != 2:
+            raise ValueError(
+                "Depth decoder backbone_hidden_state must have shape "
+                f"[batch, hidden], got {backbone_hidden_state.shape}."
+            )
+        if backbone_hidden_state.shape[0] != token_ids.shape[0]:
+            raise ValueError(
+                "Depth decoder token and hidden-state batch sizes differ: "
+                f"{token_ids.shape[0]} != {backbone_hidden_state.shape[0]}."
+            )
+        # token_ids starts with a placeholder. Position zero is replaced by the
+        # backbone state, while later positions carry codebook-specific offsets.
+        positions = mx.maximum(mx.arange(token_ids.shape[1]) - 1, 0)
+        embeds = self.embed_tokens(token_ids + positions[None, :] * self.vocab_size)
+        if self.backbone_hidden_state_projector is not None:
+            backbone_hidden_state = self.backbone_hidden_state_projector(
+                backbone_hidden_state
+            )
+        embeds = mx.concatenate(
+            [backbone_hidden_state[:, None, :], embeds[:, 1:, :]], axis=1
+        )
+        hidden = self.inputs_embeds_projector(embeds)
+        mask = create_attention_mask(hidden, None)
+        for layer in self.layers:
+            hidden = layer(hidden, mask, None)
+        return self.norm(hidden)
+
+
+class _DepthDecoder(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.model = _DepthModel(config)
+        self.codebooks_head = _CodebooksHead(
+            self.model.num_codebooks - 1,
+            self.model.hidden_size,
+            self.model.vocab_size,
+        )
+
+    def next_logits(
+        self, token_ids: mx.array, backbone_hidden_state: mx.array
+    ) -> mx.array:
+        # The most recent input token is codebook N-1, and predicts codebook N.
+        head_idx = token_ids.shape[1] - 2
+        if not 0 <= head_idx < self.codebooks_head.weight.shape[0]:
+            raise ValueError(
+                "Depth decoder input must contain the placeholder and at least "
+                f"one codebook token; got sequence length {token_ids.shape[1]}."
+            )
+        hidden = self.model(token_ids, backbone_hidden_state)[:, -1, :]
+        return hidden @ self.codebooks_head.weight[head_idx]
+
+
+class _CodebooksHead(nn.Module):
+    """Position-specific output projections for depth-decoded codebooks."""
+
+    def __init__(self, num_heads: int, hidden_size: int, vocab_size: int):
+        super().__init__()
+        self.weight = mx.zeros((num_heads, hidden_size, vocab_size))
+
+
+class Model(nn.Module):
+    """Breeze TTS 2 text-to-speech model."""
+
+    preserve_ref_audio_path = True
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.num_codebooks = config.wrapper_num_codebooks
+        self.vocab_size = config.wrapper_vocab_size
+        self.lm_head = nn.Linear(
+            config.backbone_hidden_size, self.vocab_size + 1, bias=False
+        )
+        self.embed_text_tokens = nn.Embedding(
+            config.text_vocab_size, config.backbone_hidden_size
+        )
+        self.backbone_model = _Backbone(config)
+        self.depth_decoder = _DepthDecoder(config)
+        text_config = _TextEncoder._normalize_config(config.text_encoder_config)
+        self.text_encoder = _TextEncoder(text_config)
+        self.text_encoder_proj = nn.Linear(
+            text_config["hidden_size"],
+            config.backbone_hidden_size,
+            bias=False,
+        )
+        self.tokenizer = None
+        self.audio_tokenizer = None
+
+    @property
+    def sample_rate(self) -> int:
+        return self.config.sample_rate
+
+    @property
+    def model_type(self) -> str:
+        return "breeze"
+
+    @staticmethod
+    def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Keep only main-model tensors; the bundled codec is loaded separately."""
+        sanitized = {}
+        for key, value in weights.items():
+            if (
+                key.startswith("codec_model.")
+                or key.endswith(".initialized")
+                or "rotary_emb.inv_freq" in key
+            ):
+                continue
+            sanitized[key] = value
+        # The official checkpoint ties these embeddings and stores only the
+        # depth-decoder tensor in safetensors. MLX modules retain independent
+        # parameters, so materialize the matching backbone entry at load time.
+        tied = "depth_decoder.model.embed_tokens.weight"
+        backbone_tied = "backbone_model.embed_tokens.embed_audio_tokens.weight"
+        if tied in sanitized:
+            # Always derive the backbone copy from the canonical depth tensor.
+            # This handles exports that contain a stale duplicate while
+            # preserving exact value/shape parity for strict MLX loading.
+            sanitized[backbone_tied] = sanitized[tied]
+        return sanitized
+
+    @staticmethod
+    def _validate_codec_weight_keys(expected: set[str], provided: set[str]) -> None:
+        """Reject codec snapshots except for generated quantizer flags.
+
+        Qwen3-TTS computes the 32 ``codebook.initialized`` flags at runtime;
+        they are intentionally not serialized.  Every real parameter must be
+        present exactly once so a changed codec architecture cannot be loaded
+        with a misleading ``strict=False`` fallback.
+        """
+        allowed_missing = {
+            name
+            for name in expected
+            if name.startswith("encoder_model.quantizer.")
+            and name.endswith(".codebook.initialized")
+        }
+        missing = expected - provided - allowed_missing
+        unexpected = provided - expected
+        if missing or unexpected:
+            details = []
+            if missing:
+                details.append(f"missing: {', '.join(sorted(missing))}")
+            if unexpected:
+                details.append(f"unexpected: {', '.join(sorted(unexpected))}")
+            raise ValueError(
+                "Incompatible Breeze audio tokenizer weights ("
+                + "; ".join(details)
+                + ")"
+            )
+
+    @classmethod
+    def post_load_hook(cls, model: "Model", model_path: Path) -> "Model":
+        from transformers import PreTrainedTokenizerFast
+
+        # AutoTokenizer attempts to instantiate the unknown upstream ``breeze``
+        # config before loading the otherwise standard fast tokenizer. Loading
+        # tokenizer.json directly avoids that PyTorch-runtime-only registration.
+        tokenizer_config = json.loads(
+            (model_path / "tokenizer_config.json").read_text()
+        )
+        for key in (
+            "tokenizer_class",
+            "model_max_length",
+            "clean_up_tokenization_spaces",
+            "added_tokens_decoder",
+        ):
+            tokenizer_config.pop(key, None)
+        model.tokenizer = PreTrainedTokenizerFast(
+            tokenizer_file=str(model_path / "tokenizer.json"), **tokenizer_config
+        )
+        codec_path = model_path / "audio_tokenizer"
+        if not codec_path.is_dir():
+            raise FileNotFoundError(
+                f"Breeze checkpoint has no audio_tokenizer at {codec_path}"
+            )
+        model.audio_tokenizer = cls._load_audio_tokenizer(codec_path)
+        return model
+
+    @staticmethod
+    def _load_audio_tokenizer(codec_path: Path):
+        from mlx_audio.tts.models.qwen3_tts.config import (
+            Qwen3TTSTokenizerConfig,
+            Qwen3TTSTokenizerDecoderConfig,
+            Qwen3TTSTokenizerEncoderConfig,
+            filter_dict_for_dataclass,
+        )
+        from mlx_audio.tts.models.qwen3_tts.speech_tokenizer import (
+            Qwen3TTSSpeechTokenizer,
+        )
+
+        config_data = json.loads((codec_path / "config.json").read_text())
+        decoder = Qwen3TTSTokenizerDecoderConfig(
+            **filter_dict_for_dataclass(
+                Qwen3TTSTokenizerDecoderConfig, config_data["decoder_config"]
+            )
+        )
+        encoder = Qwen3TTSTokenizerEncoderConfig(
+            **filter_dict_for_dataclass(
+                Qwen3TTSTokenizerEncoderConfig, config_data["encoder_config"]
+            )
+        )
+        codec_config = Qwen3TTSTokenizerConfig(
+            decoder_config=decoder, encoder_config=encoder
+        )
+        for key, value in config_data.items():
+            if key not in {"decoder_config", "encoder_config"} and hasattr(
+                codec_config, key
+            ):
+                setattr(codec_config, key, value)
+        codec = Qwen3TTSSpeechTokenizer(codec_config)
+        weights = {}
+        for weight_file in codec_path.glob("*.safetensors"):
+            weights.update(mx.load(str(weight_file)))
+        sanitized = Qwen3TTSSpeechTokenizer.sanitize(weights)
+        Model._validate_codec_weight_keys(
+            {name for name, _ in tree_flatten(codec.parameters())}, set(sanitized)
+        )
+        # The 32 quantizer ``initialized`` flags are generated locally by
+        # ``update_in_place`` below.  All serialized keys were validated above.
+        # ``initialized`` is an MLX-only runtime flag, so the model loader must
+        # permit precisely those known missing keys.  The complete set of
+        # real keys was validated above; this is intentionally not a blanket
+        # strict=False load.
+        codec.load_weights(list(sanitized.items()), strict=False)
+        if codec.encoder_model is not None:
+            quantizer = codec.encoder_model.quantizer
+            for layer in quantizer.rvq_first.vq.layers + quantizer.rvq_rest.vq.layers:
+                layer.codebook.update_in_place()
+        mx.eval(codec.parameters())
+        codec.eval()
+        return codec
+
+    def _speaker(self, voice: Optional[str]) -> str:
+        # mlx-audio's generic default is a Kokoro voice; Breeze's documented
+        # default speaker tag is S0.
+        speaker = "S0" if voice in (None, "", "af_heart") else voice
+        return speaker if speaker.startswith("[") else f"[{speaker}]"
+
+    def _text_ids(self, text: str) -> mx.array:
+        if self.tokenizer is None:
+            raise RuntimeError("Breeze tokenizer was not loaded")
+        return mx.array(self.tokenizer(text, add_special_tokens=True)["input_ids"])
+
+    def _encode_reference(self, ref_audio: Union[str, Path, mx.array]) -> mx.array:
+        if self.audio_tokenizer is None:
+            raise RuntimeError("Breeze audio tokenizer was not loaded")
+        if isinstance(ref_audio, (str, Path)):
+            audio = load_audio(str(ref_audio), sample_rate=self.sample_rate)
+        else:
+            audio = ref_audio
+        audio = mx.array(audio)
+        if audio.ndim == 1:
+            audio = audio[None, None, :]
+        elif audio.ndim == 2:
+            audio = audio[:, None, :]
+        elif audio.ndim != 3:
+            raise ValueError(
+                "ref_audio must be a path, [samples], [batch, samples], or [batch, channels, samples]."
+            )
+        if audio.shape[0] != 1:
+            raise ValueError(
+                "Breeze supports exactly one reference audio item per generation; "
+                f"received batch size {audio.shape[0]}."
+            )
+        return mx.transpose(self.audio_tokenizer.encode(audio), (0, 2, 1))
+
+    def _prompt_embeddings(
+        self,
+        text: str,
+        *,
+        voice: Optional[str],
+        instruct: Optional[str],
+        ref_audio: Optional[Union[str, Path, mx.array]],
+        ref_text: Optional[str],
+    ) -> mx.array:
+        if isinstance(ref_audio, (list, tuple)):
+            if len(ref_audio) != 1:
+                raise ValueError(
+                    "Breeze supports exactly one reference audio item per generation."
+                )
+            ref_audio = ref_audio[0]
+        if isinstance(ref_text, (list, tuple)):
+            if len(ref_text) != 1:
+                raise ValueError(
+                    "Breeze supports exactly one reference transcript per generation."
+                )
+            ref_text = ref_text[0]
+        if ref_audio is not None and not ref_text:
+            raise ValueError("Breeze voice cloning requires ref_text with ref_audio.")
+        speaker = self._speaker(voice)
+        segments: list[tuple[str, mx.array]] = []
+        if ref_audio is not None:
+            segments.append(("text", self._text_ids(f"{speaker}{ref_text}")))
+            segments.append(("audio", self._encode_reference(ref_audio)))
+        target = f"{speaker}{text}"
+        if instruct:
+            target = f"{speaker}<ins_bos>{instruct}<ins_eos>{text}"
+        segments.append(("text", self._text_ids(target)))
+
+        embeddings: list[mx.array] = []
+        for kind, values in segments:
+            if kind == "text":
+                hidden = self.text_encoder(values[None, :])
+                embeddings.append(self.text_encoder_proj(hidden))
+            else:
+                embeddings.append(self.backbone_model.embed_tokens(values))
+                eos_codes = mx.full(
+                    (1, 1, self.num_codebooks), self.config.codebook_eos_token_id
+                )
+                embeddings.append(self.backbone_model.embed_tokens(eos_codes))
+        return mx.concatenate(embeddings, axis=1)
+
+    def _sample(
+        self,
+        logits: mx.array,
+        *,
+        temperature: float,
+        top_p: float,
+        top_k: int,
+        allow_eos: bool = False,
+    ) -> int:
+        valid = self.vocab_size + 1 if allow_eos else self.vocab_size
+        logits = logits[..., :valid]
+        # Reserve all ids after the codec vocabulary (padding/control ids) from
+        # regular codebook sampling.  The boundary belongs to the codec config,
+        # not to a particular 2048-entry checkpoint.
+        logits = logits.at[
+            ..., self.config.codec_vocab_size : self.vocab_size
+        ].add(-mx.inf)
+        sampler = make_sampler(temp=temperature, top_p=top_p, top_k=top_k)
+        token = sampler(nn.log_softmax(logits, axis=-1))
+        return int(token.item())
+
+    @staticmethod
+    def _apply_repetition_penalty(
+        logits: mx.array, generated_tokens: list[int], penalty: float
+    ) -> mx.array:
+        """Apply the standard sign-aware repetition penalty to prior tokens."""
+        if penalty == 1.0 or not generated_tokens:
+            return logits
+        token_ids = sorted(
+            {token for token in generated_tokens if 0 <= token < logits.shape[-1]}
+        )
+        if not token_ids:
+            return logits
+        indices = mx.array(token_ids, dtype=mx.int32)
+        selected = mx.take(logits, indices, axis=-1)
+        penalized = mx.where(selected < 0, selected * penalty, selected / penalty)
+        return mx.put_along_axis(logits, indices[None, :], penalized, axis=-1)
+
+    def _depth_tokens(
+        self,
+        first_codebook: int,
+        conditional_hidden: mx.array,
+        *,
+        unconditional_hidden: Optional[mx.array],
+        cfg_scale: float,
+        temperature: float,
+        top_p: float,
+        top_k: int,
+    ) -> list[int]:
+        tokens = [0, first_codebook]
+        for _ in range(self.num_codebooks - 1):
+            token_ids = mx.array(tokens, dtype=mx.int32)[None, :]
+            logits = self.depth_decoder.next_logits(token_ids, conditional_hidden)
+            if unconditional_hidden is not None:
+                unconditional_logits = self.depth_decoder.next_logits(
+                    token_ids, unconditional_hidden
+                )
+                logits = unconditional_logits + cfg_scale * (
+                    logits - unconditional_logits
+                )
+            tokens.append(
+                self._sample(logits, temperature=temperature, top_p=top_p, top_k=top_k)
+            )
+        return tokens[1:]
+
+    def generate(
+        self,
+        text: str,
+        voice: Optional[str] = None,
+        instruct: Optional[str] = None,
+        ref_audio: Optional[Union[str, Path, mx.array]] = None,
+        ref_text: Optional[str] = None,
+        cfg_scale: Optional[float] = None,
+        max_tokens: int = 750,
+        temperature: float = 0.9,
+        top_p: float = 1.0,
+        top_k: int = 50,
+        repetition_penalty: float = 1.0,
+        seed: Optional[int] = None,
+        stream: bool = False,
+        streaming_interval: float = 2.0,
+        **_: object,
+    ) -> Generator[GenerationResult, None, None]:
+        """Generate Breeze audio for voice design, cloning, or direction."""
+        if seed is not None:
+            mx.random.seed(seed)
+        if max_tokens <= 0:
+            raise ValueError("max_tokens must be positive.")
+        if top_k < 0:
+            raise ValueError("top_k must be non-negative.")
+        if repetition_penalty <= 0:
+            raise ValueError("repetition_penalty must be positive.")
+        if streaming_interval <= 0:
+            raise ValueError("streaming_interval must be positive.")
+
+        started = time.perf_counter()
+        cond = self._prompt_embeddings(
+            text, voice=voice, instruct=instruct, ref_audio=ref_audio, ref_text=ref_text
+        )
+        use_cfg = instruct is not None and cfg_scale not in (None, 1.0)
+        scale = 1.0 if cfg_scale is None else cfg_scale
+        if use_cfg:
+            uncond = self._prompt_embeddings(
+                text, voice=voice, instruct=None, ref_audio=ref_audio, ref_text=ref_text
+            )
+
+        cond_cache = self.backbone_model.make_cache()
+        cond_hidden = self.backbone_model(input_embeddings=cond, cache=cond_cache)[
+            :, -1, :
+        ]
+        if use_cfg:
+            uncond_cache = self.backbone_model.make_cache()
+            uncond_hidden = self.backbone_model(
+                input_embeddings=uncond, cache=uncond_cache
+            )[:, -1, :]
+
+        frames: list[list[int]] = []
+        pending_frames: list[list[int]] = []
+        chunk_frames = max(
+            1,
+            round(
+                streaming_interval
+                * self.sample_rate
+                / self.audio_tokenizer.decode_upsample_rate
+            ),
+        )
+        if stream:
+            self.audio_tokenizer.decoder.reset_streaming_state()
+
+        def stream_result(audio: mx.array, token_count: int, final: bool):
+            mx.eval(audio)
+            samples = audio.shape[0]
+            elapsed = time.perf_counter() - started
+            return GenerationResult(
+                audio=audio,
+                samples=samples,
+                sample_rate=self.sample_rate,
+                segment_idx=0,
+                token_count=token_count,
+                audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
+                real_time_factor=elapsed / max(samples / self.sample_rate, 1e-6),
+                prompt={"tokens": cond.shape[1]},
+                audio_samples={"samples": samples},
+                processing_time_seconds=elapsed,
+                peak_memory_usage=mx.get_peak_memory() / 1e9,
+                is_streaming_chunk=True,
+                is_final_chunk=final,
+            )
+
+        for _ in range(max_tokens):
+            cond_logits = self.lm_head(cond_hidden)
+            if use_cfg:
+                uncond_logits = self.lm_head(uncond_hidden)
+                logits = uncond_logits + scale * (cond_logits - uncond_logits)
+            else:
+                logits = cond_logits
+            logits = self._apply_repetition_penalty(
+                logits, [frame[0] for frame in frames], repetition_penalty
+            )
+            first = self._sample(
+                logits,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                allow_eos=True,
+            )
+            if first == self.vocab_size:
+                break
+            frame = self._depth_tokens(
+                first,
+                cond_hidden,
+                unconditional_hidden=uncond_hidden if use_cfg else None,
+                cfg_scale=scale,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+            )
+            frames.append(frame)
+            pending_frames.append(frame)
+            if stream and len(pending_frames) >= chunk_frames:
+                chunk = pending_frames[:chunk_frames]
+                del pending_frames[:chunk_frames]
+                pending_codes = mx.array(chunk, dtype=mx.int32)[None, :, :]
+                stream_audio = self.audio_tokenizer.decoder.streaming_step(
+                    mx.transpose(pending_codes, (0, 2, 1))
+                )[0, 0]
+                yield stream_result(stream_audio, len(frames), final=False)
+            codebooks = mx.array(frame, dtype=mx.int32)[None, None, :]
+            cond_hidden = self.backbone_model(input_ids=codebooks, cache=cond_cache)[
+                :, -1, :
+            ]
+            if use_cfg:
+                uncond_hidden = self.backbone_model(
+                    input_ids=codebooks, cache=uncond_cache
+                )[:, -1, :]
+
+        if not frames:
+            raise RuntimeError("Breeze generated no audio codebooks before EOS.")
+        if stream:
+            if pending_frames:
+                pending_codes = mx.array(pending_frames, dtype=mx.int32)[None, :, :]
+                stream_audio = self.audio_tokenizer.decoder.streaming_step(
+                    mx.transpose(pending_codes, (0, 2, 1))
+                )[0, 0]
+                self.audio_tokenizer.decoder.reset_streaming_state()
+                yield stream_result(stream_audio, len(frames), final=True)
+            else:
+                self.audio_tokenizer.decoder.reset_streaming_state()
+            return
+        codes = mx.array(frames, dtype=mx.int32)[None, :, :]
+        audio, lengths = self.audio_tokenizer.decode(codes)
+        samples = int(lengths[0].item())
+        audio = audio[0, :samples]
+        mx.eval(audio)
+        elapsed = time.perf_counter() - started
+        yield GenerationResult(
+            audio=audio,
+            samples=samples,
+            sample_rate=self.sample_rate,
+            segment_idx=0,
+            token_count=len(frames),
+            audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
+            real_time_factor=elapsed / max(samples / self.sample_rate, 1e-6),
+            prompt={"tokens": cond.shape[1]},
+            audio_samples={"samples": samples},
+            processing_time_seconds=elapsed,
+            peak_memory_usage=mx.get_peak_memory() / 1e9,
+            is_final_chunk=True,
+        )

--- a/mlx_audio/tts/models/breeze_tts/breeze_tts.py
+++ b/mlx_audio/tts/models/breeze_tts/breeze_tts.py
@@ -7,9 +7,10 @@ no PyTorch or upstream Breeze runtime is required at inference time.
 """
 
 import json
+import math
 import time
 from pathlib import Path
-from typing import Dict, Generator, Optional, Union
+from typing import Any, Dict, Generator, Optional, Union
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -816,17 +817,51 @@ class Model(nn.Module):
         top_k: int,
         allow_eos: bool = False,
     ) -> int:
+        if temperature < 0:
+            raise ValueError("temperature must be non-negative")
+        if not 0 <= top_p <= 1:
+            raise ValueError("top_p must be between 0 and 1")
+        if not isinstance(top_k, int) or top_k < 0:
+            raise ValueError("top_k must be a non-negative integer")
+
         valid = self.vocab_size + 1 if allow_eos else self.vocab_size
-        logits = logits[..., :valid]
-        # Reserve all ids after the codec vocabulary (padding/control ids) from
-        # regular codebook sampling.  The boundary belongs to the codec config,
-        # not to a particular 2048-entry checkpoint.
-        logits = logits.at[
-            ..., self.config.codec_vocab_size : self.vocab_size
-        ].add(-mx.inf)
-        sampler = make_sampler(temp=temperature, top_p=top_p, top_k=top_k)
+        if logits.shape[-1] < valid:
+            raise ValueError(
+                "Breeze logits do not contain the expected codebook vocabulary: "
+                f"{logits.shape[-1]} < {valid}."
+            )
+
+        # Keep EOS as the one extra class used by the backbone while reserving
+        # padding/control ids in every regular codebook distribution.  Clamp
+        # top-k to this distribution: tiny deterministic fixtures often use a
+        # vocab smaller than the user-facing default of 50.
+        logits = self._mask_reserved_codec_logits(logits)[..., :valid]
+        effective_top_k = min(top_k, valid) if top_k else 0
+        if effective_top_k == valid:
+            effective_top_k = 0
+        sampler = make_sampler(
+            temp=temperature, top_p=top_p, top_k=effective_top_k
+        )
         token = sampler(nn.log_softmax(logits, axis=-1))
         return int(token.item())
+
+    def _mask_reserved_codec_logits(self, logits: mx.array) -> mx.array:
+        """Mask ids outside the codec codebook in a logits tensor.
+
+        Breeze's wrapper vocabulary contains codec entries followed by
+        padding/control ids (and one separate backbone EOS class).  The same
+        mask is used for the first codebook and for every depth-decoder step;
+        callers may still retain the EOS column by slicing after this helper.
+        """
+        if logits.shape[-1] < self.vocab_size:
+            raise ValueError(
+                "Breeze logits do not contain the wrapper vocabulary: "
+                f"{logits.shape[-1]} < {self.vocab_size}."
+            )
+        start = self.config.codec_vocab_size
+        if start >= self.vocab_size:
+            return logits
+        return logits.at[..., start : self.vocab_size].add(-mx.inf)
 
     @staticmethod
     def _apply_repetition_penalty(
@@ -867,10 +902,59 @@ class Model(nn.Module):
                 logits = unconditional_logits + cfg_scale * (
                     logits - unconditional_logits
                 )
+            # Apply the reserved-id mask before handing logits to the sampler.
+            # Keeping it here (as well as in ``_sample``) means custom samplers
+            # and deterministic test doubles observe the same official flow.
+            logits = self._mask_reserved_codec_logits(logits)
             tokens.append(
                 self._sample(logits, temperature=temperature, top_p=top_p, top_k=top_k)
             )
         return tokens[1:]
+
+    @staticmethod
+    def _audio_vector(audio: Any) -> mx.array:
+        """Normalize codec output to the one-dimensional public waveform."""
+        if hasattr(audio, "audio_values"):
+            audio = audio.audio_values
+        while isinstance(audio, (list, tuple)):
+            audio = audio[0]
+        audio = mx.array(audio)
+        while audio.ndim > 1:
+            audio = audio[0]
+        return audio
+
+    def _decode_codes(self, codes: mx.array) -> mx.array:
+        """Decode one sequence and honor the tokenizer's valid length."""
+        decoded = self.audio_tokenizer.decode(codes)
+        lengths = None
+        if isinstance(decoded, (list, tuple)):
+            if not decoded:
+                return mx.zeros((0,), dtype=mx.float32)
+            audio_data = decoded[0]
+            if len(decoded) > 1:
+                lengths = decoded[1]
+        else:
+            audio_data = decoded
+        audio = self._audio_vector(audio_data)
+        if lengths is not None:
+            lengths = mx.array(lengths).reshape(-1)
+            if lengths.shape[0]:
+                valid_samples = max(0, int(lengths[0].item()))
+                audio = audio[:valid_samples]
+        return audio
+
+    def _empty_audio(self) -> mx.array:
+        """Return the official silent fallback when EOS precedes all frames."""
+        # The upstream implementation decodes a one-frame dummy code rather
+        # than raising.  Keep that behavior when a codec is available, while
+        # retaining a zero-length CPU-safe fallback for light test doubles.
+        try:
+            dummy = mx.ones(
+                (1, 1, self.num_codebooks), dtype=mx.int32
+            )
+            return self._decode_codes(dummy)
+        except Exception:  # pragma: no cover - only used by partial fakes
+            return mx.zeros((0,), dtype=mx.float32)
 
     def generate(
         self,
@@ -897,8 +981,14 @@ class Model(nn.Module):
             raise ValueError("max_tokens must be positive.")
         if top_k < 0:
             raise ValueError("top_k must be non-negative.")
+        if temperature < 0:
+            raise ValueError("temperature must be non-negative.")
+        if not 0 <= top_p <= 1:
+            raise ValueError("top_p must be between 0 and 1.")
         if repetition_penalty <= 0:
             raise ValueError("repetition_penalty must be positive.")
+        if cfg_scale is not None and not math.isfinite(cfg_scale):
+            raise ValueError("cfg_scale must be finite.")
         if streaming_interval <= 0:
             raise ValueError("streaming_interval must be positive.")
 
@@ -906,7 +996,7 @@ class Model(nn.Module):
         cond = self._prompt_embeddings(
             text, voice=voice, instruct=instruct, ref_audio=ref_audio, ref_text=ref_text
         )
-        use_cfg = instruct is not None and cfg_scale not in (None, 1.0)
+        use_cfg = bool(instruct) and cfg_scale not in (None, 1.0)
         scale = 1.0 if cfg_scale is None else cfg_scale
         if use_cfg:
             uncond = self._prompt_embeddings(
@@ -925,13 +1015,14 @@ class Model(nn.Module):
 
         frames: list[list[int]] = []
         pending_frames: list[list[int]] = []
+        decode_rate = getattr(self.audio_tokenizer, "decode_upsample_rate", None)
+        if decode_rate is None:
+            decoder = getattr(self.audio_tokenizer, "decoder", None)
+            decode_rate = getattr(decoder, "decode_upsample_rate", None)
+        if decode_rate is None or decode_rate <= 0:
+            raise ValueError("Breeze audio tokenizer has no valid decode rate")
         chunk_frames = max(
-            1,
-            round(
-                streaming_interval
-                * self.sample_rate
-                / self.audio_tokenizer.decode_upsample_rate
-            ),
+            1, int(streaming_interval * self.sample_rate / decode_rate)
         )
         if stream:
             self.audio_tokenizer.decoder.reset_streaming_state()
@@ -966,6 +1057,7 @@ class Model(nn.Module):
             logits = self._apply_repetition_penalty(
                 logits, [frame[0] for frame in frames], repetition_penalty
             )
+            logits = self._mask_reserved_codec_logits(logits)
             first = self._sample(
                 logits,
                 temperature=temperature,
@@ -992,8 +1084,10 @@ class Model(nn.Module):
                 pending_codes = mx.array(chunk, dtype=mx.int32)[None, :, :]
                 stream_audio = self.audio_tokenizer.decoder.streaming_step(
                     mx.transpose(pending_codes, (0, 2, 1))
-                )[0, 0]
-                yield stream_result(stream_audio, len(frames), final=False)
+                )
+                yield stream_result(
+                    self._audio_vector(stream_audio), len(chunk), final=False
+                )
             codebooks = mx.array(frame, dtype=mx.int32)[None, None, :]
             cond_hidden = self.backbone_model(input_ids=codebooks, cache=cond_cache)[
                 :, -1, :
@@ -1004,22 +1098,43 @@ class Model(nn.Module):
                 )[:, -1, :]
 
         if not frames:
-            raise RuntimeError("Breeze generated no audio codebooks before EOS.")
+            empty_audio = self._empty_audio()
+            if stream:
+                self.audio_tokenizer.decoder.reset_streaming_state()
+            mx.eval(empty_audio)
+            elapsed = time.perf_counter() - started
+            yield GenerationResult(
+                audio=empty_audio,
+                samples=empty_audio.shape[0],
+                sample_rate=self.sample_rate,
+                segment_idx=0,
+                token_count=0,
+                audio_duration=f"00:00:{empty_audio.shape[0] / self.sample_rate:06.3f}",
+                real_time_factor=0.0,
+                prompt={"tokens": cond.shape[1]},
+                audio_samples={"samples": empty_audio.shape[0]},
+                processing_time_seconds=elapsed,
+                peak_memory_usage=mx.get_peak_memory() / 1e9,
+                is_streaming_chunk=stream,
+                is_final_chunk=True,
+            )
+            return
         if stream:
             if pending_frames:
                 pending_codes = mx.array(pending_frames, dtype=mx.int32)[None, :, :]
                 stream_audio = self.audio_tokenizer.decoder.streaming_step(
                     mx.transpose(pending_codes, (0, 2, 1))
-                )[0, 0]
+                )
                 self.audio_tokenizer.decoder.reset_streaming_state()
-                yield stream_result(stream_audio, len(frames), final=True)
+                yield stream_result(
+                    self._audio_vector(stream_audio), len(pending_frames), final=True
+                )
             else:
                 self.audio_tokenizer.decoder.reset_streaming_state()
             return
         codes = mx.array(frames, dtype=mx.int32)[None, :, :]
-        audio, lengths = self.audio_tokenizer.decode(codes)
-        samples = int(lengths[0].item())
-        audio = audio[0, :samples]
+        audio = self._decode_codes(codes)
+        samples = audio.shape[0]
         mx.eval(audio)
         elapsed = time.perf_counter() - started
         yield GenerationResult(

--- a/mlx_audio/tts/models/breeze_tts/breeze_tts.py
+++ b/mlx_audio/tts/models/breeze_tts/breeze_tts.py
@@ -64,9 +64,10 @@ class _AudioEmbedding(nn.Module):
                 "Breeze audio codebooks must have shape "
                 f"[batch, time, {self.num_codebooks}], got {codebooks.shape}."
             )
-        offsets = mx.arange(self.num_codebooks, dtype=codebooks.dtype)[
-            None, None, :
-        ] * self.vocab_size
+        offsets = (
+            mx.arange(self.num_codebooks, dtype=codebooks.dtype)[None, None, :]
+            * self.vocab_size
+        )
         hidden = self.embed_audio_tokens(codebooks + offsets)
         if self.audio_embeds_projector is not None:
             hidden = self.audio_embeds_projector(hidden)
@@ -97,9 +98,7 @@ class _Backbone(nn.Module):
                 "num_key_value_heads", config.num_key_value_heads
             ),
             head_dim=config.backbone_value("head_dim", config.head_dim),
-            rms_norm_eps=config.backbone_value(
-                "rms_norm_eps", config.rms_norm_eps
-            ),
+            rms_norm_eps=config.backbone_value("rms_norm_eps", config.rms_norm_eps),
             # This is metadata for the Qwen args.  The actual embedding below
             # deliberately uses the wrapper audio vocabulary.
             vocab_size=config.backbone_value("vocab_size", wrapper_vocab_size),
@@ -108,9 +107,7 @@ class _Backbone(nn.Module):
             ),
             rope_theta=config.backbone_value("rope_theta", config.rope_theta),
             rope_scaling=config.backbone_value("rope_scaling", config.rope_scaling),
-            tie_word_embeddings=config.backbone_value(
-                "tie_word_embeddings", False
-            ),
+            tie_word_embeddings=config.backbone_value("tie_word_embeddings", False),
         )
         self.args = args
         self.embed_tokens = _AudioEmbedding(
@@ -390,9 +387,7 @@ class _TextEncoder(nn.Module):
                     "T5Gemma2 sliding_window_pattern must be a positive integer"
                 )
             config["layer_types"] = [
-                "sliding_attention"
-                if (idx + 1) % pattern
-                else "full_attention"
+                "sliding_attention" if (idx + 1) % pattern else "full_attention"
                 for idx in range(config["num_hidden_layers"])
             ]
         # Keep the upstream defaults for the two attention-specific RoPE
@@ -839,9 +834,7 @@ class Model(nn.Module):
         effective_top_k = min(top_k, valid) if top_k else 0
         if effective_top_k == valid:
             effective_top_k = 0
-        sampler = make_sampler(
-            temp=temperature, top_p=top_p, top_k=effective_top_k
-        )
+        sampler = make_sampler(temp=temperature, top_p=top_p, top_k=effective_top_k)
         token = sampler(nn.log_softmax(logits, axis=-1))
         return int(token.item())
 
@@ -949,9 +942,7 @@ class Model(nn.Module):
         # than raising.  Keep that behavior when a codec is available, while
         # retaining a zero-length CPU-safe fallback for light test doubles.
         try:
-            dummy = mx.ones(
-                (1, 1, self.num_codebooks), dtype=mx.int32
-            )
+            dummy = mx.ones((1, 1, self.num_codebooks), dtype=mx.int32)
             return self._decode_codes(dummy)
         except Exception:  # pragma: no cover - only used by partial fakes
             return mx.zeros((0,), dtype=mx.float32)
@@ -1021,9 +1012,7 @@ class Model(nn.Module):
             decode_rate = getattr(decoder, "decode_upsample_rate", None)
         if decode_rate is None or decode_rate <= 0:
             raise ValueError("Breeze audio tokenizer has no valid decode rate")
-        chunk_frames = max(
-            1, int(streaming_interval * self.sample_rate / decode_rate)
-        )
+        chunk_frames = max(1, int(streaming_interval * self.sample_rate / decode_rate))
         if stream:
             self.audio_tokenizer.decoder.reset_streaming_state()
 

--- a/mlx_audio/tts/models/breeze_tts/breeze_tts.py
+++ b/mlx_audio/tts/models/breeze_tts/breeze_tts.py
@@ -1031,6 +1031,8 @@ class Model(nn.Module):
             mx.eval(audio)
             samples = audio.shape[0]
             elapsed = time.perf_counter() - started
+            tokens_per_sec = token_count / elapsed if elapsed > 0 else 0.0
+            samples_per_sec = samples / elapsed if elapsed > 0 else 0.0
             return GenerationResult(
                 audio=audio,
                 samples=samples,
@@ -1039,8 +1041,14 @@ class Model(nn.Module):
                 token_count=token_count,
                 audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
                 real_time_factor=elapsed / max(samples / self.sample_rate, 1e-6),
-                prompt={"tokens": cond.shape[1]},
-                audio_samples={"samples": samples},
+                prompt={
+                    "tokens": token_count,
+                    "tokens-per-sec": tokens_per_sec,
+                },
+                audio_samples={
+                    "samples": samples,
+                    "samples-per-sec": samples_per_sec,
+                },
                 processing_time_seconds=elapsed,
                 peak_memory_usage=mx.get_peak_memory() / 1e9,
                 is_streaming_chunk=True,
@@ -1103,16 +1111,21 @@ class Model(nn.Module):
                 self.audio_tokenizer.decoder.reset_streaming_state()
             mx.eval(empty_audio)
             elapsed = time.perf_counter() - started
+            samples = empty_audio.shape[0]
+            samples_per_sec = samples / elapsed if elapsed > 0 else 0.0
             yield GenerationResult(
                 audio=empty_audio,
-                samples=empty_audio.shape[0],
+                samples=samples,
                 sample_rate=self.sample_rate,
                 segment_idx=0,
                 token_count=0,
-                audio_duration=f"00:00:{empty_audio.shape[0] / self.sample_rate:06.3f}",
+                audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
                 real_time_factor=0.0,
-                prompt={"tokens": cond.shape[1]},
-                audio_samples={"samples": empty_audio.shape[0]},
+                prompt={"tokens": 0, "tokens-per-sec": 0.0},
+                audio_samples={
+                    "samples": samples,
+                    "samples-per-sec": samples_per_sec,
+                },
                 processing_time_seconds=elapsed,
                 peak_memory_usage=mx.get_peak_memory() / 1e9,
                 is_streaming_chunk=stream,
@@ -1137,16 +1150,25 @@ class Model(nn.Module):
         samples = audio.shape[0]
         mx.eval(audio)
         elapsed = time.perf_counter() - started
+        token_count = len(frames)
+        tokens_per_sec = token_count / elapsed if elapsed > 0 else 0.0
+        samples_per_sec = samples / elapsed if elapsed > 0 else 0.0
         yield GenerationResult(
             audio=audio,
             samples=samples,
             sample_rate=self.sample_rate,
             segment_idx=0,
-            token_count=len(frames),
+            token_count=token_count,
             audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
             real_time_factor=elapsed / max(samples / self.sample_rate, 1e-6),
-            prompt={"tokens": cond.shape[1]},
-            audio_samples={"samples": samples},
+            prompt={
+                "tokens": token_count,
+                "tokens-per-sec": tokens_per_sec,
+            },
+            audio_samples={
+                "samples": samples,
+                "samples-per-sec": samples_per_sec,
+            },
             processing_time_seconds=elapsed,
             peak_memory_usage=mx.get_peak_memory() / 1e9,
             is_final_chunk=True,

--- a/mlx_audio/tts/models/breeze_tts/config.py
+++ b/mlx_audio/tts/models/breeze_tts/config.py
@@ -1,0 +1,181 @@
+"""Configuration helpers for Breeze TTS 2 checkpoints."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from mlx_audio.tts.models.base import BaseModelArgs
+
+
+@dataclass
+class ModelConfig(BaseModelArgs):
+    """The subset of the upstream Breeze config required for MLX inference."""
+
+    model_type: str = "breeze"
+    hidden_size: int = 2048
+    intermediate_size: int = 6144
+    num_hidden_layers: int = 28
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    hidden_act: str = "silu"
+    rms_norm_eps: float = 1e-5
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    mlp_bias: bool = False
+    initializer_range: float = 0.02
+    use_cache: bool = True
+    pad_token_id: int = 0
+    bos_token_id: int = 2
+    eos_token_id: int | None = 1
+    tie_word_embeddings: bool = False
+    rope_theta: float = 500000.0
+    rope_scaling: dict | None = None
+    max_position_embeddings: int = 2048
+    num_codebooks: int = 16
+    vocab_size: int = 2051
+    # Newer Breeze checkpoints retain the canonical ``num_codebooks`` and
+    # ``vocab_size`` fields, while some exports also expose these as
+    # ``audio_*`` aliases.  Keep both so loading does not accidentally use the
+    # nested Qwen vocabulary for the audio wrapper.
+    audio_num_codebooks: int | None = None
+    audio_vocab_size: int | None = None
+    audio_embed_size: int | None = None
+    text_vocab_size: int = 262158
+    audio_token_id: int = 262144
+    audio_eos_token_id: int = 262145
+    codebook_pad_token_id: int = 2050
+    codebook_eos_token_id: int = 0
+    sample_rate: int = 24000
+    backbone_config: dict | None = None
+    codec_config: dict | None = None
+    depth_decoder_config: dict | None = None
+    text_encoder_config: dict | None = None
+    tie_codebooks_embeddings: bool = True
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> "ModelConfig":
+        """Build a wrapper config while retaining nested model configs.
+
+        ``BreezeConfig`` is a multimodal wrapper.  Its nested Qwen config has
+        a large text vocabulary (151936 for Breeze-TTS-2), whereas the wrapper
+        vocabulary is the 2051-entry codec vocabulary.  The checkpoint also
+        contains ``audio_vocab_size``/``audio_num_codebooks`` aliases in some
+        revisions.  Normalize those aliases here so all callers, including
+        the generation path, continue to read the wrapper-level fields.
+        """
+        params = dict(params)
+        if "num_codebooks" not in params and "audio_num_codebooks" in params:
+            params["num_codebooks"] = params["audio_num_codebooks"]
+        if "vocab_size" not in params and "audio_vocab_size" in params:
+            params["vocab_size"] = params["audio_vocab_size"]
+
+        codec = cls._as_mapping(params.get("codec_config"))
+        audio_num_codebooks = params.get("audio_num_codebooks")
+        audio_vocab_size = params.get("audio_vocab_size")
+        # Prefer explicit audio aliases when both names are present.  They are
+        # the unambiguous wrapper fields in checkpoints produced by newer
+        # Transformers versions; the nested backbone's ``vocab_size`` is
+        # never used for this purpose.
+        if audio_num_codebooks is not None:
+            params["num_codebooks"] = audio_num_codebooks
+        if audio_vocab_size is not None:
+            params["vocab_size"] = audio_vocab_size
+
+        values = {
+            key: value
+            for key, value in params.items()
+            if key in cls.__dataclass_fields__ and key != "sample_rate"
+        }
+        return cls(
+            **values,
+            sample_rate=codec.get(
+                "sampling_rate",
+                codec.get(
+                    "output_sample_rate", params.get("sample_rate", 24000)
+                ),
+            ),
+        )
+
+    @staticmethod
+    def _as_mapping(value: Any) -> Mapping[str, Any]:
+        """Return a nested config as a mapping when possible.
+
+        ``base_load_model`` supplies dictionaries, but accepting a
+        ``PretrainedConfig``-like object here keeps direct callers and tests
+        compatible with the upstream configuration classes.
+        """
+        if value is None:
+            return {}
+        if isinstance(value, Mapping):
+            return value
+        to_dict = getattr(value, "to_dict", None)
+        if callable(to_dict):
+            converted = to_dict()
+            if isinstance(converted, Mapping):
+                return converted
+        return {
+            name: getattr(value, name)
+            for name in dir(value)
+            if not name.startswith("_")
+            and not callable(getattr(value, name, None))
+        }
+
+    def backbone_value(self, name: str, default: Any = None) -> Any:
+        """Return a Qwen backbone value, preferring the checkpoint sub-config.
+
+        Breeze's top-level fields describe its multimodal wrapper and retain
+        values inherited from another architecture.  The nested
+        ``backbone_config`` is the authoritative Qwen3 configuration.
+        """
+        backbone = self._as_mapping(self.backbone_config)
+        if name in backbone:
+            return backbone[name]
+        return getattr(self, name, default)
+
+    @property
+    def wrapper_num_codebooks(self) -> int:
+        """Number of codebooks used by the audio wrapper.
+
+        This is deliberately separate from ``backbone_config.num_codebooks``
+        (which is not a Qwen field today, but may appear in future exports).
+        """
+        value = (
+            self.audio_num_codebooks
+            if self.audio_num_codebooks is not None
+            else self.num_codebooks
+        )
+        return int(value)
+
+    @property
+    def wrapper_vocab_size(self) -> int:
+        """Size of each audio codebook, excluding the backbone EOS class."""
+        value = (
+            self.audio_vocab_size
+            if self.audio_vocab_size is not None
+            else self.vocab_size
+        )
+        return int(value)
+
+    @property
+    def wrapper_audio_embed_size(self) -> int:
+        """Embedding width consumed by the audio-token wrapper."""
+        if self.audio_embed_size is not None:
+            return int(self.audio_embed_size)
+        return self.backbone_hidden_size
+
+    @property
+    def backbone_hidden_size(self) -> int:
+        return int(self.backbone_value("hidden_size"))
+
+    @property
+    def codec_vocab_size(self) -> int:
+        """Number of actual codec entries before Breeze's reserved ids."""
+        codec = self._as_mapping(self.codec_config)
+        size = int(codec.get("codebook_size", self.wrapper_vocab_size - 3))
+        if not 0 < size <= self.wrapper_vocab_size:
+            raise ValueError(
+                "codec codebook_size must be between 1 and the wrapper "
+                f"vocab_size ({self.wrapper_vocab_size}), got {size}"
+            )
+        return size

--- a/mlx_audio/tts/models/breeze_tts/config.py
+++ b/mlx_audio/tts/models/breeze_tts/config.py
@@ -91,9 +91,7 @@ class ModelConfig(BaseModelArgs):
             **values,
             sample_rate=codec.get(
                 "sampling_rate",
-                codec.get(
-                    "output_sample_rate", params.get("sample_rate", 24000)
-                ),
+                codec.get("output_sample_rate", params.get("sample_rate", 24000)),
             ),
         )
 
@@ -117,8 +115,7 @@ class ModelConfig(BaseModelArgs):
         return {
             name: getattr(value, name)
             for name in dir(value)
-            if not name.startswith("_")
-            and not callable(getattr(value, name, None))
+            if not name.startswith("_") and not callable(getattr(value, name, None))
         }
 
     def backbone_value(self, name: str, default: Any = None) -> Any:

--- a/mlx_audio/tts/tests/test_breeze_architecture.py
+++ b/mlx_audio/tts/tests/test_breeze_architecture.py
@@ -1,0 +1,223 @@
+"""Download-free architecture and checkpoint-loading regressions for Breeze."""
+
+import pytest
+
+try:
+    import mlx.core as mx
+except (ImportError, RuntimeError) as exc:  # pragma: no cover - CI without Metal
+    pytest.skip(f"MLX device unavailable: {exc}", allow_module_level=True)
+
+from mlx_audio.tts.models.breeze_tts.breeze_tts import (
+    Model,
+    _t5gemma2_attention_mask,
+    _TextEncoder,
+)
+from mlx_audio.tts.models.breeze_tts.config import ModelConfig
+
+
+def _tiny_config(**overrides):
+    values = dict(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        num_codebooks=3,
+        vocab_size=8,
+        text_vocab_size=32,
+        text_encoder_config={
+            "hidden_size": 12,
+            "num_hidden_layers": 1,
+            "intermediate_size": 24,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 6,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": 32,
+            "layer_types": ["full_attention"],
+        },
+        depth_decoder_config={
+            "hidden_size": 12,
+            "num_hidden_layers": 1,
+            "intermediate_size": 24,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 6,
+            "rms_norm_eps": 1e-5,
+            "num_codebooks": 3,
+            "vocab_size": 8,
+            "audio_embed_size": 16,
+        },
+    )
+    values.update(overrides)
+    return ModelConfig(**values)
+
+
+def test_config_keeps_audio_wrapper_fields_distinct_from_nested_qwen():
+    config = ModelConfig.from_dict(
+        {
+            "model_type": "breeze",
+            "vocab_size": 151936,
+            "num_codebooks": 32,
+            "audio_vocab_size": 2051,
+            "audio_num_codebooks": 16,
+            "backbone_config": {
+                "model_type": "qwen3",
+                "vocab_size": 151936,
+                "hidden_size": 2048,
+                "rms_norm_eps": 1e-6,
+            },
+            "codec_config": {"sampling_rate": 24000},
+        }
+    )
+
+    assert config.wrapper_vocab_size == 2051
+    assert config.wrapper_num_codebooks == 16
+    assert config.backbone_value("vocab_size") == 151936
+    assert config.backbone_hidden_size == 2048
+    assert config.sample_rate == 24000
+
+
+def test_backbone_honors_nested_qwen_architecture_and_wrapper_embedding_shape():
+    config = _tiny_config(
+        rms_norm_eps=1e-5,
+        rope_theta=500000,
+        max_position_embeddings=2048,
+        backbone_config={
+            "hidden_size": 16,
+            "num_hidden_layers": 1,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 8,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 1_000_000,
+            "rope_scaling": None,
+            "max_position_embeddings": 40960,
+            "vocab_size": 151936,
+            "tie_word_embeddings": True,
+        },
+    )
+    model = Model(config)
+
+    assert model.backbone_model.args.rms_norm_eps == 1e-6
+    assert model.backbone_model.args.rope_theta == 1_000_000
+    assert model.backbone_model.args.max_position_embeddings == 40960
+    assert model.backbone_model.args.vocab_size == 151936
+    assert model.backbone_model.args.tie_word_embeddings is True
+    assert model.backbone_model.embed_tokens.embed_audio_tokens.weight.shape == (
+        3 * 8,
+        16,
+    )
+
+
+def test_audio_embedding_projection_matches_wrapper_audio_embed_size():
+    config = _tiny_config(audio_embed_size=10)
+    model = Model(config)
+
+    assert model.backbone_model.embed_tokens.embed_audio_tokens.weight.shape == (
+        3 * 8,
+        10,
+    )
+    assert model.backbone_model.embed_tokens.audio_embeds_projector.weight.shape == (
+        16,
+        10,
+    )
+
+
+def test_t5gemma2_masks_are_bidirectional_and_padding_aware():
+    assert _t5gemma2_attention_mask(5, "full_attention", None) is None
+    sliding = _t5gemma2_attention_mask(5, "sliding_attention", 4)
+    assert sliding.tolist() == [
+        [True, True, True, False, False],
+        [True, True, True, True, False],
+        [False, True, True, True, True],
+        [False, False, True, True, True],
+        [False, False, False, True, True],
+    ]
+
+    padding = mx.array([[1, 1, 1, 0, 0]], dtype=mx.int32)
+    full_padded = _t5gemma2_attention_mask(
+        5, "full_attention", None, attention_mask=padding
+    )
+    sliding_padded = _t5gemma2_attention_mask(
+        5, "sliding_attention", 4, attention_mask=padding
+    )
+    assert full_padded.shape == (1, 1, 1, 5)
+    assert full_padded.tolist() == [[[[True, True, True, False, False]]]]
+    assert sliding_padded.shape == (1, 1, 5, 5)
+    assert sliding_padded.tolist()[0][0][0] == [True, True, True, False, False]
+    assert sliding_padded.tolist()[0][0][4] == [False, False, False, False, False]
+
+
+def test_text_encoder_accepts_padded_batches_without_causal_mask():
+    config = {
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 16,
+        "layer_types": ["full_attention"],
+    }
+    encoder = _TextEncoder(config)
+    hidden = encoder(
+        mx.array([[1, 2, 3, 0], [4, 5, 0, 0]], dtype=mx.int32),
+        attention_mask=mx.array([[1, 1, 1, 0], [1, 1, 0, 0]], dtype=mx.int32),
+    )
+    assert hidden.shape == (2, 4, 8)
+
+
+def test_depth_heads_follow_nested_depth_configuration():
+    config = _tiny_config(
+        num_codebooks=5,
+        vocab_size=7,
+        depth_decoder_config={
+            "hidden_size": 12,
+            "num_hidden_layers": 1,
+            "intermediate_size": 24,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 6,
+            "rms_norm_eps": 1e-5,
+            "num_codebooks": 4,
+            "vocab_size": 7,
+            "audio_embed_size": 16,
+        },
+    )
+    model = Model(config)
+    assert model.depth_decoder.model.embed_tokens.weight.shape == (4 * 7, 16)
+    assert model.depth_decoder.codebooks_head.weight.shape == (3, 12, 7)
+
+
+def test_sanitize_materializes_checkpoint_tied_embedding_and_drops_codec():
+    depth = mx.zeros((24, 8))
+    sanitized = Model.sanitize(
+        {
+            "depth_decoder.model.embed_tokens.weight": depth,
+            "backbone_model.embed_tokens.embed_audio_tokens.weight": mx.ones(
+                (24, 8)
+            ),
+            "codec_model.decoder.weight": mx.zeros((1,)),
+            "text_encoder.rotary_emb.inv_freq": mx.zeros((1,)),
+        }
+    )
+    assert sanitized["depth_decoder.model.embed_tokens.weight"] is depth
+    assert sanitized["backbone_model.embed_tokens.embed_audio_tokens.weight"] is depth
+    assert "codec_model.decoder.weight" not in sanitized
+    assert "text_encoder.rotary_emb.inv_freq" not in sanitized
+
+
+def test_codec_key_validation_is_exact_except_runtime_initialized_flags():
+    expected = {
+        "decoder.weight",
+        "encoder_model.quantizer.rvq_first.vq.layers.0.codebook.initialized",
+    }
+    Model._validate_codec_weight_keys(expected, {"decoder.weight"})
+    with pytest.raises(ValueError, match="unexpected"):
+        Model._validate_codec_weight_keys(expected, {"decoder.weight", "extra"})
+    with pytest.raises(ValueError, match="missing"):
+        Model._validate_codec_weight_keys(expected, set())

--- a/mlx_audio/tts/tests/test_breeze_architecture.py
+++ b/mlx_audio/tts/tests/test_breeze_architecture.py
@@ -198,9 +198,7 @@ def test_sanitize_materializes_checkpoint_tied_embedding_and_drops_codec():
     sanitized = Model.sanitize(
         {
             "depth_decoder.model.embed_tokens.weight": depth,
-            "backbone_model.embed_tokens.embed_audio_tokens.weight": mx.ones(
-                (24, 8)
-            ),
+            "backbone_model.embed_tokens.embed_audio_tokens.weight": mx.ones((24, 8)),
             "codec_model.decoder.weight": mx.zeros((1,)),
             "text_encoder.rotary_emb.inv_freq": mx.zeros((1,)),
         }

--- a/mlx_audio/tts/tests/test_breeze_cli.py
+++ b/mlx_audio/tts/tests/test_breeze_cli.py
@@ -1,0 +1,29 @@
+"""CPU-safe CLI and registry coverage for Breeze TTS 2."""
+
+import pytest
+
+from mlx_audio.registry import SUPPORTED_MODEL_TYPES
+from mlx_audio.tts.models.breeze_tts import Model
+from mlx_audio.tts.utils import MODEL_REMAPPING, get_model_and_args
+from mlx_audio.utils import get_model_category, get_model_name_parts
+
+
+@pytest.mark.parametrize("alias", ["breeze", "breeze-tts", "breeze_tts"])
+def test_breeze_registry_aliases_resolve_to_one_module(alias):
+    module, model_type = get_model_and_args(
+        alias, get_model_name_parts("BreezeBlue/breeze-tts-2")
+    )
+
+    assert model_type == "breeze_tts"
+    assert module.Model is Model
+    assert MODEL_REMAPPING[alias] == "breeze_tts"
+
+
+def test_breeze_registry_advertises_all_aliases():
+    assert {"breeze", "breeze-tts", "breeze_tts"} <= SUPPORTED_MODEL_TYPES["tts"]
+
+
+def test_breeze_publisher_repository_is_classified_as_tts():
+    parts = get_model_name_parts("BreezeBlue/breeze-tts-2")
+
+    assert get_model_category("breeze", parts) == "tts"

--- a/mlx_audio/tts/tests/test_breeze_tts.py
+++ b/mlx_audio/tts/tests/test_breeze_tts.py
@@ -5,10 +5,7 @@ try:
 except (ImportError, RuntimeError) as exc:  # pragma: no cover - no Metal host
     pytest.skip(f"MLX device unavailable: {exc}", allow_module_level=True)
 
-from mlx_audio.tts.models.breeze_tts.breeze_tts import (
-    Model,
-    _t5gemma2_attention_mask,
-)
+from mlx_audio.tts.models.breeze_tts.breeze_tts import Model, _t5gemma2_attention_mask
 from mlx_audio.tts.models.breeze_tts.config import ModelConfig
 from mlx_audio.tts.utils import get_model_and_args
 from mlx_audio.utils import get_model_name_parts

--- a/mlx_audio/tts/tests/test_breeze_tts.py
+++ b/mlx_audio/tts/tests/test_breeze_tts.py
@@ -1,0 +1,376 @@
+import pytest
+
+try:
+    import mlx.core as mx
+except (ImportError, RuntimeError) as exc:  # pragma: no cover - no Metal host
+    pytest.skip(f"MLX device unavailable: {exc}", allow_module_level=True)
+
+from mlx_audio.tts.models.breeze_tts.breeze_tts import (
+    Model,
+    _t5gemma2_attention_mask,
+)
+from mlx_audio.tts.models.breeze_tts.config import ModelConfig
+from mlx_audio.tts.utils import get_model_and_args
+from mlx_audio.utils import get_model_name_parts
+
+
+def tiny_config():
+    return ModelConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        num_codebooks=3,
+        vocab_size=8,
+        text_vocab_size=32,
+        text_encoder_config={
+            "hidden_size": 12,
+            "num_hidden_layers": 1,
+            "intermediate_size": 24,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 6,
+            "rms_norm_eps": 1e-6,
+            "vocab_size": 32,
+        },
+        depth_decoder_config={
+            "hidden_size": 12,
+            "num_hidden_layers": 1,
+            "intermediate_size": 24,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 6,
+            "rms_norm_eps": 1e-5,
+            "num_codebooks": 3,
+            "vocab_size": 8,
+            "audio_embed_size": 16,
+        },
+    )
+
+
+def test_config_reads_breeze_nested_sample_rate():
+    config = ModelConfig.from_dict(
+        {
+            "model_type": "breeze",
+            "codec_config": {"sampling_rate": 24000},
+            "backbone_config": {
+                "rms_norm_eps": 1e-6,
+                "rope_theta": 1_000_000,
+                "max_position_embeddings": 40960,
+            },
+        }
+    )
+    assert config.model_type == "breeze"
+    assert config.sample_rate == 24000
+    assert config.backbone_config["rms_norm_eps"] == 1e-6
+
+
+def test_backbone_uses_nested_qwen_config_not_top_level_rope_settings():
+    config = tiny_config()
+    config.rms_norm_eps = 1e-5
+    config.rope_theta = 500000
+    config.max_position_embeddings = 2048
+    config.rope_scaling = {"rope_type": "llama3", "factor": 32.0}
+    config.backbone_config = {
+        "hidden_size": 16,
+        "num_hidden_layers": 1,
+        "intermediate_size": 32,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 8,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 1_000_000,
+        "rope_scaling": None,
+        "max_position_embeddings": 40960,
+    }
+
+    model = Model(config)
+    assert model.backbone_model.args.rms_norm_eps == 1e-6
+    assert model.backbone_model.args.rope_theta == 1_000_000
+    assert model.backbone_model.args.max_position_embeddings == 40960
+    assert model.backbone_model.args.rope_scaling is None
+
+
+def test_t5gemma2_masks_are_bidirectional_with_symmetric_local_window():
+    assert _t5gemma2_attention_mask(5, "full_attention", None) is None
+    mask = _t5gemma2_attention_mask(5, "sliding_attention", 4)
+    assert mask.tolist() == [
+        [True, True, True, False, False],
+        [True, True, True, True, False],
+        [False, True, True, True, True],
+        [False, False, True, True, True],
+        [False, False, False, True, True],
+    ]
+
+
+def test_depth_decoder_predicts_each_remaining_codebook():
+    model = Model(tiny_config())
+    logits = model.depth_decoder.next_logits(
+        mx.array([[0, 1]], dtype=mx.int32), mx.zeros((1, 16))
+    )
+    assert logits.shape == (1, 8)
+
+
+def test_sanitize_keeps_main_checkpoint_weights_only():
+    weights = {
+        "lm_head.weight": mx.zeros((9, 16)),
+        "text_encoder.layers.0.pre_self_attn_layernorm.weight": mx.zeros((16,)),
+        "codec_model.decoder.weight": mx.zeros((1,)),
+        "codec_model.quantizer.initialized": mx.zeros((1,)),
+        "backbone_model.layers.0.self_attn.rotary_emb.inv_freq": mx.zeros((1,)),
+    }
+    sanitized = Model.sanitize(weights)
+    assert list(sanitized) == [
+        "lm_head.weight",
+        "text_encoder.layers.0.pre_self_attn_layernorm.weight",
+    ]
+
+
+def test_codec_key_validation_allows_only_generated_quantizer_flags():
+    expected = {
+        "decoder.weight",
+        "encoder_model.quantizer.rvq_first.vq.layers.0.codebook.initialized",
+    }
+    Model._validate_codec_weight_keys(expected, {"decoder.weight"})
+    with pytest.raises(ValueError, match="unexpected"):
+        Model._validate_codec_weight_keys(expected, {"decoder.weight", "other.weight"})
+    with pytest.raises(ValueError, match="missing"):
+        Model._validate_codec_weight_keys(expected, set())
+
+
+def test_default_generic_voice_maps_to_breeze_s0():
+    model = Model(tiny_config())
+    assert model._speaker("af_heart") == "[S0]"
+    assert model._speaker("S2") == "[S2]"
+    assert model._speaker("[S3]") == "[S3]"
+
+
+def test_depth_cfg_applies_to_every_remaining_codebook(monkeypatch):
+    model = Model(tiny_config())
+    sampled_logits = []
+
+    def next_logits(_token_ids, hidden):
+        return mx.full((1, 8), hidden[0, 0])
+
+    def sample(logits, **_kwargs):
+        sampled_logits.append(logits)
+        return 1
+
+    monkeypatch.setattr(model.depth_decoder, "next_logits", next_logits)
+    monkeypatch.setattr(model, "_sample", sample)
+    tokens = model._depth_tokens(
+        1,
+        mx.ones((1, 16)),
+        unconditional_hidden=mx.zeros((1, 16)),
+        cfg_scale=3.0,
+        temperature=0,
+        top_p=1,
+        top_k=0,
+    )
+
+    assert tokens == [1, 1, 1]
+    assert len(sampled_logits) == 2
+    assert all(float(logits[0, 0].item()) == 3.0 for logits in sampled_logits)
+
+
+def test_depth_cfg_masks_reserved_tokens_at_every_step(monkeypatch):
+    model = Model(tiny_config())
+    sampled_logits = []
+
+    def next_logits(_token_ids, _hidden):
+        return mx.arange(8, dtype=mx.float32)[None, :]
+
+    def sample(logits, **_kwargs):
+        sampled_logits.append(logits)
+        return 1
+
+    monkeypatch.setattr(model.depth_decoder, "next_logits", next_logits)
+    monkeypatch.setattr(model, "_sample", sample)
+    model._depth_tokens(
+        1,
+        mx.ones((1, 16)),
+        unconditional_hidden=mx.zeros((1, 16)),
+        cfg_scale=2.0,
+        temperature=0,
+        top_p=1,
+        top_k=0,
+    )
+
+    assert len(sampled_logits) == 2
+    for logits in sampled_logits:
+        assert logits[0, :5].tolist() == [0, 1, 2, 3, 4]
+        assert all(value == float("-inf") for value in logits[0, 5:].tolist())
+
+
+def test_repetition_penalty_is_sign_aware():
+    logits = mx.array([[4.0, -2.0, 7.0, -5.0]])
+    penalized = Model._apply_repetition_penalty(logits, [0, 1, 1, 3], 2.0)
+    assert penalized.tolist() == [[2.0, -4.0, 7.0, -10.0]]
+
+
+def test_codec_vocab_boundary_comes_from_config():
+    config = tiny_config()
+    config.codec_config = {"codebook_size": 5}
+    model = Model(config)
+    token = model._sample(
+        mx.array([[0.0, 0.0, 1.0, 0.0, 2.0, 99.0, 98.0, 97.0, 96.0]]),
+        temperature=0,
+        top_p=1,
+        top_k=0,
+    )
+    assert token == 4
+
+
+def test_reference_audio_batch_is_rejected_before_codec_encode():
+    model = Model(tiny_config())
+    model.audio_tokenizer = object()
+    with pytest.raises(ValueError, match="exactly one reference audio"):
+        model._encode_reference(mx.zeros((2, 10)))
+
+
+def test_multiple_reference_paths_are_rejected_before_prompt_encoding():
+    model = Model(tiny_config())
+    with pytest.raises(ValueError, match="exactly one reference audio"):
+        model._prompt_embeddings(
+            "target",
+            voice=None,
+            instruct=None,
+            ref_audio=["a.wav", "b.wav"],
+            ref_text=["a", "b"],
+        )
+
+
+def test_exact_prompt_template_for_cloning_and_direction(monkeypatch):
+    model = Model(tiny_config())
+    prompts = []
+
+    def text_ids(value):
+        prompts.append(value)
+        return mx.array([1, 2], dtype=mx.int32)
+
+    monkeypatch.setattr(model, "_text_ids", text_ids)
+    monkeypatch.setattr(
+        model, "_encode_reference", lambda _audio: mx.zeros((1, 1, 3), mx.int32)
+    )
+    model._prompt_embeddings(
+        "target",
+        voice="S2",
+        instruct="warm",
+        ref_audio="reference.wav",
+        ref_text="reference text",
+    )
+    assert prompts == ["[S2]reference text", "[S2]<ins_bos>warm<ins_eos>target"]
+
+
+def test_stream_flushes_at_exact_interval_and_resets_state(monkeypatch):
+    model = Model(tiny_config())
+
+    class Decoder:
+        decode_upsample_rate = 24000
+
+        def __init__(self):
+            self.reset_calls = 0
+
+        def reset_streaming_state(self):
+            self.reset_calls += 1
+
+        def streaming_step(self, codes):
+            return mx.zeros((1, 1, codes.shape[-1]))
+
+    class AudioTokenizer:
+        decode_upsample_rate = 24000
+
+        def __init__(self):
+            self.decoder = Decoder()
+
+    class Head:
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, _hidden):
+            self.calls += 1
+            logits = mx.full((1, 9), -100.0)
+            logits[..., 1 if self.calls <= 2 else 8] = 100.0
+            return logits
+
+    model.audio_tokenizer = AudioTokenizer()
+    monkeypatch.setattr(
+        model, "_prompt_embeddings", lambda *_args, **_kwargs: mx.zeros((1, 1, 16))
+    )
+    monkeypatch.setattr(
+        model, "_depth_tokens", lambda first, *_args, **_kwargs: [first, 2, 3]
+    )
+    model.lm_head = Head()
+
+    chunks = list(
+        model.generate(
+            "test", temperature=0, top_k=0, stream=True, streaming_interval=2.0
+        )
+    )
+    assert len(chunks) == 2
+    assert chunks[0].token_count == 2
+    assert not chunks[0].is_final_chunk
+    assert chunks[1].token_count == 1
+    assert chunks[1].is_final_chunk
+    assert model.audio_tokenizer.decoder.reset_calls == 2
+
+
+def test_early_eos_yields_silent_result_instead_of_raising(monkeypatch):
+    model = Model(tiny_config())
+
+    class Decoder:
+        decode_upsample_rate = 24000
+
+        def reset_streaming_state(self):
+            pass
+
+    class AudioTokenizer:
+        decode_upsample_rate = 24000
+        decoder = Decoder()
+
+        def decode(self, codes):
+            assert codes.shape == (1, 1, 3)
+            return mx.zeros((1, 4)), mx.array([4], dtype=mx.int32)
+
+    class Backbone:
+        def make_cache(self):
+            return []
+
+        def __call__(self, input_embeddings=None, input_ids=None, cache=None):
+            del cache
+            length = (
+                input_embeddings.shape[1]
+                if input_embeddings is not None
+                else input_ids.shape[1]
+            )
+            return mx.zeros((1, length, 16))
+
+    class Head:
+        def __call__(self, _hidden):
+            logits = mx.full((1, 9), -100.0)
+            logits[..., 8] = 100.0
+            return logits
+
+    model.audio_tokenizer = AudioTokenizer()
+    model.backbone_model = Backbone()
+    model.lm_head = Head()
+    monkeypatch.setattr(
+        model, "_prompt_embeddings", lambda *_args, **_kwargs: mx.zeros((1, 1, 16))
+    )
+
+    results = list(model.generate("test", temperature=0, top_k=0))
+    assert len(results) == 1
+    assert results[0].is_final_chunk
+    assert results[0].token_count == 0
+    assert results[0].samples == 4
+    assert results[0].audio.tolist() == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_breeze_registry_loads_model_module():
+    module, model_type = get_model_and_args(
+        "breeze", get_model_name_parts("BreezeBlue/breeze-tts-2")
+    )
+    assert model_type == "breeze_tts"
+    assert module.Model is Model

--- a/mlx_audio/tts/tests/test_breeze_tts.py
+++ b/mlx_audio/tts/tests/test_breeze_tts.py
@@ -292,7 +292,7 @@ def test_stream_flushes_at_exact_interval_and_resets_state(monkeypatch):
         def __call__(self, _hidden):
             self.calls += 1
             logits = mx.full((1, 9), -100.0)
-            logits[..., 1 if self.calls <= 2 else 8] = 100.0
+            logits[..., 1 if self.calls <= 3 else 8] = 100.0
             return logits
 
     model.audio_tokenizer = AudioTokenizer()
@@ -311,8 +311,14 @@ def test_stream_flushes_at_exact_interval_and_resets_state(monkeypatch):
     )
     assert len(chunks) == 2
     assert chunks[0].token_count == 2
+    assert chunks[0].prompt["tokens"] == 2
+    assert chunks[0].prompt["tokens-per-sec"] >= 0
+    assert chunks[0].audio_samples["samples-per-sec"] >= 0
     assert not chunks[0].is_final_chunk
     assert chunks[1].token_count == 1
+    assert chunks[1].prompt["tokens"] == 1
+    assert chunks[1].prompt["tokens-per-sec"] >= 0
+    assert chunks[1].audio_samples["samples-per-sec"] >= 0
     assert chunks[1].is_final_chunk
     assert model.audio_tokenizer.decoder.reset_calls == 2
 
@@ -365,6 +371,9 @@ def test_early_eos_yields_silent_result_instead_of_raising(monkeypatch):
     assert results[0].is_final_chunk
     assert results[0].token_count == 0
     assert results[0].samples == 4
+    assert results[0].prompt == {"tokens": 0, "tokens-per-sec": 0.0}
+    assert results[0].audio_samples["samples"] == 4
+    assert results[0].audio_samples["samples-per-sec"] >= 0
     assert results[0].audio.tolist() == [0.0, 0.0, 0.0, 0.0]
 
 

--- a/mlx_audio/tts/utils.py
+++ b/mlx_audio/tts/utils.py
@@ -17,6 +17,9 @@ from mlx_audio.utils import (
 )
 
 MODEL_REMAPPING = {
+    "breeze": "breeze_tts",
+    "breeze-tts": "breeze_tts",
+    "breeze_tts": "breeze_tts",
     "qwen3_tts": "qwen3_tts",
     "outetts": "outetts",
     "spark": "spark",


### PR DESCRIPTION
## Context
I have made an AI-assisted implementation of [BreezeBlue/Breeze-TTS-2](https://huggingface.co/BreezeBlue/Breeze-TTS-2) inference sample code from here: [breezeblue-ai/breeze-tts](https://github.com/breezeblue-ai/breeze-tts)  
Breeze TTS 2 is the leading Open Weights TTS model in the Artificial Analysis Provider Voices Speech Arena (as of 08/26/26) and as I am working on a TTS/VoiceCloning tool as a hobby, I wanted to support it.

## Description
- **Implementation:** A new self-contained model package `mlx_audio/tts/models/breeze_tts/` ports the full architecture to MLX (text encoder plus the bundled Qwen3-TTS audio codec), with a checkpoint loader and typed model config, producing 24 kHz mono audio. The generation pipeline matches the upstream sampling semantics, supports incremental streaming via `-stream`/`--streaming_interval`, and reports standard token and audio throughput fields on every result path (streaming, early-EOS, and non-streaming).
- **Service integration:** The model is registered under three aliases (breeze, breeze-tts, breeze_tts) in the TTS MODEL_REMAPPING; repository names resolve to the architecture through the existing name-tokenization path. The change touches no shared infrastructure (`mlx_audio/utils.py`, `generate.py`) and changes no behavior of existing models.
- **Verification:** a CPU-safe regression tests covers architecture and config loading, registry alias resolution, sampling/streaming behavior, and throughput reporting; all existing model tests pass unmodified.
- **Documentation:** A model docs page and in-tree README document voice design, cloning, direction, inline vocal events (parenthesized English, bracketed Chinese), and streaming. Since the publisher's checkpoint ships PyTorch safetensors that MLX cannot load directly, all examples use an unofficial MLX 4-bit conversion and quantization I made myself, hosted at https://huggingface.co/LunaFox/Breeze-TTS-2-mlx-4bit.
- **Licensing:** Breeze TTS 2 is released under the custom BreezeBlue Research and Non-Commercial License Agreement (RESONIA, INC. — https://huggingface.co/BreezeBlue/Breeze-TTS-2/raw/main/LICENSE), which is not an open-source license: it permits research and non-commercial use only, and any commercial use requires a separate written license from BreezeBlue. The model weights, derivative models (expressly including quantizations such as my 4-bit MLX conversion), and generated outputs remain governed by that agreement; only the implementation code contributed in this PR falls under this repository's MIT license.

## Changes in the codebase
New functionality: Adds support for BreezeBlue's Breeze TTS 2 to mlx-audio, as a new model package (`mlx_audio/tts/models/breeze_tts/`). Capabilities exposed through the existing mlx_audio.tts.generate CLI and Python API:
- Voice design — generate a voice from a natural-language description (`--instruct`/`--instruction`, with configurable `--cfg_scale`), no reference audio required.
- Voice cloning — clone a speaker from one reference audio clip plus its exact transcript (`--ref_audio`/`--ref_text`); one pair per generation, 24 kHz mono output.
- Voice direction — combine a reference pair with an instruction to preserve speaker identity while directing tone, emotion, or pace (`--voice S0` selects Breeze's default speaker tag).
- Inline vocal events — parenthesized English events (e.g. (laugh), (cough), (sigh)) and square-bracket Chinese events (e.g. [笑], [咳嗽]) pass through --text and are rendered in the audio.
- Streaming generation — `--stream` yields incremental codec-decoded audio chunks with selectable cadence (`--streaming_interval`), plus `--save` to join chunks into a WAV; the Python API yields GenerationResult objects for the same flow.
- Throughput reporting - token and audio throughput fields (tokens/sec, samples/sec) populated on all generation paths: streaming, early-EOS, and non-streaming.
Modifications to existing code: none. The only change outside the new package and docs is three additive registration entries (`breeze`, `breeze-tts`, `breeze_tts`) in the TTS `MODEL_REMAPPING` dictionary — no refactoring, no edits to shared infrastructure; the full existing test suite passes unmodified.

## Changes outside the codebase
No changes to external services, infrastructure, third-party integrations, or database updates have been made.

## Additional information
This is my first contribution and I hope it falls within your expectations of quality but I'm happy to accommodate any desired and required changes. If AI-assisted contributions aren't welcome, I will of course retract my PR and still offer my code/repo under MIT if ever needed as a reference.

Cheers!
