### PR TITLE
fix(stt): stop fabricating Qwen3-ASR stream timestamps

### DIFF
--- a/mlx_audio/stt/generate.py
+++ b/mlx_audio/stt/generate.py
@@ -214,11 +214,16 @@ def save_as_json(segments, output_path: str):
             "segments": [],
         }
         for s in segments.segments:
+            duration = (
+                s["end"] - s["start"]
+                if s["start"] is not None and s["end"] is not None
+                else None
+            )
             seg = {
                 "text": s["text"],
                 "start": s["start"],
                 "end": s["end"],
-                "duration": s["end"] - s["start"],
+                "duration": duration,
             }
             # Add word-level timestamps if available
             if "words" in s and s["words"]:
@@ -294,6 +299,7 @@ def generate_transcription(
         all_segments = []
         accumulated_text = ""
         pending_text = ""
+        pending_is_final = False
         language = "en"
         prompt_tokens = 0
         generation_tokens = 0
@@ -301,6 +307,7 @@ def generate_transcription(
             # Accumulate text (handles both incremental and cumulative streaming)
             accumulated_text += result.text
             pending_text += result.text
+            pending_is_final = pending_is_final or result.is_final
             language = result.language
 
             # Untimed text is committed when the model emits a timed boundary.
@@ -317,12 +324,25 @@ def generate_transcription(
                         }
                     )
                 pending_text = ""
+                pending_is_final = False
 
             # Extract token counts from results (final result has cumulative totals)
             if hasattr(result, "prompt_tokens") and result.prompt_tokens > 0:
                 prompt_tokens = result.prompt_tokens
             if hasattr(result, "generation_tokens") and result.generation_tokens > 0:
                 generation_tokens = result.generation_tokens
+
+        if pending_text:
+            if format in {"srt", "vtt"}:
+                raise ValueError("Cannot write untimed streaming text as SRT or VTT")
+            all_segments.append(
+                {
+                    "text": pending_text,
+                    "start": None,
+                    "end": None,
+                    "is_final": pending_is_final,
+                }
+            )
 
         stream_end_time = time.time()
         stream_duration = stream_end_time - start_time

--- a/mlx_audio/stt/generate.py
+++ b/mlx_audio/stt/generate.py
@@ -293,21 +293,30 @@ def generate_transcription(
     if kwargs.get("stream", False):
         all_segments = []
         accumulated_text = ""
+        pending_text = ""
         language = "en"
         prompt_tokens = 0
         generation_tokens = 0
         for result in model.generate(audio, verbose=verbose, **kwargs):
-            segment_dict = {
-                "text": result.text,
-                "start": result.start_time,
-                "end": result.end_time,
-                "is_final": result.is_final,
-            }
-
-            all_segments.append(segment_dict)
             # Accumulate text (handles both incremental and cumulative streaming)
             accumulated_text += result.text
+            pending_text += result.text
             language = result.language
+
+            # Untimed text is committed when the model emits a timed boundary.
+            # Qwen3-ASR exposes coarse chunk boundaries because generated tokens
+            # do not carry real audio alignment.
+            if result.start_time is not None and result.end_time is not None:
+                if pending_text or result.is_final:
+                    all_segments.append(
+                        {
+                            "text": pending_text,
+                            "start": result.start_time,
+                            "end": result.end_time,
+                            "is_final": result.is_final,
+                        }
+                    )
+                pending_text = ""
 
             # Extract token counts from results (final result has cumulative totals)
             if hasattr(result, "prompt_tokens") and result.prompt_tokens > 0:

--- a/mlx_audio/stt/models/qwen3_asr/README.md
+++ b/mlx_audio/stt/models/qwen3_asr/README.md
@@ -63,9 +63,13 @@ from mlx_audio.stt import load
 
 model = load("mlx-community/Qwen3-ASR-0.6B-8bit")
 
-# Stream tokens as they're generated
-for text in model.stream_transcribe("audio.wav", language="English"):
-    print(text, end="", flush=True)
+# Text deltas do not have timestamps. Empty-text events carry coarse audio
+# chunk extents; use the forced aligner below for text-level timestamps.
+for event in model.stream_transcribe("audio.wav", language="English"):
+    if event.text:
+        print(event.text, end="", flush=True)
+    elif event.start_time is not None:
+        print(f"\nchunk: {event.start_time:.2f}s - {event.end_time:.2f}s")
 ```
 
 ### Forced Alignment

--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -24,8 +24,8 @@ class StreamingResult:
     Attributes:
         text: Decoded text for this emission.
         is_final: True if this is a final (committed) result, False if partial.
-        start_time: Start timestamp in seconds.
-        end_time: End timestamp in seconds.
+        start_time: Start timestamp in seconds, or None for untimed text.
+        end_time: End timestamp in seconds, or None for untimed text.
         language: Language of the transcription.
         prompt_tokens: Total prompt tokens (only set on final result).
         generation_tokens: Total generation tokens (only set on final result).
@@ -33,8 +33,8 @@ class StreamingResult:
 
     text: str
     is_final: bool
-    start_time: float
-    end_time: float
+    start_time: Optional[float]
+    end_time: Optional[float]
     language: str = "en"
     prompt_tokens: int = 0
     generation_tokens: int = 0
@@ -1556,20 +1556,13 @@ class Qwen3ASRModel(nn.Module):
                         language, _ = self.extract_language(language_accumulator)
                     continue
 
-                # Estimate timing based on token position within chunk
-                # This is approximate since we don't have word-level alignment
-                prev_progress = token_count / max(remaining_tokens, 1)
                 token_count += 1
-                curr_progress = min(token_count / max(remaining_tokens, 1), 1.0)
-
-                estimated_start = offset_sec + (actual_chunk_duration * prev_progress)
-                estimated_end = offset_sec + (actual_chunk_duration * curr_progress)
 
                 yield StreamingResult(
                     text=text,
                     is_final=False,
-                    start_time=estimated_start,
-                    end_time=estimated_end,
+                    start_time=None,
+                    end_time=None,
                     language=language,
                 )
 

--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -19,13 +19,13 @@ from .config import AudioEncoderConfig, ModelConfig, TextConfig
 
 @dataclass
 class StreamingResult:
-    """Result object for streaming transcription.
+    """Text-delta or chunk-boundary event from streaming transcription.
 
     Attributes:
         text: Decoded text for this emission.
         is_final: True if this is a final (committed) result, False if partial.
-        start_time: Start timestamp in seconds, or None for untimed text.
-        end_time: End timestamp in seconds, or None for untimed text.
+        start_time: Chunk start in seconds, or None for a text delta.
+        end_time: Chunk end in seconds, or None for a text delta.
         language: Language of the transcription.
         prompt_tokens: Total prompt tokens (only set on final result).
         generation_tokens: Total generation tokens (only set on final result).
@@ -38,6 +38,13 @@ class StreamingResult:
     language: str = "en"
     prompt_tokens: int = 0
     generation_tokens: int = 0
+
+
+def _audio_duration(wav: np.ndarray, sr: int) -> float:
+    """Return the duration before model-only padding is applied."""
+    if wav.ndim > 1 and wav.shape[-1] > 2:
+        return wav.shape[-1] / sr
+    return len(wav) / sr
 
 
 def split_audio_into_chunks(
@@ -1483,8 +1490,8 @@ class Qwen3ASRModel(nn.Module):
             np.array(audio_input) if isinstance(audio_input, mx.array) else audio_input
         )
 
-        # Calculate total audio duration
-        total_duration = len(audio_np) / self.sample_rate
+        # Calculate duration before model-only padding.
+        total_duration = _audio_duration(audio_np, self.sample_rate)
 
         # Split into chunks if needed
         chunks = split_audio_into_chunks(
@@ -1526,7 +1533,10 @@ class Qwen3ASRModel(nn.Module):
             disable=not verbose or len(chunks) == 1,
         )
         for chunk_idx, (chunk_audio, offset_sec) in chunk_iter:
-            actual_chunk_duration = len(chunk_audio) / self.sample_rate
+            actual_chunk_duration = min(
+                len(chunk_audio) / self.sample_rate,
+                max(total_duration - offset_sec, 0.0),
+            )
             is_last_chunk = chunk_idx == len(chunks) - 1
             token_count = 0
 

--- a/mlx_audio/stt/tests/test_qwen3_asr_batched.py
+++ b/mlx_audio/stt/tests/test_qwen3_asr_batched.py
@@ -175,5 +175,43 @@ class TestBatchedGeneration(unittest.TestCase):
         )
 
 
+class TestStreamingTimestamps(unittest.TestCase):
+    def make_minimal_model(self):
+        model = Qwen3ASRModel.__new__(Qwen3ASRModel)
+        model._tokenizer = _FakeTokenizer()
+        model._feature_extractor = object()
+        model._preprocess_audio = Mock(return_value=(mx.zeros((1, 1)), None, 1))
+        model._build_prompt = Mock(return_value=mx.array([[0]]))
+
+        def stream_generate(*args, **kwargs):
+            yield mx.array(10), mx.zeros((1,))
+            yield mx.array(11), mx.zeros((1,))
+
+        model.stream_generate = stream_generate
+        return model
+
+    def test_partial_tokens_are_untimed_for_any_generation_budget(self):
+        model = self.make_minimal_model()
+        audio = np.zeros(16000, dtype=np.float32)
+
+        for max_tokens in (64, 8192):
+            results = list(
+                model.stream_transcribe(
+                    audio,
+                    max_tokens=max_tokens,
+                    language="English",
+                )
+            )
+
+            self.assertEqual([result.text for result in results], ["10", "11", ""])
+            self.assertIsNone(results[0].start_time)
+            self.assertIsNone(results[0].end_time)
+            self.assertIsNone(results[1].start_time)
+            self.assertIsNone(results[1].end_time)
+            self.assertEqual(results[2].start_time, 0.0)
+            self.assertEqual(results[2].end_time, 1.0)
+            self.assertEqual(results[2].generation_tokens, 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mlx_audio/stt/tests/test_qwen3_asr_batched.py
+++ b/mlx_audio/stt/tests/test_qwen3_asr_batched.py
@@ -212,6 +212,21 @@ class TestStreamingTimestamps(unittest.TestCase):
             self.assertEqual(results[2].end_time, 1.0)
             self.assertEqual(results[2].generation_tokens, 2)
 
+    def test_short_audio_boundary_uses_unpadded_duration(self):
+        model = self.make_minimal_model()
+
+        results = list(
+            model.stream_transcribe(
+                np.zeros(3200, dtype=np.float32),
+                max_tokens=64,
+                min_chunk_duration=1.0,
+                language="English",
+            )
+        )
+
+        self.assertEqual(results[-1].start_time, 0.0)
+        self.assertEqual(results[-1].end_time, 0.2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/mlx_audio/stt/tests/test_streaming_cli.py
+++ b/mlx_audio/stt/tests/test_streaming_cli.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from mlx_audio.stt.generate import generate_transcription
 from mlx_audio.stt.models.qwen3_asr.qwen3_asr import StreamingResult
 
@@ -36,6 +38,18 @@ class _StreamingModel:
             language="English",
             prompt_tokens=5,
             generation_tokens=2,
+        )
+
+
+class _UntimedFinalModel:
+    def generate(self, audio, *, stream=False, verbose=False):
+        assert stream
+        yield StreamingResult(
+            text="Hello",
+            is_final=True,
+            start_time=None,
+            end_time=None,
+            language="English",
         )
 
 
@@ -84,3 +98,41 @@ def test_streaming_cli_groups_untimed_text_at_timed_boundary(tmp_path):
             "duration": 1.0,
         },
     ]
+
+
+def test_streaming_cli_preserves_untimed_final_text_in_json(tmp_path):
+    output_path = tmp_path / "transcript"
+
+    result = generate_transcription(
+        model=_UntimedFinalModel(),
+        audio="ignored.wav",
+        output_path=str(output_path),
+        format="json",
+        stream=True,
+    )
+
+    assert result.text == "Hello"
+    assert result.segments == [
+        {
+            "text": "Hello",
+            "start": None,
+            "end": None,
+            "is_final": True,
+        }
+    ]
+    saved = json.loads(output_path.with_suffix(".json").read_text())
+    assert saved["segments"] == [
+        {"text": "Hello", "start": None, "end": None, "duration": None}
+    ]
+
+
+@pytest.mark.parametrize("output_format", ["srt", "vtt"])
+def test_streaming_cli_rejects_untimed_subtitles(tmp_path, output_format):
+    with pytest.raises(ValueError, match="untimed streaming text"):
+        generate_transcription(
+            model=_UntimedFinalModel(),
+            audio="ignored.wav",
+            output_path=str(tmp_path / "transcript"),
+            format=output_format,
+            stream=True,
+        )

--- a/mlx_audio/stt/tests/test_streaming_cli.py
+++ b/mlx_audio/stt/tests/test_streaming_cli.py
@@ -1,0 +1,86 @@
+import json
+
+from mlx_audio.stt.generate import generate_transcription
+from mlx_audio.stt.models.qwen3_asr.qwen3_asr import StreamingResult
+
+
+class _StreamingModel:
+    def generate(self, audio, *, stream=False, verbose=False):
+        assert stream
+        yield StreamingResult(
+            text="Hello",
+            is_final=False,
+            start_time=None,
+            end_time=None,
+            language="English",
+        )
+        yield StreamingResult(
+            text="",
+            is_final=False,
+            start_time=0.0,
+            end_time=1.0,
+            language="English",
+        )
+        yield StreamingResult(
+            text=" world",
+            is_final=False,
+            start_time=None,
+            end_time=None,
+            language="English",
+        )
+        yield StreamingResult(
+            text="",
+            is_final=True,
+            start_time=1.0,
+            end_time=2.0,
+            language="English",
+            prompt_tokens=5,
+            generation_tokens=2,
+        )
+
+
+def test_streaming_cli_groups_untimed_text_at_timed_boundary(tmp_path):
+    output_path = tmp_path / "transcript"
+
+    result = generate_transcription(
+        model=_StreamingModel(),
+        audio="ignored.wav",
+        output_path=str(output_path),
+        format="json",
+        stream=True,
+    )
+
+    assert result.text == "Hello world"
+    assert result.segments == [
+        {
+            "text": "Hello",
+            "start": 0.0,
+            "end": 1.0,
+            "is_final": False,
+        },
+        {
+            "text": " world",
+            "start": 1.0,
+            "end": 2.0,
+            "is_final": True,
+        },
+    ]
+    assert result.prompt_tokens == 5
+    assert result.generation_tokens == 2
+
+    saved = json.loads(output_path.with_suffix(".json").read_text())
+    assert saved["text"] == "Hello world"
+    assert saved["segments"] == [
+        {
+            "text": "Hello",
+            "start": 0.0,
+            "end": 1.0,
+            "duration": 1.0,
+        },
+        {
+            "text": " world",
+            "start": 1.0,
+            "end": 2.0,
+            "duration": 1.0,
+        },
+    ]


### PR DESCRIPTION
## Summary

Closes #927.

Qwen3-ASR derives partial streaming timestamps from token-budget progress, so changing `max_tokens` changes the reported timing for identical text. Generated text has no real audio alignment, so this change makes text deltas untimed and keeps only coarse audio chunk extents.

## Changes

- Return `start_time=None` and `end_time=None` for text-delta events.
- Keep numeric start/end values on empty-text chunk-boundary events.
- Clamp chunk boundaries to the real input duration before model-only padding.
- Buffer untimed text into the matching chunk in the CLI.
- Preserve an untimed final text segment in JSON.
- Raise a clear error instead of silently writing empty SRT/VTT output when no timed boundary exists.
- Document the streaming event contract and point users to the forced aligner for text-level timestamps.

## Compatibility

Streaming consumers must handle nullable `start_time` and `end_time` on text deltas. The server serializes these as `null`. Numeric values are coarse audio chunk extents, not transcription timestamps.

## Validation

- Focused streaming tests: 12 passed.
- Full STT suite: 283 passed, 9 skipped, 18 subtests passed.
- Black, isort, and `git diff --check` passed.
- Confirmed identical partial timestamp metadata for `max_tokens=64` and `8192`.
