### PR TITLE
Add streaming generation for VibeVoice

### DIFF
--- a/mlx_audio/tts/generate.py
+++ b/mlx_audio/tts/generate.py
@@ -384,7 +384,7 @@ def generate_audio(
                     f"Samples/sec:           {result.audio_samples['samples-per-sec']:.1f}"
                 )
                 print(
-                    f"Prompt:                {result.token_count} tokens, {result.prompt['tokens-per-sec']:.1f} tokens-per-sec"
+                    f"Prompt:                {result.prompt['tokens']} tokens, {result.prompt['tokens-per-sec']:.1f} tokens-per-sec"
                 )
                 print(
                     f"Audio:                 {result.audio_samples['samples']} samples, {result.audio_samples['samples-per-sec']:.1f} samples-per-sec"

--- a/mlx_audio/tts/models/vibevoice/acoustic_tokenizer.py
+++ b/mlx_audio/tts/models/vibevoice/acoustic_tokenizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 
 import math
+from typing import MutableMapping, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -58,6 +59,7 @@ class CausalConv1d(nn.Module):
         self.stride = stride
         self.dilation = dilation
         self.groups = groups
+        self._cache_key = f"causal_conv:{id(self)}"
 
         # Calculate padding for causal convolution
         self.padding = (kernel_size - 1) * dilation
@@ -75,7 +77,29 @@ class CausalConv1d(nn.Module):
             bias=bias,
         )
 
-    def __call__(self, x: mx.array) -> mx.array:
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
+        if cache is not None:
+            if self.stride != 1:
+                raise ValueError("Streaming CausalConv1d requires stride=1")
+
+            previous = cache.get(self._cache_key)
+            if previous is None and self.padding > 0:
+                previous = mx.zeros(
+                    (x.shape[0], self.in_channels, self.padding), dtype=x.dtype
+                )
+            if previous is not None and previous.shape[2] > 0:
+                x = mx.concatenate([previous, x], axis=2)
+
+            if self.padding > 0:
+                cache[self._cache_key] = x[:, :, -self.padding :]
+
+            x = self.conv(mx.transpose(x, (0, 2, 1)))
+            return mx.transpose(x, (0, 2, 1))
+
         # x: (B, C, T) - input in PyTorch format
         # Transpose to MLX format: (B, C, T) -> (B, T, C)
         x = mx.transpose(x, (0, 2, 1))
@@ -115,6 +139,7 @@ class CausalConvTranspose1d(nn.Module):
         self.kernel_size = kernel_size
         self.stride = stride
         self.trim_right_ratio = trim_right_ratio
+        self._cache_key = f"causal_conv_transpose:{id(self)}"
 
         # Calculate padding
         self.padding_total = kernel_size - stride
@@ -129,7 +154,14 @@ class CausalConvTranspose1d(nn.Module):
             bias=bias,
         )
 
-    def __call__(self, x: mx.array) -> mx.array:
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
+        if cache is not None:
+            return self._stream(x, cache)
+
         # x: (B, C, T) - input in PyTorch format
         # Transpose to MLX format: (B, C, T) -> (B, T, C)
         x = mx.transpose(x, (0, 2, 1))
@@ -150,6 +182,33 @@ class CausalConvTranspose1d(nn.Module):
             x = x[:, :, :-padding_right]
 
         return x
+
+    def _stream(self, x: mx.array, cache: MutableMapping[str, mx.array]) -> mx.array:
+        contributions = mx.conv_transpose1d(
+            mx.transpose(x, (0, 2, 1)),
+            self.convtr.weight,
+            stride=self.stride,
+        )
+        contributions = mx.transpose(contributions, (0, 2, 1))
+
+        pending = cache.get(self._cache_key)
+        if pending is not None and pending.shape[2] > 0:
+            overlap = min(pending.shape[2], contributions.shape[2])
+            contributions = mx.concatenate(
+                [
+                    contributions[:, :, :overlap] + pending[:, :, :overlap],
+                    contributions[:, :, overlap:],
+                ],
+                axis=2,
+            )
+
+        emit_samples = x.shape[2] * self.stride
+        output = contributions[:, :, :emit_samples]
+        cache[self._cache_key] = contributions[:, :, emit_samples:]
+
+        if self.convtr.bias is not None:
+            output = output + self.convtr.bias[None, :, None]
+        return output
 
 
 class DepthwiseConv(nn.Module):
@@ -176,8 +235,12 @@ class DepthwiseConv(nn.Module):
             bias=bias,
         )
 
-    def __call__(self, x: mx.array) -> mx.array:
-        return self.conv(x)
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
+        return self.conv(x, cache=cache)
 
 
 class Mixer(nn.Module):
