### PR TITLE
fix(stt): process every Qwen3-ASR list input

### DIFF
--- a/mlx_audio/stt/models/mega_asr/mega_asr.py
+++ b/mlx_audio/stt/models/mega_asr/mega_asr.py
@@ -88,6 +88,28 @@ class Model:
             self._lora_active = False
 
     def generate(self, audio, **kwargs):
+        if isinstance(audio, list):
+            if kwargs.get("stream"):
+                raise ValueError("Streaming does not support a list of audio inputs")
+
+            language = kwargs.pop("language", None)
+            if isinstance(language, list):
+                if len(language) == 1:
+                    languages = language * len(audio)
+                elif len(language) != len(audio):
+                    raise ValueError(
+                        "language and audio must contain the same number of items"
+                    )
+                else:
+                    languages = language
+            else:
+                languages = [language] * len(audio)
+
+            return [
+                self.generate(audio_input, language=input_language, **kwargs)
+                for audio_input, input_language in zip(audio, languages)
+            ]
+
         route = self._router.route(audio)
         self._set_lora(bool(route["use_lora"]))
         return self._asr.generate(audio, **kwargs)

--- a/mlx_audio/stt/models/qwen3_asr/README.md
+++ b/mlx_audio/stt/models/qwen3_asr/README.md
@@ -56,6 +56,25 @@ for segment in result.segments:
     print(f"[{segment['start']:.2f}s - {segment['end']:.2f}s] {segment['text']}")
 ```
 
+### Batch Transcription
+
+```python
+from mlx_audio.stt import load
+
+model = load("mlx-community/Qwen3-ASR-0.6B-8bit")
+
+results = model.generate(
+    ["audio1.wav", "audio2.wav"],
+    language=["English", "French"],
+)
+
+for result in results:
+    print(result.text)
+```
+
+A single language is applied to every input. Streaming accepts only one audio
+input at a time.
+
 ### Streaming Transcription
 
 ```python

--- a/mlx_audio/stt/models/qwen3_asr/README.md
+++ b/mlx_audio/stt/models/qwen3_asr/README.md
@@ -56,7 +56,7 @@ for segment in result.segments:
     print(f"[{segment['start']:.2f}s - {segment['end']:.2f}s] {segment['text']}")
 ```
 
-### Batch Transcription
+### Multiple-input Transcription
 
 ```python
 from mlx_audio.stt import load
