### PR TITLE
fix(audio_io): decode CAF, and route mp4/m4b paths through ffmpeg

### DIFF
--- a/mlx_audio/audio_io.py
+++ b/mlx_audio/audio_io.py
@@ -52,6 +52,9 @@ def _detect_format_from_bytes(data: bytes) -> str:
     elif data[:4] == b"\x1a\x45\xdf\xa3":
         # WebM/Matroska container (EBML header)
         return "webm"
+    elif data[:4] == b"caff":
+        # Core Audio Format (macOS default recording container)
+        return "caf"
     else:
         raise ValueError("Unable to detect audio format from bytes")
 
@@ -236,7 +239,7 @@ def read(
     sample_rate: Optional[int] = None,
     nchannels: Optional[int] = None,
 ) -> Tuple[np.ndarray, int]:
-    """Read an audio file using miniaudio (or ffmpeg for M4A/AAC/OGG/Opus/WebM).
+    """Read an audio file using miniaudio (or ffmpeg for M4A/AAC/OGG/Opus/WebM/CAF).
 
     Args:
         file: Path to the audio file or a BytesIO object.
@@ -259,7 +262,7 @@ def read(
     use_ffmpeg = False
     if isinstance(file, (str, Path)):
         ext = Path(file).suffix.lstrip(".").lower()
-        if ext in ("m4a", "aac", "ogg", "opus", "webm"):
+        if ext in ("m4a", "m4b", "mp4", "aac", "ogg", "opus", "webm", "caf"):
             use_ffmpeg = True
     elif isinstance(file, io.BytesIO):
         file.seek(0)
@@ -269,6 +272,7 @@ def read(
             header[4:8] == b"ftyp"
             or header[:4] == b"OggS"
             or header[:4] == b"\x1a\x45\xdf\xa3"
+            or header[:4] == b"caff"
         ):
             use_ffmpeg = True
 

--- a/mlx_audio/tests/test_audio_io.py
+++ b/mlx_audio/tests/test_audio_io.py
@@ -2,6 +2,7 @@
 
 import io
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -359,3 +360,55 @@ class TestAudioIOEdgeCases:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestAudioIOCAF:
+    """Test reading Core Audio Format, the macOS native recording container."""
+
+    @pytest.fixture
+    def caf_file(self, tmp_path):
+        """Encode one second of 440 Hz mono audio into a CAF container."""
+        samplerate = 16000
+        t = np.linspace(0, 1.0, samplerate, endpoint=False)
+        pcm = (np.sin(2 * np.pi * 440 * t) * 0.5 * 32767).astype(np.int16)
+        path = tmp_path / "recording.caf"
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "s16le",
+                "-ar",
+                str(samplerate),
+                "-ac",
+                "1",
+                "-i",
+                "pipe:0",
+                "-c:a",
+                "pcm_s16le",
+                str(path),
+            ],
+            input=pcm.tobytes(),
+            capture_output=True,
+            check=True,
+        )
+        return path, samplerate
+
+    @pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg not installed")
+    def test_read_caf_path(self, caf_file):
+        path, samplerate = caf_file
+
+        data, read_samplerate = read(path)
+
+        assert read_samplerate == samplerate
+        assert data.shape[0] > 0
+
+    @pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg not installed")
+    def test_read_caf_bytesio(self, caf_file):
+        """Uploads arrive as bytes, so the caff magic alone must route to ffmpeg."""
+        path, samplerate = caf_file
+
+        data, read_samplerate = read(io.BytesIO(path.read_bytes()))
+
+        assert read_samplerate == samplerate
+        assert data.shape[0] > 0


### PR DESCRIPTION
CAF is the container macOS records to by default, but `read()` did not recognize it — neither the extension list nor the magic-byte sniff — so reading one failed with `Unable to detect audio format from bytes`. This detects the `caff` magic and routes it to ffmpeg alongside the existing MPEG-4/Ogg/WebM cases, for both path and `BytesIO` inputs.

Also in here:

- Path reads now route `mp4` and `m4b` to ffmpeg too. Both are `ftyp` containers that the `BytesIO` path already handled via the header sniff, so reading one by path failed where reading the same bytes succeeded.
- `_detect_format_from_bytes` reports `caf` instead of raising, so callers that use it for reporting get a useful name.

### Tests

Two CAF read cases, path and `BytesIO`, both skipped when ffmpeg is absent. Both fail on `main` with the error above.

```
mlx_audio/tests/test_audio_io.py ........................ 24 passed
```

### Related

Blaizzy/mlx-vlm#2051 — which also fixes Blaizzy/nativ#404