@@ -189,8 +252,12 @@ class Mixer(nn.Module):
         super().__init__()
         self.conv = DepthwiseConv(dim, kernel_size, causal, bias)
 
-    def __call__(self, x: mx.array) -> mx.array:
-        return self.conv(x)
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
+        return self.conv(x, cache=cache)
 
 
 class FeedForward(nn.Module):
@@ -246,13 +313,17 @@ class Block1D(nn.Module):
             self.gamma = None
             self.ffn_gamma = None
 
-    def __call__(self, x: mx.array) -> mx.array:
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
         # x: (B, C, T)
 
         # Mixer path
         residual = x
         x = self.norm(x)
-        x = self.mixer(x)
+        x = self.mixer(x, cache=cache)
         if self.gamma is not None:
             x = x * mx.expand_dims(self.gamma, axis=(0, 2))
         x = residual + x
@@ -290,8 +361,12 @@ class StemConv(nn.Module):
             bias=bias,
         )
 
-    def __call__(self, x: mx.array) -> mx.array:
-        return self.conv(x)
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
+        return self.conv(x, cache=cache)
 
 
 class UpsampleLayer(nn.Module):
@@ -314,8 +389,12 @@ class UpsampleLayer(nn.Module):
             bias=bias,
         )
 
-    def __call__(self, x: mx.array) -> mx.array:
-        return self.convtr(x)
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
+        return self.convtr(x, cache=cache)
 
 
 class HeadConv(nn.Module):
@@ -336,8 +415,12 @@ class HeadConv(nn.Module):
             bias=bias,
         )
 
-    def __call__(self, x: mx.array) -> mx.array:
-        return self.conv(x)
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
+        return self.conv(x, cache=cache)
 
 
 class TokenizerDecoder(nn.Module):
@@ -446,7 +529,11 @@ class TokenizerDecoder(nn.Module):
             bias=config.conv_bias,
         )
 
-    def __call__(self, x: mx.array) -> mx.array:
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
         """
         Args:
             x: Latent tensor of shape (B, T, D) or (B, D, T)
@@ -459,20 +546,20 @@ class TokenizerDecoder(nn.Module):
             x = mx.transpose(x, (0, 2, 1))
 
         # Apply stem (first upsample layer)
-        x = self.upsample_layers[0][0](x)
+        x = self.upsample_layers[0][0](x, cache=cache)
 
         # Process through stages and upsampling
         for i in range(self.n_stages):
             # Apply stage blocks
             for block in self.stages[i]:
-                x = block(x)
+                x = block(x, cache=cache)
 
             # Apply upsampling (skip first upsample which was stem)
             if i + 1 < len(self.upsample_layers):
-                x = self.upsample_layers[i + 1][0](x)
+                x = self.upsample_layers[i + 1][0](x, cache=cache)
 
         # Output head
-        x = self.head(x)
+        x = self.head(x, cache=cache)
 
         return x
 
@@ -488,7 +575,11 @@ class AcousticTokenizer(nn.Module):
 
         self.decoder = TokenizerDecoder(config)
 
-    def decode(self, latents: mx.array) -> mx.array:
+    def decode(
+        self,
+        latents: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
         """Convert latent representations to audio.
 
         Args:
@@ -497,8 +588,19 @@ class AcousticTokenizer(nn.Module):
         Returns:
             Audio tensor of shape (B, 1, T')
         """
-        return self.decoder(latents)
+        if latents.ndim != 3 or latents.shape[-1] != self.decoder.dimension:
+            raise ValueError(
+                "AcousticTokenizer.decode expects latents with shape (B, T, D) "
+                f"where D={self.decoder.dimension}; received {latents.shape}"
+            )
 
-    def __call__(self, latents: mx.array) -> mx.array:
+        latents = mx.transpose(latents, (0, 2, 1))
+        return self.decoder(latents, cache=cache)
+
+    def __call__(
+        self,
+        latents: mx.array,
+        cache: Optional[MutableMapping[str, mx.array]] = None,
+    ) -> mx.array:
         """Alias for decode."""
-        return self.decode(latents)
+        return self.decode(latents, cache=cache)

--- a/mlx_audio/tts/models/vibevoice/acoustic_tokenizer.py
+++ b/mlx_audio/tts/models/vibevoice/acoustic_tokenizer.py
@@ -206,7 +206,7 @@ class CausalConvTranspose1d(nn.Module):
         output = contributions[:, :, :emit_samples]
         cache[self._cache_key] = contributions[:, :, emit_samples:]
 
-        if self.convtr.bias is not None:
+        if "bias" in self.convtr:
             output = output + self.convtr.bias[None, :, None]
         return output
 

--- a/mlx_audio/tts/models/vibevoice/acoustic_tokenizer.py
+++ b/mlx_audio/tts/models/vibevoice/acoustic_tokenizer.py
@@ -184,6 +184,11 @@ class CausalConvTranspose1d(nn.Module):
         return x
 
     def _stream(self, x: mx.array, cache: MutableMapping[str, mx.array]) -> mx.array:
+        if self.trim_right_ratio != 1.0:
+            raise ValueError(
+                "Streaming CausalConvTranspose1d requires trim_right_ratio=1.0"
+            )
+
         contributions = mx.conv_transpose1d(
             mx.transpose(x, (0, 2, 1)),
             self.convtr.weight,

--- a/mlx_audio/tts/models/vibevoice/vibevoice.py
+++ b/mlx_audio/tts/models/vibevoice/vibevoice.py
@@ -685,7 +685,6 @@ class Model(nn.Module):
         speech_latents = []
         stream_latents = []
         stream_cache = {} if stream else None
-        stream_chunk_idx = 0
         stream_chunk_start = start_time
         if stream:
             if streaming_interval <= 0:
@@ -769,12 +768,11 @@ class Model(nn.Module):
                         yield make_result(
                             audio_chunk,
                             len(stream_latents),
-                            stream_chunk_idx,
+                            0,
                             stream_chunk_start,
                             is_streaming_chunk=True,
                         )
                         stream_latents.clear()
-                        stream_chunk_idx += 1
                         stream_chunk_start = time.perf_counter()
                 else:
                     speech_latents.append(speech_latent)
@@ -818,7 +816,7 @@ class Model(nn.Module):
                 yield make_result(
                     final_audio,
                     len(stream_latents),
-                    stream_chunk_idx,
+                    0,
                     stream_chunk_start,
                     is_streaming_chunk=True,
                     is_final_chunk=True,
@@ -827,7 +825,7 @@ class Model(nn.Module):
                 yield make_result(
                     mx.array([]),
                     0,
-                    stream_chunk_idx,
+                    0,
                     stream_chunk_start,
                     is_streaming_chunk=True,
                     is_final_chunk=True,

--- a/mlx_audio/tts/models/vibevoice/vibevoice.py
+++ b/mlx_audio/tts/models/vibevoice/vibevoice.py
@@ -498,6 +498,7 @@ class Model(nn.Module):
         start_time = time.perf_counter()
         all_audio_segments = []
         total_tokens = 0
+        total_prompt_tokens = 0
 
         for segment_idx, (voice_name, segment_text) in enumerate(dialogue):
             if verbose:
@@ -521,10 +522,14 @@ class Model(nn.Module):
             ):
                 if stream:
                     result.segment_idx = segment_idx
+                    result.is_final_chunk = (
+                        result.is_final_chunk and segment_idx == len(dialogue) - 1
+                    )
                     yield result
                     continue
                 all_audio_segments.append(result.audio)
                 total_tokens += result.token_count
+                total_prompt_tokens += result.prompt["tokens"]
 
         if stream:
             return
@@ -559,9 +564,11 @@ class Model(nn.Module):
             audio_duration=duration_str,
             real_time_factor=rtf,
             prompt={
-                "tokens": total_tokens,
+                "tokens": total_prompt_tokens,
                 "tokens-per-sec": (
-                    round(total_tokens / elapsed_time, 2) if elapsed_time > 0 else 0
+                    round(total_prompt_tokens / elapsed_time, 2)
+                    if elapsed_time > 0
+                    else 0
                 ),
             },
             audio_samples={
@@ -630,9 +637,9 @@ class Model(nn.Module):
                 audio_duration=duration,
                 real_time_factor=(duration_seconds / elapsed if elapsed > 0 else 0),
                 prompt={
-                    "tokens": token_count,
+                    "tokens": prompt_token_count,
                     "tokens-per-sec": (
-                        round(token_count / elapsed, 2) if elapsed > 0 else 0
+                        round(prompt_token_count / elapsed, 2) if elapsed > 0 else 0
                     ),
                 },
                 audio_samples={
@@ -652,6 +659,7 @@ class Model(nn.Module):
             text.strip() + "\n", add_special_tokens=False
         )
         input_ids = mx.array([text_token_ids], dtype=mx.int32)
+        prompt_token_count = len(text_token_ids)
 
         batch_size = 1
         seq_len = input_ids.shape[1]
@@ -849,13 +857,13 @@ class Model(nn.Module):
             samples=samples,
             sample_rate=self.sample_rate,
             segment_idx=0,
-            token_count=len(input_ids[0]),
+            token_count=len(speech_latents),
             audio_duration=duration_str,
             real_time_factor=rtf,
             prompt={
-                "tokens": len(input_ids[0]),
+                "tokens": prompt_token_count,
                 "tokens-per-sec": (
-                    round(len(input_ids[0]) / elapsed_time, 2)
+                    round(prompt_token_count / elapsed_time, 2)
                     if elapsed_time > 0
                     else 0
                 ),

--- a/mlx_audio/tts/models/vibevoice/vibevoice.py
+++ b/mlx_audio/tts/models/vibevoice/vibevoice.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025, Prince Canuma and contributors (https://github.com/Blaizzy/mlx-audio)
 
+import math
 import os
 import time
 from pathlib import Path
@@ -411,6 +412,8 @@ class Model(nn.Module):
         ddpm_steps: Optional[int] = None,
         voice: Optional[Union[str, Path, List[Tuple[str, str]]]] = None,
         verbose: bool = False,
+        stream: bool = False,
+        streaming_interval: float = 2.0,
         **kwargs,
     ) -> Generator[GenerationResult, None, None]:
         """Generate speech from text.
@@ -444,6 +447,8 @@ class Model(nn.Module):
                 cfg_scale=cfg_scale,
                 ddpm_steps=ddpm_steps,
                 verbose=verbose,
+                stream=stream,
+                streaming_interval=streaming_interval,
                 **kwargs,
             )
             return