@@ -72,8 +72,9 @@ for result in results:
     print(result.text)
 ```
 
-A single language is applied to every input. Streaming accepts only one audio
-input at a time.
+Inputs are processed independently and serially. ``batch_size`` only batches
+chunks within one input. A single language is applied to every input. Streaming
+accepts only one audio input at a time.
 
 ### Streaming Transcription
 

--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -1292,11 +1292,14 @@ class Qwen3ASRModel(nn.Module):
             raise ValueError("Streaming does not support a list of audio inputs")
 
         if isinstance(language, list):
-            if len(language) != len(audio):
+            if len(language) == 1:
+                languages = language * len(audio)
+            elif len(language) != len(audio):
                 raise ValueError(
                     "language and audio must contain the same number of items"
                 )
-            languages = language
+            else:
+                languages = language
         else:
             languages = [language] * len(audio)
 

--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -871,19 +871,17 @@ class Qwen3ASRModel(nn.Module):
 
     def _preprocess_audio(
         self,
-        audio: Union[str, mx.array, np.ndarray, List[Union[str, mx.array, np.ndarray]]],
+        audio: Union[str, mx.array, np.ndarray],
     ) -> Tuple[mx.array, mx.array, int]:
         """Preprocess audio for the model."""
         from mlx_audio.stt.utils import load_audio
 
-        audio_input = audio[0] if isinstance(audio, list) else audio
+        if isinstance(audio, list):
+            raise ValueError("Audio preprocessing expects one input")
+        if isinstance(audio, str):
+            audio = load_audio(audio)
 
-        if isinstance(audio_input, str):
-            audio_input = load_audio(audio_input)
-
-        audio_np = (
-            np.array(audio_input) if isinstance(audio_input, mx.array) else audio_input
-        )
+        audio_np = np.array(audio) if isinstance(audio, mx.array) else audio
 
         audio_inputs = self._feature_extractor(
             audio_np,
@@ -948,7 +946,7 @@ class Qwen3ASRModel(nn.Module):
 
     def stream_generate(
         self,
-        audio: Union[str, mx.array, np.ndarray, List[Union[str, mx.array, np.ndarray]]],
+        audio: Union[str, mx.array, np.ndarray],
         *,
         max_tokens: int = 8192,
         sampler: Optional[Callable[[mx.array], mx.array]] = None,
@@ -1239,6 +1237,107 @@ class Qwen3ASRModel(nn.Module):
         min_tokens_to_keep: int = 1,
         repetition_penalty: Optional[float] = None,
         repetition_context_size: int = 100,
+        language: Union[Optional[str], List[Optional[str]]] = None,
+        prefill_step_size: int = 2048,
+        chunk_duration: float = 1200.0,
+        min_chunk_duration: float = 1.0,
+        verbose: bool = False,
+        stream: bool = False,
+        system_prompt: str | None = None,
+        hotwords: Optional[List[str]] = None,
+        **kwargs,
+    ) -> Union[STTOutput, List[STTOutput], Generator[StreamingResult, None, None]]:
+        """Generate transcription from one audio input or a list of inputs.
+
+        Lists are processed independently in input order. ``batch_size`` still
+        controls parallel decoding of chunks within each input. Streaming a
+        list is not supported.
+
+        Args:
+            chunk_duration: Maximum chunk duration in seconds (default: 1200 = 20 min).
+            min_chunk_duration: Minimum chunk duration in seconds (default: 1.0).
+            stream: If True, return a generator that yields tokens as they are generated.
+            hotwords: Optional vocabulary/hotword list, folded into ``system_prompt``.
+        """
+        if not isinstance(audio, list):
+            if isinstance(language, list):
+                if len(language) != 1:
+                    raise ValueError(
+                        "language must contain one item for a single audio input"
+                    )
+                language = language[0]
+            return self._generate_one(
+                audio,
+                max_tokens=max_tokens,
+                batch_size=batch_size,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                min_p=min_p,
+                min_tokens_to_keep=min_tokens_to_keep,
+                repetition_penalty=repetition_penalty,
+                repetition_context_size=repetition_context_size,
+                language=language,
+                prefill_step_size=prefill_step_size,
+                chunk_duration=chunk_duration,
+                min_chunk_duration=min_chunk_duration,
+                verbose=verbose,
+                stream=stream,
+                system_prompt=system_prompt,
+                hotwords=hotwords,
+                **kwargs,
+            )
+
+        if stream:
+            raise ValueError("Streaming does not support a list of audio inputs")
+
+        if isinstance(language, list):
+            if len(language) != len(audio):
+                raise ValueError(
+                    "language and audio must contain the same number of items"
+                )
+            languages = language
+        else:
+            languages = [language] * len(audio)
+
+        return [
+            self._generate_one(
+                audio_input,
+                max_tokens=max_tokens,
+                batch_size=batch_size,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                min_p=min_p,
+                min_tokens_to_keep=min_tokens_to_keep,
+                repetition_penalty=repetition_penalty,
+                repetition_context_size=repetition_context_size,
+                language=input_language,
+                prefill_step_size=prefill_step_size,
+                chunk_duration=chunk_duration,
+                min_chunk_duration=min_chunk_duration,
+                verbose=verbose,
+                stream=False,
+                system_prompt=system_prompt,
+                hotwords=hotwords,
+                **kwargs,
+            )
+            for audio_input, input_language in zip(audio, languages)
+        ]
+
+    def _generate_one(
+        self,
+        audio: Union[str, mx.array, np.ndarray],
+        *,
+        max_tokens: int = 8192,
+        batch_size: int = 1,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        top_k: int = 0,
+        min_p: float = 0.0,
+        min_tokens_to_keep: int = 1,
+        repetition_penalty: Optional[float] = None,
+        repetition_context_size: int = 100,
         language: Optional[str] = None,
         prefill_step_size: int = 2048,
         chunk_duration: float = 1200.0,
@@ -1248,17 +1347,8 @@ class Qwen3ASRModel(nn.Module):
         system_prompt: str | None = None,
         hotwords: Optional[List[str]] = None,
         **kwargs,
-    ) -> Union[STTOutput, Generator[str, None, None]]:
-        """Generate transcription from audio.
-
-        Automatically chunks long audio and processes sequentially.
-
-        Args:
-            chunk_duration: Maximum chunk duration in seconds (default: 1200 = 20 min).
-            min_chunk_duration: Minimum chunk duration in seconds (default: 1.0).
-            stream: If True, return a generator that yields tokens as they are generated.
-            hotwords: Optional vocabulary/hotword list, folded into ``system_prompt``.
-        """
+    ) -> Union[STTOutput, Generator[StreamingResult, None, None]]:
+        """Generate transcription from one audio input."""
         from mlx_audio.stt.utils import merge_hotwords
 
         # Qwen3-ASR biases toward rare vocabulary via the system prompt.
@@ -1302,12 +1392,9 @@ class Qwen3ASRModel(nn.Module):
             )
 
         # Load audio
-        audio_input = audio[0] if isinstance(audio, list) else audio
-        if isinstance(audio_input, str):
-            audio_input = load_audio(audio_input)
-        audio_np = (
-            np.array(audio_input) if isinstance(audio_input, mx.array) else audio_input
-        )
+        if isinstance(audio, str):
+            audio = load_audio(audio)
+        audio_np = np.array(audio) if isinstance(audio, mx.array) else audio
 
         # Split into chunks if needed
         chunks = split_audio_into_chunks(
@@ -1442,7 +1529,7 @@ class Qwen3ASRModel(nn.Module):
 
     def stream_transcribe(
         self,
-        audio: Union[str, mx.array, np.ndarray, List[Union[str, mx.array, np.ndarray]]],
+        audio: Union[str, mx.array, np.ndarray],
         *,
         max_tokens: int = 8192,
         temperature: float = 0.0,
@@ -1476,12 +1563,11 @@ class Qwen3ASRModel(nn.Module):
             )
 
         # Load audio
-        audio_input = audio[0] if isinstance(audio, list) else audio
-        if isinstance(audio_input, str):
-            audio_input = load_audio(audio_input)
-        audio_np = (
-            np.array(audio_input) if isinstance(audio_input, mx.array) else audio_input
-        )
+        if isinstance(audio, list):
+            raise ValueError("Streaming does not support a list of audio inputs")
+        if isinstance(audio, str):
+            audio = load_audio(audio)
+        audio_np = np.array(audio) if isinstance(audio, mx.array) else audio
 
         # Calculate total audio duration
         total_duration = len(audio_np) / self.sample_rate

--- a/mlx_audio/stt/tests/mega_asr/test_routed_generate.py
+++ b/mlx_audio/stt/tests/mega_asr/test_routed_generate.py
@@ -149,6 +149,31 @@ def test_generate_routes_before_delegating():
     assert routed and routed[0] is audio
 
 
+def test_generate_routes_list_items_independently():
+    model, _, _, calls = _build()
+    first_audio = mx.zeros((8000,))
+    second_audio = mx.ones((8000,))
+    routed = []
+    routes = iter([False, True])
+
+    def fake_route(wav):
+        routed.append(wav)
+        return {"use_lora": next(routes)}
+
+    setattr(model._router, "route", fake_route)
+
+    outputs = model.generate(
+        [first_audio, second_audio],
+        language=["English"],
+    )
+
+    assert outputs == [SENTINEL, SENTINEL]
+    assert routed == [first_audio, second_audio]
+    assert [call[0] for call in calls] == [first_audio, second_audio]
+    assert [call[1]["language"] for call in calls] == ["English", "English"]
+    assert model._lora_active is True
+
+
 def test_stream_transcribe_routes_and_delegates():
     model, base, delta, _ = _build()
     _set_route(model, True)

--- a/mlx_audio/stt/tests/test_qwen3_asr_batched.py
+++ b/mlx_audio/stt/tests/test_qwen3_asr_batched.py
@@ -38,6 +38,23 @@ class _FakeTextModel:
         return inputs_embeds
 
 
+def _make_minimal_model():
+    model = Qwen3ASRModel.__new__(Qwen3ASRModel)
+    model.config = SimpleNamespace(
+        text_config=SimpleNamespace(num_hidden_layers=0),
+    )
+    model._tokenizer = _FakeTokenizer()
+    model._feature_extractor = object()
+    model.model = _FakeTextModel()
+    model.lm_head = None
+    model.get_audio_features = Mock(return_value=mx.zeros((1, 1)))
+    model._preprocess_audio = Mock(return_value=(mx.zeros((1, 1)), None, 1))
+    model._build_prompt = Mock(return_value=mx.array([[0]]))
+    model._build_inputs_embeds = Mock(return_value=mx.zeros((1, 1, 1)))
+    model._forward_with_embeds = Mock(return_value=mx.zeros((2, 1, 128)))
+    return model
+
+
 class TestRopeSafe(unittest.TestCase):
     """Regression test for the mx.fast.rope batched single-token bug.
 
@@ -68,20 +85,7 @@ class TestRopeSafe(unittest.TestCase):
 
 class TestBatchedGeneration(unittest.TestCase):
     def make_minimal_model(self):
-        model = Qwen3ASRModel.__new__(Qwen3ASRModel)
-        model.config = SimpleNamespace(
-            text_config=SimpleNamespace(num_hidden_layers=0),
-        )
-        model._tokenizer = _FakeTokenizer()
-        model._feature_extractor = object()
-        model.model = _FakeTextModel()
-        model.lm_head = None
-        model.get_audio_features = Mock(return_value=mx.zeros((1, 1)))
-        model._preprocess_audio = Mock(return_value=(mx.zeros((1, 1)), None, 1))
-        model._build_prompt = Mock(return_value=mx.array([[0]]))
-        model._build_inputs_embeds = Mock(return_value=mx.zeros((1, 1, 1)))
-        model._forward_with_embeds = Mock(return_value=mx.zeros((2, 1, 128)))
-        return model
+        return _make_minimal_model()
 
     def test_batched_generation_respects_global_token_budget(self):
         model = self.make_minimal_model()
@@ -226,11 +230,46 @@ class TestListInputGeneration(unittest.TestCase):
         self.assertEqual(output.text, "single.wav")
         model._generate_one.assert_called_once()
 
+    def test_singleton_language_list_is_broadcast(self):
+        model = self.make_model()
+
+        model.generate(["first.wav", "second.wav"], language=["English"])
+
+        self.assertEqual(
+            [call.kwargs["language"] for call in model._generate_one.call_args_list],
+            ["English", "English"],
+        )
+
     def test_language_count_must_match_audio_count(self):
         model = self.make_model()
 
         with self.assertRaisesRegex(ValueError, "same number"):
-            model.generate(["first.wav", "second.wav"], language=["English"])
+            model.generate(
+                ["first.wav", "second.wav"],
+                language=["English", "French", "German"],
+            )
+
+    def test_numpy_list_uses_scalar_generation_path(self):
+        model = _make_minimal_model()
+        model._generate_single_chunk = Mock(
+            side_effect=[("first", 5, 1), ("second", 5, 1)]
+        )
+        first_audio = np.ones(16000, dtype=np.float32)
+        second_audio = np.full(16000, 2, dtype=np.float32)
+
+        outputs = model.generate(
+            [first_audio, second_audio],
+            language=["English"],
+        )
+
+        self.assertEqual([output.text for output in outputs], ["first", "second"])
+        calls = model._generate_single_chunk.call_args_list
+        np.testing.assert_array_equal(calls[0].args[0], first_audio)
+        np.testing.assert_array_equal(calls[1].args[0], second_audio)
+        self.assertEqual(
+            [call.kwargs["language"] for call in calls],
+            ["English", "English"],
+        )
 
     def test_list_input_rejects_streaming(self):
         model = self.make_model()

--- a/mlx_audio/stt/tests/test_qwen3_asr_batched.py
+++ b/mlx_audio/stt/tests/test_qwen3_asr_batched.py
@@ -6,6 +6,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
+from mlx_audio.stt.models.base import STTOutput
 from mlx_audio.stt.models.qwen3_asr.qwen3_asr import Qwen3ASRModel, _rope_safe
 
 
@@ -173,6 +174,83 @@ class TestBatchedGeneration(unittest.TestCase):
         self.assertIsNone(
             model._generate_chunks_batched.call_args.kwargs["logits_processors"]
         )
+
+
+class TestListInputGeneration(unittest.TestCase):
+    def make_model(self):
+        model = Qwen3ASRModel.__new__(Qwen3ASRModel)
+        model._generate_one = Mock(
+            side_effect=lambda audio, **kwargs: STTOutput(text=audio)
+        )
+        return model
+
+    def test_list_input_processes_every_item_in_order(self):
+        model = self.make_model()
+
+        outputs = model.generate(
+            ["first.wav", "second.wav"],
+            language=["English", "French"],
+            max_tokens=17,
+            custom_option=True,
+        )
+
+        self.assertEqual(
+            [output.text for output in outputs], ["first.wav", "second.wav"]
+        )
+        self.assertEqual(model._generate_one.call_count, 2)
+        first, second = model._generate_one.call_args_list
+        self.assertEqual(first.args, ("first.wav",))
+        self.assertEqual(first.kwargs["language"], "English")
+        self.assertEqual(second.args, ("second.wav",))
+        self.assertEqual(second.kwargs["language"], "French")
+        self.assertEqual(first.kwargs["max_tokens"], 17)
+        self.assertTrue(first.kwargs["custom_option"])
+        self.assertEqual(second.kwargs["max_tokens"], 17)
+
+    def test_scalar_language_is_broadcast(self):
+        model = self.make_model()
+
+        model.generate(["first.wav", "second.wav"], language="English")
+
+        self.assertEqual(
+            [call.kwargs["language"] for call in model._generate_one.call_args_list],
+            ["English", "English"],
+        )
+
+    def test_single_input_still_returns_one_output(self):
+        model = self.make_model()
+
+        output = model.generate("single.wav", language=["English"])
+
+        self.assertIsInstance(output, STTOutput)
+        self.assertEqual(output.text, "single.wav")
+        model._generate_one.assert_called_once()
+
+    def test_language_count_must_match_audio_count(self):
+        model = self.make_model()
+
+        with self.assertRaisesRegex(ValueError, "same number"):
+            model.generate(["first.wav", "second.wav"], language=["English"])
+
+    def test_list_input_rejects_streaming(self):
+        model = self.make_model()
+
+        with self.assertRaisesRegex(ValueError, "Streaming"):
+            model.generate(["first.wav", "second.wav"], stream=True)
+
+        model._generate_one.assert_not_called()
+
+    def test_preprocessing_rejects_list_input(self):
+        model = self.make_model()
+
+        with self.assertRaisesRegex(ValueError, "one input"):
+            model._preprocess_audio(["first.wav", "second.wav"])
+
+    def test_empty_list_returns_empty_list(self):
+        model = self.make_model()
+
+        self.assertEqual(model.generate([]), [])
+        model._generate_one.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #926.

`Qwen3ASRModel.generate()` is typed to accept a list of audio inputs, but the MLX implementation selects `audio[0]` in several paths and silently discards the rest. This change processes every list item and returns one `STTOutput` per input, in order.

## Changes

- Extract the existing scalar generation path into `_generate_one()`.
- Preserve the scalar-input return type.
- Process list inputs independently and preserve their order.
- Broadcast a scalar or one-item language list, or validate a per-item language list.
- Give each input its own `max_tokens` budget.
- Return `[]` for an empty list.
- Reject list input in streaming and low-level preprocessing instead of silently selecting the first item.
- Route Mega-ASR list items independently before selecting its LoRA state.
- Add dispatch, helper-path, routing, and API regression tests.

## Scope

This is correctness-first serial processing. It does not decode several audio sources in one model batch. `batch_size` still batches chunks within one input.

## Validation

- Focused Qwen3-ASR and Mega-ASR tests: 20 passed.
- Full STT suite: 287 passed, 9 skipped, 18 subtests passed.
- Black, isort, and `git diff --check` passed.
- A real `Qwen3-ASR-0.6B-4bit` run returned two separate outputs in input order.
