### PR TITLE
fix(omnivoice): stop swallowing audio tokenizer load failures

### DIFF
--- a/mlx_audio/tts/models/omnivoice/omnivoice.py
+++ b/mlx_audio/tts/models/omnivoice/omnivoice.py
@@ -671,14 +671,11 @@ class Model(nn.Module):
             warnings.warn(f"Could not load text tokenizer: {e}")
             model.text_tokenizer = None
 
-        try:
-            from mlx_audio.codec.models.higgs_audio.higgs_audio import (
-                HiggsAudioTokenizer,
-            )
+        # Not caught like the text tokenizer above: generate() treats a
+        # missing audio_tokenizer as "emit silence", so swallowing a real
+        # load failure here used to surface as a silent all-zero WAV.
+        from mlx_audio.codec.models.higgs_audio.higgs_audio import HiggsAudioTokenizer
 
-            model.audio_tokenizer = HiggsAudioTokenizer.from_pretrained(str(model_path))
-        except Exception as e:
-            warnings.warn(f"Could not load audio tokenizer: {e}")
-            model.audio_tokenizer = None
+        model.audio_tokenizer = HiggsAudioTokenizer.from_pretrained(str(model_path))
 
         return model

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -6708,6 +6708,74 @@ class TestOmniVoiceGenerateWithTokenizer(unittest.TestCase):
         self.assertEqual(result.audio.size, expected_samples)
 
 
+class TestOmniVoicePostLoadHook(unittest.TestCase):
+    """A real audio_tokenizer load failure must not be swallowed: generate()
+    treats a missing audio_tokenizer as "emit silence", so post_load_hook is
+    the only place left that can turn it into an actionable error."""
+
+    def _make_model(self):
+        from mlx_audio.tts.models.omnivoice.config import OmniVoiceConfig
+        from mlx_audio.tts.models.omnivoice.omnivoice import Model
+
+        cfg = OmniVoiceConfig.from_dict(
+            {
+                "model_type": "omnivoice",
+                "audio_vocab_size": 1025,
+                "audio_mask_id": 1024,
+                "num_audio_codebook": 8,
+                "sample_rate": 24000,
+                "llm_config": {
+                    "hidden_size": 64,
+                    "num_hidden_layers": 2,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 2,
+                    "intermediate_size": 128,
+                    "vocab_size": 200,
+                    "head_dim": 16,
+                    "rms_norm_eps": 1e-6,
+                },
+            }
+        )
+        return Model(cfg)
+
+    def test_audio_tokenizer_load_failure_propagates(self):
+        from mlx_audio.tts.models.omnivoice.omnivoice import Model
+
+        model = self._make_model()
+        with (
+            patch(
+                "transformers.AutoTokenizer.from_pretrained",
+                side_effect=OSError("no text tokenizer here"),
+            ),
+            patch(
+                "mlx_audio.codec.models.higgs_audio.higgs_audio.HiggsAudioTokenizer.from_pretrained",
+                side_effect=RuntimeError("Missing 225 parameters"),
+            ),
+        ):
+            with self.assertRaises(RuntimeError):
+                Model.post_load_hook(model, Path("/nonexistent/checkpoint"))
+
+    def test_text_tokenizer_failure_alone_is_still_caught(self):
+        """Unaffected by this change: a text_tokenizer load failure still
+        just warns and sets None, same as before."""
+        from mlx_audio.tts.models.omnivoice.omnivoice import Model
+
+        model = self._make_model()
+        with (
+            patch(
+                "transformers.AutoTokenizer.from_pretrained",
+                side_effect=OSError("no text tokenizer here"),
+            ),
+            patch(
+                "mlx_audio.codec.models.higgs_audio.higgs_audio.HiggsAudioTokenizer.from_pretrained",
+                return_value=object(),
+            ),
+        ):
+            result = Model.post_load_hook(model, Path("/nonexistent/checkpoint"))
+        self.assertIsNone(result.text_tokenizer)
+        self.assertIsNotNone(result.audio_tokenizer)
+
+
 class TestHiggsAudioDAC(unittest.TestCase):
     def test_residual_unit_shape(self):
         from mlx_audio.codec.models.higgs_audio.dac import ResidualUnit


### PR DESCRIPTION
`Model.post_load_hook` (omnivoice.py) wraps the audio tokenizer load in a bare `except Exception`, warns, and sets `model.audio_tokenizer = None`. `generate()` and `generate_batch()` both treat a `None` audio tokenizer as "emit silence" (`mx.zeros(...)`) rather than raising, so a real load failure, for example strict weight loading rejecting a checkpoint missing the semantic encoder, produces a valid, playable, completely silent WAV with no error anywhere in the path.

Fix: stop swallowing the audio tokenizer's load exception in `post_load_hook`, so it propagates the same way `HiggsAudioModel.post_load_hook` already loads its own codec (no try/except there at all), and the same way every other model in this repo's `generate()` raises when `post_load_hook` was skipped or failed. The text tokenizer's separate, already-optional load path is untouched.

I deliberately did not touch the `tokenizer is not None` branches inside `generate()`/`generate_batch()` themselves: the existing OmniVoice test suite calls both with no audio tokenizer at all (`TestOmniVoiceGenerate`, `TestOmniVoiceGenerateBatch`), by design, to exercise the masking and batching logic without needing the real codec weights. Making those methods raise as well would change that testing contract for a case the issue does not actually report.

Verification:
- New test `test_audio_tokenizer_load_failure_propagates` fails on main (`RuntimeError not raised`) and passes on the branch, by making `HiggsAudioTokenizer.from_pretrained` raise and asserting `post_load_hook` now propagates it instead of swallowing it.
- `test_text_tokenizer_failure_alone_is_still_caught` pins that the unrelated text tokenizer path keeps its existing catch-and-warn behavior.
- `mlx_audio/tts/tests/test_models.py -k OmniVoice` (53 tests) passes in full.
- Not verified: an end-to-end run against a real `mlx-community/OmniVoice-bf16` checkpoint. I don't have Apple Silicon here, so this is scoped to the load-hook logic itself, which is pure Python and CPU-testable.

Fixes #714