@@ -462,6 +467,8 @@ class Model(nn.Module):
             cfg_scale=cfg_scale,
             ddpm_steps=ddpm_steps,
             verbose=verbose,
+            stream=stream,
+            streaming_interval=streaming_interval,
             **kwargs,
         )
 
@@ -472,6 +479,8 @@ class Model(nn.Module):
         cfg_scale: float = 1.5,
         ddpm_steps: Optional[int] = None,
         verbose: bool = False,
+        stream: bool = False,
+        streaming_interval: float = 2.0,
         **kwargs,
     ) -> Generator[GenerationResult, None, None]:
         """Generate speech from multiple speakers.
@@ -506,10 +515,19 @@ class Model(nn.Module):
                 cfg_scale=cfg_scale,
                 ddpm_steps=ddpm_steps,
                 verbose=verbose,
+                stream=stream,
+                streaming_interval=streaming_interval,
                 **kwargs,
             ):
+                if stream:
+                    result.segment_idx = segment_idx
+                    yield result
+                    continue
                 all_audio_segments.append(result.audio)
                 total_tokens += result.token_count
+
+        if stream:
+            return
 
         # Combine all audio segments
         if all_audio_segments:
@@ -563,6 +581,8 @@ class Model(nn.Module):
         cfg_scale: float = 1.5,
         ddpm_steps: Optional[int] = None,
         verbose: bool = False,
+        stream: bool = False,
+        streaming_interval: float = 2.0,
         **kwargs,
     ) -> Generator[GenerationResult, None, None]:
         """Generate speech for a single speaker segment (internal method).
@@ -571,6 +591,61 @@ class Model(nn.Module):
         _generate_multi_speaker().
         """
         start_time = time.perf_counter()
+
+        def decode_latents(latents, cache=None):
+            latent_seq = mx.concatenate(latents, axis=1)
+            scaled_latents = (
+                latent_seq / self.speech_scaling_factor - self.speech_bias_factor
+            )
+            audio = self.acoustic_tokenizer.decode(scaled_latents, cache=cache)
+            audio = audio.squeeze(1).squeeze(0)
+            mx.eval(audio)
+            return audio
+
+        def make_result(
+            audio,
+            token_count,
+            segment_idx,
+            chunk_start,
+            *,
+            is_streaming_chunk=False,
+            is_final_chunk=False,
+        ):
+            elapsed = time.perf_counter() - chunk_start
+            samples = audio.shape[0] if audio.size > 0 else 0
+            duration_seconds = samples / self.sample_rate if samples > 0 else 0
+            duration_mins = int(duration_seconds // 60)
+            duration_secs = int(duration_seconds % 60)
+            duration_ms = int((duration_seconds % 1) * 1000)
+            duration = (
+                f"{int(duration_seconds // 3600):02d}:{duration_mins:02d}:"
+                f"{duration_secs:02d}.{duration_ms:03d}"
+            )
+            return GenerationResult(
+                audio=audio,
+                samples=samples,
+                sample_rate=self.sample_rate,
+                segment_idx=segment_idx,
+                token_count=token_count,
+                audio_duration=duration,
+                real_time_factor=(duration_seconds / elapsed if elapsed > 0 else 0),
+                prompt={
+                    "tokens": token_count,
+                    "tokens-per-sec": (
+                        round(token_count / elapsed, 2) if elapsed > 0 else 0
+                    ),
+                },
+                audio_samples={
+                    "samples": samples,
+                    "samples-per-sec": (
+                        round(samples / elapsed, 2) if elapsed > 0 else 0
+                    ),
+                },
+                processing_time_seconds=elapsed,
+                peak_memory_usage=mx.get_peak_memory() / 1e9,
+                is_streaming_chunk=is_streaming_chunk,
+                is_final_chunk=is_final_chunk,
+            )
 
         # Tokenize input
         text_token_ids = self.tokenizer.encode(
@@ -600,6 +675,25 @@ class Model(nn.Module):
             neg_cache = None
 
         speech_latents = []
+        stream_latents = []
+        stream_cache = {} if stream else None
+        stream_chunk_idx = 0
+        stream_chunk_start = start_time
+        if stream:
+            if streaming_interval <= 0:
+                stream_latents_per_chunk = 1
+            else:
+                acoustic_config = self.config.acoustic_tokenizer_config
+                ratios = (
+                    acoustic_config.decoder_ratios
+                    if acoustic_config.decoder_ratios
+                    else acoustic_config.encoder_ratios
+                )
+                samples_per_latent = math.prod(ratios)
+                stream_latents_per_chunk = max(
+                    1,
+                    int(streaming_interval * self.sample_rate / samples_per_latent),
+                )
         finished = False
         step = 0
         text_pos = 0
@@ -660,7 +754,22 @@ class Model(nn.Module):
                 )
                 speech_latent = mx.expand_dims(speech_latent, 1)
 
-                speech_latents.append(speech_latent)
+                if stream:
+                    stream_latents.append(speech_latent)
+                    if len(stream_latents) >= stream_latents_per_chunk:
+                        audio_chunk = decode_latents(stream_latents, cache=stream_cache)
+                        yield make_result(
+                            audio_chunk,
+                            len(stream_latents),
+                            stream_chunk_idx,
+                            stream_chunk_start,
+                            is_streaming_chunk=True,
+                        )
+                        stream_latents.clear()
+                        stream_chunk_idx += 1
+                        stream_chunk_start = time.perf_counter()
+                else:
+                    speech_latents.append(speech_latent)
 
                 acoustic_embed = self.acoustic_connector(speech_latent)
 
@@ -695,13 +804,30 @@ class Model(nn.Module):
                     finished = True
                     break
 
+        if stream:
+            if stream_latents:
+                final_audio = decode_latents(stream_latents, cache=stream_cache)
+                yield make_result(
+                    final_audio,
+                    len(stream_latents),
+                    stream_chunk_idx,
+                    stream_chunk_start,
+                    is_streaming_chunk=True,
+                    is_final_chunk=True,
+                )
+            else:
+                yield make_result(
+                    mx.array([]),
+                    0,
+                    stream_chunk_idx,
+                    stream_chunk_start,
+                    is_streaming_chunk=True,
+                    is_final_chunk=True,
+                )
+            return
+
         if speech_latents:
-            speech_latent_seq = mx.concatenate(speech_latents, axis=1)
-            scaled_latents = (
-                speech_latent_seq / self.speech_scaling_factor - self.speech_bias_factor
-            )
-            audio = self.acoustic_tokenizer.decode(scaled_latents)
-            final_audio = audio.squeeze(1).squeeze(0)
+            final_audio = decode_latents(speech_latents)
         else:
             final_audio = mx.array([])
 

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -1403,6 +1403,172 @@ class TestVibeVoiceModel(unittest.TestCase):
         self.assertEqual(config.decoder_config.hidden_size, 896)
         self.assertEqual(config.decoder_config.num_hidden_layers, 24)
 
+    def test_stream_true_emits_audio_before_generation_finishes(self):
+        """VibeVoice must decode and yield speech latents incrementally."""
+        from mlx_audio.tts.models.vibevoice.vibevoice import Model
+
+        hidden_size = 4
+
+        class FakeLanguageModel:
+            def embed_tokens(self, token_ids):
+                return mx.zeros(
+                    (token_ids.shape[0], token_ids.shape[1], hidden_size),
+                    dtype=mx.float32,
+                )
+
+            def __call__(self, inputs_embeds, cache=None):
+                return inputs_embeds, cache
+
+        class FakeAcousticTokenizer:
+            def decode(self, latents, **kwargs):
+                samples = latents.shape[1] * 4
+                return mx.arange(samples, dtype=mx.float32).reshape(1, 1, samples)
+
+        model = Model.__new__(Model)
+        model.config = SimpleNamespace(
+            sample_rate=8,
+            decoder_config=SimpleNamespace(hidden_size=hidden_size),
+            acoustic_tokenizer_config=SimpleNamespace(
+                decoder_ratios=[2],
+                encoder_ratios=[2],
+            ),
+        )
+        model.tokenizer = SimpleNamespace(
+            encode=lambda text, add_special_tokens=False: [1]
+        )
+        model.language_model = FakeLanguageModel()
+        model.tts_language_model = FakeLanguageModel()
+        model.tts_input_types = lambda token_types: mx.zeros(
+            (token_types.shape[0], token_types.shape[1], hidden_size),
+            dtype=mx.float32,
+        )
+        model.sample_speech_tokens = lambda *args, **kwargs: mx.ones(
+            (1, 2), dtype=mx.float32
+        )
+        model.acoustic_connector = lambda speech_latent: mx.zeros(
+            (1, 1, hidden_size), dtype=mx.float32
+        )
+        model.tts_eos_classifier = lambda hidden: mx.array([-100.0])
+        model.acoustic_tokenizer = FakeAcousticTokenizer()
+        model.speech_scaling_factor = mx.array(1.0)
+        model.speech_bias_factor = mx.array(0.0)
+
+        results = list(
+            model.generate(
+                "hello",
+                max_tokens=3,
+                stream=True,
+                streaming_interval=0.0,
+            )
+        )
+
+        audio_results = [result for result in results if result.samples > 0]
+        self.assertEqual(len(audio_results), 3)
+        self.assertTrue(all(result.is_streaming_chunk for result in results))
+        self.assertTrue(results[-1].is_final_chunk)
+
+        interval_results = list(
+            model.generate(
+                "hello",
+                max_tokens=3,
+                stream=True,
+                streaming_interval=0.5,
+            )
+        )
+        self.assertEqual(
+            [result.samples for result in interval_results if result.samples > 0],
+            [8, 4],
+        )
+        self.assertTrue(interval_results[-1].is_final_chunk)
+
+        non_streaming_results = list(model.generate("hello", max_tokens=3))
+        self.assertEqual(len(non_streaming_results), 1)
+        self.assertEqual(non_streaming_results[0].samples, 12)
+        self.assertFalse(non_streaming_results[0].is_streaming_chunk)
+
+    def test_streaming_causal_conv_matches_full_decode(self):
+        from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import CausalConv1d
+
+        layer = CausalConv1d(2, 3, kernel_size=3, bias=True)
+        layer.conv.weight = (
+            mx.arange(layer.conv.weight.size, dtype=mx.float32).reshape(
+                layer.conv.weight.shape
+            )
+            / 20.0
+        )
+        layer.conv.bias = mx.array([0.1, -0.2, 0.3], dtype=mx.float32)
+        inputs = mx.arange(12, dtype=mx.float32).reshape(1, 2, 6) / 10.0
+
+        expected = layer(inputs)
+        cache = {}
+        actual = mx.concatenate(
+            [
+                layer(inputs[:, :, :2], cache=cache),
+                layer(inputs[:, :, 2:], cache=cache),
+            ],
+            axis=2,
+        )
+
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+    def test_streaming_causal_conv_transpose_matches_full_decode(self):
+        from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import (
+            CausalConvTranspose1d,
+        )
+
+        layer = CausalConvTranspose1d(2, 3, kernel_size=4, stride=2, bias=True)
+        layer.convtr.weight = (
+            mx.arange(layer.convtr.weight.size, dtype=mx.float32).reshape(
+                layer.convtr.weight.shape
+            )
+            / 20.0
+        )
+        layer.convtr.bias = mx.array([0.1, -0.2, 0.3], dtype=mx.float32)
+        inputs = mx.arange(10, dtype=mx.float32).reshape(1, 2, 5) / 10.0
+
+        expected = layer(inputs)
+        cache = {}
+        actual = mx.concatenate(
+            [
+                layer(inputs[:, :, :2], cache=cache),
+                layer(inputs[:, :, 2:], cache=cache),
+            ],
+            axis=2,
+        )
+
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
+    def test_streaming_acoustic_tokenizer_matches_full_decode(self):
+        from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import (
+            AcousticTokenizer,
+        )
+        from mlx_audio.tts.models.vibevoice.config import AcousticTokenizerConfig
+
+        config = AcousticTokenizerConfig(
+            vae_dim=2,
+            channels=1,
+            encoder_n_filters=2,
+            decoder_n_filters=2,
+            encoder_ratios=[2],
+            decoder_ratios=[2],
+            encoder_depths="1-1",
+            decoder_depths="1-1",
+        )
+        tokenizer = AcousticTokenizer(config)
+        latents = mx.arange(10, dtype=mx.float32).reshape(1, 5, 2) / 10.0
+
+        expected = tokenizer.decode(latents)
+        cache = {}
+        actual = mx.concatenate(
+            [
+                tokenizer.decode(latents[:, :2], cache=cache),
+                tokenizer.decode(latents[:, 2:], cache=cache),
+            ],
+            axis=2,
+        )
+
+        np.testing.assert_allclose(actual, expected, rtol=1e-4, atol=1e-6)
+
 
 class TestChatterboxConfig(unittest.TestCase):
     def test_t3_config_defaults(self):

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -1479,12 +1479,74 @@ class TestVibeVoiceModel(unittest.TestCase):
             [result.samples for result in interval_results if result.samples > 0],
             [8, 4],
         )
+        self.assertEqual(
+            [result.token_count for result in interval_results],
+            [2, 1],
+        )
+        self.assertTrue(
+            all(result.prompt["tokens"] == 1 for result in interval_results)
+        )
         self.assertTrue(interval_results[-1].is_final_chunk)
 
         non_streaming_results = list(model.generate("hello", max_tokens=3))
         self.assertEqual(len(non_streaming_results), 1)
         self.assertEqual(non_streaming_results[0].samples, 12)
+        self.assertEqual(non_streaming_results[0].token_count, 3)
+        self.assertEqual(non_streaming_results[0].prompt["tokens"], 1)
         self.assertFalse(non_streaming_results[0].is_streaming_chunk)
+
+    def test_multi_speaker_streaming_has_one_final_chunk(self):
+        from mlx_audio.tts.models.base import GenerationResult
+        from mlx_audio.tts.models.vibevoice.vibevoice import Model
+
+        model = Model.__new__(Model)
+        model.tokenizer = object()
+        model.config = SimpleNamespace(sample_rate=24000)
+        model.load_voice = lambda voice: None
+
+        def fake_single_speaker(*, text, **kwargs):
+            yield GenerationResult(
+                audio=mx.array([len(text)], dtype=mx.float32),
+                samples=1,
+                sample_rate=24000,
+                segment_idx=0,
+                token_count=1,
+                audio_duration="00:00:00.000",
+                real_time_factor=1.0,
+                prompt={"tokens": len(text), "tokens-per-sec": 1.0},
+                audio_samples={"samples": 1, "samples-per-sec": 1.0},
+                processing_time_seconds=1.0,
+                peak_memory_usage=0.0,
+                is_streaming_chunk=True,
+                is_final_chunk=True,
+            )
+
+        model._generate_single_speaker = fake_single_speaker
+
+        results = list(
+            model.generate(
+                ["one", "second"],
+                voice=["speaker-a", "speaker-b"],
+                stream=True,
+            )
+        )
+
+        self.assertEqual([result.segment_idx for result in results], [0, 1])
+        self.assertEqual([result.samples for result in results], [1, 1])
+        self.assertEqual(
+            [result.is_final_chunk for result in results],
+            [False, True],
+        )
+
+        combined = list(
+            model.generate(
+                ["one", "second"],
+                voice=["speaker-a", "speaker-b"],
+            )
+        )
+        self.assertEqual(len(combined), 1)
+        self.assertEqual(combined[0].token_count, 2)
+        self.assertEqual(combined[0].prompt["tokens"], 9)
 
     def test_streaming_causal_conv_matches_full_decode(self):
         from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import CausalConv1d
@@ -1565,9 +1627,7 @@ class TestVibeVoiceModel(unittest.TestCase):
         np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
 
     def test_streaming_acoustic_tokenizer_matches_full_decode(self):
-        from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import (
-            AcousticTokenizer,
-        )
+        from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import AcousticTokenizer
         from mlx_audio.tts.models.vibevoice.config import AcousticTokenizerConfig
 
         config = AcousticTokenizerConfig(

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -1605,6 +1605,22 @@ class TestVibeVoiceModel(unittest.TestCase):
 
         np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
 
+    def test_streaming_causal_conv_transpose_rejects_nondefault_trim_ratio(self):
+        from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import (
+            CausalConvTranspose1d,
+        )
+
+        layer = CausalConvTranspose1d(
+            2,
+            3,
+            kernel_size=4,
+            stride=2,
+            trim_right_ratio=0.5,
+        )
+
+        with self.assertRaisesRegex(ValueError, "trim_right_ratio=1.0"):
+            layer(mx.ones((1, 2, 2)), cache={})
+
     def test_streaming_causal_conv_transpose_without_bias_matches_full_decode(self):
         from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import (
             CausalConvTranspose1d,

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -1464,6 +1464,7 @@ class TestVibeVoiceModel(unittest.TestCase):
 
         audio_results = [result for result in results if result.samples > 0]
         self.assertEqual(len(audio_results), 3)
+        self.assertEqual([result.segment_idx for result in results], [0, 0, 0, 0])
         self.assertTrue(all(result.is_streaming_chunk for result in results))
         self.assertTrue(results[-1].is_final_chunk)
 
@@ -1482,6 +1483,10 @@ class TestVibeVoiceModel(unittest.TestCase):
         self.assertEqual(
             [result.token_count for result in interval_results],
             [2, 1],
+        )
+        self.assertEqual(
+            [result.segment_idx for result in interval_results],
+            [0, 0],
         )
         self.assertTrue(
             all(result.prompt["tokens"] == 1 for result in interval_results)

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -1538,6 +1538,32 @@ class TestVibeVoiceModel(unittest.TestCase):
 
         np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
 
+    def test_streaming_causal_conv_transpose_without_bias_matches_full_decode(self):
+        from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import (
+            CausalConvTranspose1d,
+        )
+
+        layer = CausalConvTranspose1d(2, 3, kernel_size=4, stride=2, bias=False)
+        layer.convtr.weight = (
+            mx.arange(layer.convtr.weight.size, dtype=mx.float32).reshape(
+                layer.convtr.weight.shape
+            )
+            / 20.0
+        )
+        inputs = mx.arange(10, dtype=mx.float32).reshape(1, 2, 5) / 10.0
+
+        expected = layer(inputs)
+        cache = {}
+        actual = mx.concatenate(
+            [
+                layer(inputs[:, :, :2], cache=cache),
+                layer(inputs[:, :, 2:], cache=cache),
+            ],
+            axis=2,
+        )
+
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-6)
+
     def test_streaming_acoustic_tokenizer_matches_full_decode(self):
         from mlx_audio.tts.models.vibevoice.acoustic_tokenizer import (
             AcousticTokenizer,


### PR DESCRIPTION
## Context

MLX Audio's TTS generation interface exposes `stream=True` for incremental audio output, but VibeVoice currently accumulates every generated speech latent, decodes the full sequence once, and yields a single final result. This prevents callers from receiving audio while the utterance is still being generated, even when they use the documented streaming interface.

## Description

This PR adds true streaming generation to the existing VibeVoice implementation.

VibeVoice now collects generated speech latents up to a configurable streaming interval, incrementally decodes each batch through the acoustic tokenizer, and yields marked audio chunks as they become available. The acoustic decoder preserves causal convolution context and transposed-convolution overlap between calls so concatenated streamed output follows the same decoding path as one-shot output.

Non-streaming acoustic generation retains the existing one-shot behavior. Both modes now distinguish generated acoustic units from input prompt-token metadata.

## Changes in the codebase

- pass `stream` and `streaming_interval` through the single-speaker and multi-speaker VibeVoice generation paths
- incrementally decode speech latents and emit `GenerationResult` chunks with streaming/final markers
- preserve semantic segment identity and one terminal result across multi-speaker dialogue while keeping generated-unit accounting distinct from prompt-token metadata
- when generation ends exactly on a streaming interval, emit a terminal result that may carry no additional samples
- add per-generation causal convolution and transposed-convolution caches to the acoustic tokenizer decoder
- fail loudly when cached transposed-convolution streaming is requested with a non-default trim ratio that only one-shot decode implements
- make the public acoustic-tokenizer decode boundary explicitly consume its documented `(batch, time, dimension)` layout
- cover chunk timing, segment identity, terminal flush behavior, multi-speaker termination and metadata, streaming-disabled behavior, causal-cache parity, bias-free convolution, and full tokenizer stream/one-shot parity with focused tests

## Changes outside the codebase

None.

## Additional information

- The focused VibeVoice suite passes all 14 tests.
- Using `mlx-community/VibeVoice-Realtime-0.5B-6bit@b964f7a`, concatenated streaming and one-shot output each contained 64,000 samples with maximum absolute difference `7.90e-07`. Streaming emitted seven results and exactly one final marker.
- A multi-speaker smoke streamed `en-Emma_woman` followed by `en-Mike_man`, preserved both segment indices, and emitted exactly one final marker for the complete call.
- Single-speaker chunks retain segment index `0`; multi-speaker generation assigns dialogue segment indices at the coordinator boundary.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Issue referenced
