### PR TITLE
fix(stt): validate empty Qwen3-ASR audio

### DIFF
--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -40,6 +40,21 @@ class StreamingResult:
     generation_tokens: int = 0
 
 
+def _validate_audio(wav: np.ndarray) -> None:
+    if wav.size == 0:
+        raise ValueError("Audio input must contain at least one sample")
+    if not np.isfinite(wav).all():
+        raise ValueError("Audio input must contain only finite samples")
+
+
+def _audio_duration(wav: np.ndarray, sr: int) -> float:
+    """Return the duration before model-only padding is applied."""
+    _validate_audio(wav)
+    if wav.ndim > 1 and wav.shape[-1] > 2:
+        return wav.shape[-1] / sr
+    return len(wav) / sr
+
+
 def split_audio_into_chunks(
     wav: np.ndarray,
     sr: int,
@@ -61,6 +76,8 @@ def split_audio_into_chunks(
     Returns:
         List of (chunk_waveform, offset_seconds) tuples.
     """
+    _validate_audio(wav)
+
     # Ensure mono
     if wav.ndim > 1:
         wav = wav.mean(axis=-1) if wav.shape[-1] <= 2 else wav.mean(axis=0)
@@ -884,6 +901,7 @@ class Qwen3ASRModel(nn.Module):
         audio_np = (
             np.array(audio_input) if isinstance(audio_input, mx.array) else audio_input
         )
+        _validate_audio(audio_np)
 
         audio_inputs = self._feature_extractor(
             audio_np,
@@ -905,13 +923,14 @@ class Qwen3ASRModel(nn.Module):
     def extract_language(
         self,
         text: str,
-    ) -> str:
+    ) -> Tuple[str, str]:
         """Extract language from text."""
         if "<asr_text>" in text and text.startswith("language "):
-            return (
-                text[len("language ") : text.find("<asr_text>")].strip(),
-                text[text.find("<asr_text>") + len("<asr_text>") :],
-            )
+            language, transcript = text.split("<asr_text>", 1)
+            language = language[len("language ") :].strip()
+            if language.lower() == "none":
+                return "", transcript.strip()
+            return language, transcript
         return "English", text
 
     def _build_prompt(
@@ -1308,6 +1327,7 @@ class Qwen3ASRModel(nn.Module):
         audio_np = (
             np.array(audio_input) if isinstance(audio_input, mx.array) else audio_input
         )
+        total_duration = _audio_duration(audio_np, self.sample_rate)
 
         # Split into chunks if needed
         chunks = split_audio_into_chunks(
@@ -1367,7 +1387,11 @@ class Qwen3ASRModel(nn.Module):
                         "text": text,
                         "language": language,
                         "start": offset_sec,
-                        "end": offset_sec + len(chunk_audio) / self.sample_rate,
+                        "end": offset_sec
+                        + min(
+                            len(chunk_audio) / self.sample_rate,
+                            max(total_duration - offset_sec, 0.0),
+                        ),
                     }
                 )
             chunks = []  # skip the sequential loop below
@@ -1380,7 +1404,10 @@ class Qwen3ASRModel(nn.Module):
             if remaining_tokens <= 0:
                 break
 
-            actual_chunk_duration = len(chunk_audio) / self.sample_rate
+            actual_chunk_duration = min(
+                len(chunk_audio) / self.sample_rate,
+                max(total_duration - offset_sec, 0.0),
+            )
 
             text, prompt_toks, gen_toks = self._generate_single_chunk(
                 chunk_audio,
@@ -1483,8 +1510,8 @@ class Qwen3ASRModel(nn.Module):
             np.array(audio_input) if isinstance(audio_input, mx.array) else audio_input
         )
 
-        # Calculate total audio duration
-        total_duration = len(audio_np) / self.sample_rate
+        # Calculate duration before short inputs are padded for the model.
+        total_duration = _audio_duration(audio_np, self.sample_rate)
 
         # Split into chunks if needed
         chunks = split_audio_into_chunks(
@@ -1526,7 +1553,10 @@ class Qwen3ASRModel(nn.Module):
             disable=not verbose or len(chunks) == 1,
         )
         for chunk_idx, (chunk_audio, offset_sec) in chunk_iter:
-            actual_chunk_duration = len(chunk_audio) / self.sample_rate
+            actual_chunk_duration = min(
+                len(chunk_audio) / self.sample_rate,
+                max(total_duration - offset_sec, 0.0),
+            )
             is_last_chunk = chunk_idx == len(chunks) - 1
             token_count = 0
 

--- a/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
+++ b/mlx_audio/stt/models/qwen3_asr/qwen3_asr.py
@@ -76,8 +76,6 @@ def split_audio_into_chunks(
     Returns:
         List of (chunk_waveform, offset_seconds) tuples.
     """
-    _validate_audio(wav)
-
     # Ensure mono
     if wav.ndim > 1:
         wav = wav.mean(axis=-1) if wav.shape[-1] <= 2 else wav.mean(axis=0)
@@ -925,12 +923,16 @@ class Qwen3ASRModel(nn.Module):
         text: str,
     ) -> Tuple[str, str]:
         """Extract language from text."""
-        if "<asr_text>" in text and text.startswith("language "):
-            language, transcript = text.split("<asr_text>", 1)
-            language = language[len("language ") :].strip()
-            if language.lower() == "none":
-                return "", transcript.strip()
-            return language, transcript
+        stripped_text = text.strip()
+        if "<asr_text>" in stripped_text:
+            metadata, transcript = stripped_text.split("<asr_text>", 1)
+            for line in metadata.splitlines():
+                line = line.strip()
+                if line.lower().startswith("language "):
+                    language = line[len("language ") :].strip()
+                    if language.lower() == "none":
+                        return "", transcript.strip()
+                    return language, transcript.strip()
         return "English", text
 
     def _build_prompt(
@@ -1377,15 +1379,16 @@ class Qwen3ASRModel(nn.Module):
             ):
                 if not was_processed:
                     continue
+                chunk_language = language
                 if language is None:
-                    language, text = self.extract_language(text)
+                    chunk_language, text = self.extract_language(text)
                 all_texts.append(text)
                 total_prompt_tokens += pt
                 total_generation_tokens += gt
                 segments.append(
                     {
                         "text": text,
-                        "language": language,
+                        "language": chunk_language,
                         "start": offset_sec,
                         "end": offset_sec
                         + min(
@@ -1421,8 +1424,9 @@ class Qwen3ASRModel(nn.Module):
                 system_prompt=system_prompt,
             )
 
+            chunk_language = language
             if language is None:
-                language, text = self.extract_language(text)
+                chunk_language, text = self.extract_language(text)
 
             all_texts.append(text)
             total_prompt_tokens += prompt_toks
@@ -1433,7 +1437,7 @@ class Qwen3ASRModel(nn.Module):
             segments.append(
                 {
                     "text": text,
-                    "language": language,
+                    "language": chunk_language,
                     "start": offset_sec,
                     "end": offset_sec + actual_chunk_duration,
                 }
@@ -1445,7 +1449,7 @@ class Qwen3ASRModel(nn.Module):
         end_time = time.time()
 
         # Combine transcriptions
-        full_text = " ".join(all_texts)
+        full_text = " ".join(text for text in all_texts if text).strip()
 
         return STTOutput(
             text=full_text,
@@ -1543,8 +1547,6 @@ class Qwen3ASRModel(nn.Module):
         total_generation_tokens = 0
         remaining_tokens = max_tokens
 
-        language_accumulator = ""
-
         # Process each chunk and stream tokens
         chunk_iter = tqdm(
             enumerate(chunks),
@@ -1559,6 +1561,8 @@ class Qwen3ASRModel(nn.Module):
             )
             is_last_chunk = chunk_idx == len(chunks) - 1
             token_count = 0
+            chunk_language = language
+            language_accumulator = ""
 
             # Get prompt tokens for this chunk
             _, _, num_audio_tokens = self._preprocess_audio(chunk_audio)
@@ -1583,7 +1587,7 @@ class Qwen3ASRModel(nn.Module):
                 if language is None and i <= 2:
                     language_accumulator += text
                     if "<asr_text>" in language_accumulator:
-                        language, _ = self.extract_language(language_accumulator)
+                        chunk_language, _ = self.extract_language(language_accumulator)
                     continue
 
                 # Estimate timing based on token position within chunk
@@ -1600,7 +1604,7 @@ class Qwen3ASRModel(nn.Module):
                     is_final=False,
                     start_time=estimated_start,
                     end_time=estimated_end,
-                    language=language,
+                    language=chunk_language,
                 )
 
             # Update token counts
@@ -1613,7 +1617,7 @@ class Qwen3ASRModel(nn.Module):
                 is_final=is_last_chunk or remaining_tokens <= 0,
                 start_time=offset_sec,
                 end_time=offset_sec + actual_chunk_duration,
-                language=language,
+                language=chunk_language,
                 prompt_tokens=total_prompt_tokens,
                 generation_tokens=total_generation_tokens,
             )

--- a/mlx_audio/stt/tests/test_qwen3_asr_batched.py
+++ b/mlx_audio/stt/tests/test_qwen3_asr_batched.py
@@ -6,7 +6,11 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from mlx_audio.stt.models.qwen3_asr.qwen3_asr import Qwen3ASRModel, _rope_safe
+from mlx_audio.stt.models.qwen3_asr.qwen3_asr import (
+    Qwen3ASRModel,
+    _rope_safe,
+    split_audio_into_chunks,
+)
 
 
 class _FakeTokenizer:
@@ -172,6 +176,66 @@ class TestBatchedGeneration(unittest.TestCase):
         model._generate_chunks_batched.assert_called_once()
         self.assertIsNone(
             model._generate_chunks_batched.call_args.kwargs["logits_processors"]
+        )
+
+    def test_short_audio_segment_uses_unpadded_duration(self):
+        model = self.make_minimal_model()
+        model._generate_single_chunk = Mock(return_value=("text", 5, 1))
+
+        out = model.generate(
+            np.zeros(4000, dtype=np.float32),
+            min_chunk_duration=1.0,
+            language="English",
+        )
+
+        self.assertEqual(len(out.segments), 1)
+        self.assertEqual(out.segments[0]["start"], 0.0)
+        self.assertEqual(out.segments[0]["end"], 0.25)
+
+
+class TestAudioInputValidation(unittest.TestCase):
+    def test_empty_audio_is_rejected_before_padding(self):
+        with self.assertRaisesRegex(ValueError, "at least one sample"):
+            split_audio_into_chunks(np.array([], dtype=np.float32), 16000)
+
+    def test_non_finite_audio_is_rejected(self):
+        for value in (np.nan, np.inf, -np.inf):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    split_audio_into_chunks(
+                        np.array([0.0, value], dtype=np.float32), 16000
+                    )
+
+    def test_direct_preprocessing_rejects_empty_audio(self):
+        model = Qwen3ASRModel.__new__(Qwen3ASRModel)
+        model._feature_extractor = Mock()
+
+        with self.assertRaisesRegex(ValueError, "at least one sample"):
+            model._preprocess_audio(np.array([], dtype=np.float32))
+
+        model._feature_extractor.assert_not_called()
+
+
+class TestLanguageParsing(unittest.TestCase):
+    def setUp(self):
+        self.model = Qwen3ASRModel.__new__(Qwen3ASRModel)
+
+    def test_language_none_with_empty_text_is_no_speech(self):
+        self.assertEqual(
+            self.model.extract_language("language None<asr_text>"),
+            ("", ""),
+        )
+
+    def test_language_none_preserves_returned_text(self):
+        self.assertEqual(
+            self.model.extract_language("language None<asr_text>quiet speech"),
+            ("", "quiet speech"),
+        )
+
+    def test_named_language_is_unchanged(self):
+        self.assertEqual(
+            self.model.extract_language("language English<asr_text>Hello"),
+            ("English", "Hello"),
         )
 
 

--- a/mlx_audio/stt/tests/test_qwen3_asr_batched.py
+++ b/mlx_audio/stt/tests/test_qwen3_asr_batched.py
@@ -1,6 +1,6 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -9,7 +9,6 @@ import numpy as np
 from mlx_audio.stt.models.qwen3_asr.qwen3_asr import (
     Qwen3ASRModel,
     _rope_safe,
-    split_audio_into_chunks,
 )
 
 
@@ -39,6 +38,23 @@ class _FakeTextModel:
 
     def __call__(self, *, inputs_embeds, cache=None):
         return inputs_embeds
+
+
+def _make_minimal_model():
+    model = Qwen3ASRModel.__new__(Qwen3ASRModel)
+    model.config = SimpleNamespace(
+        text_config=SimpleNamespace(num_hidden_layers=0),
+    )
+    model._tokenizer = _FakeTokenizer()
+    model._feature_extractor = object()
+    model.model = _FakeTextModel()
+    model.lm_head = None
+    model.get_audio_features = Mock(return_value=mx.zeros((1, 1)))
+    model._preprocess_audio = Mock(return_value=(mx.zeros((1, 1)), None, 1))
+    model._build_prompt = Mock(return_value=mx.array([[0]]))
+    model._build_inputs_embeds = Mock(return_value=mx.zeros((1, 1, 1)))
+    model._forward_with_embeds = Mock(return_value=mx.zeros((2, 1, 128)))
+    return model
 
 
 class TestRopeSafe(unittest.TestCase):
@@ -71,20 +87,7 @@ class TestRopeSafe(unittest.TestCase):
 
 class TestBatchedGeneration(unittest.TestCase):
     def make_minimal_model(self):
-        model = Qwen3ASRModel.__new__(Qwen3ASRModel)
-        model.config = SimpleNamespace(
-            text_config=SimpleNamespace(num_hidden_layers=0),
-        )
-        model._tokenizer = _FakeTokenizer()
-        model._feature_extractor = object()
-        model.model = _FakeTextModel()
-        model.lm_head = None
-        model.get_audio_features = Mock(return_value=mx.zeros((1, 1)))
-        model._preprocess_audio = Mock(return_value=(mx.zeros((1, 1)), None, 1))
-        model._build_prompt = Mock(return_value=mx.array([[0]]))
-        model._build_inputs_embeds = Mock(return_value=mx.zeros((1, 1, 1)))
-        model._forward_with_embeds = Mock(return_value=mx.zeros((2, 1, 128)))
-        return model
+        return _make_minimal_model()
 
     def test_batched_generation_respects_global_token_budget(self):
         model = self.make_minimal_model()
@@ -195,16 +198,24 @@ class TestBatchedGeneration(unittest.TestCase):
 
 class TestAudioInputValidation(unittest.TestCase):
     def test_empty_audio_is_rejected_before_padding(self):
+        model = _make_minimal_model()
+        model._generate_single_chunk = Mock()
+
         with self.assertRaisesRegex(ValueError, "at least one sample"):
-            split_audio_into_chunks(np.array([], dtype=np.float32), 16000)
+            model.generate(np.array([], dtype=np.float32))
+
+        model._generate_single_chunk.assert_not_called()
 
     def test_non_finite_audio_is_rejected(self):
+        model = _make_minimal_model()
+        model._generate_single_chunk = Mock()
+
         for value in (np.nan, np.inf, -np.inf):
             with self.subTest(value=value):
                 with self.assertRaisesRegex(ValueError, "finite"):
-                    split_audio_into_chunks(
-                        np.array([0.0, value], dtype=np.float32), 16000
-                    )
+                    model.generate(np.array([0.0, value], dtype=np.float32))
+
+        model._generate_single_chunk.assert_not_called()
 
     def test_direct_preprocessing_rejects_empty_audio(self):
         model = Qwen3ASRModel.__new__(Qwen3ASRModel)
@@ -236,6 +247,126 @@ class TestLanguageParsing(unittest.TestCase):
         self.assertEqual(
             self.model.extract_language("language English<asr_text>Hello"),
             ("English", "Hello"),
+        )
+
+    def test_language_marker_tolerates_case_and_whitespace(self):
+        variants = (
+            " language None<asr_text> ",
+            "\nlanguage None<asr_text>",
+            "Language None<asr_text>",
+            "language None\n<asr_text>",
+        )
+
+        for text in variants:
+            with self.subTest(text=text):
+                self.assertEqual(self.model.extract_language(text), ("", ""))
+
+
+class TestPerChunkLanguageParsing(unittest.TestCase):
+    def setUp(self):
+        self.chunks = [
+            (np.zeros(16000, dtype=np.float32), 0.0),
+            (np.zeros(16000, dtype=np.float32), 1.0),
+        ]
+
+    def test_sequential_chunks_keep_auto_detection_enabled(self):
+        model = _make_minimal_model()
+        model._generate_single_chunk = Mock(
+            side_effect=[
+                ("language None<asr_text>", 1, 1),
+                ("language English<asr_text>Hello", 1, 1),
+            ]
+        )
+
+        with patch(
+            "mlx_audio.stt.models.qwen3_asr.qwen3_asr.split_audio_into_chunks",
+            return_value=self.chunks,
+        ):
+            out = model.generate(np.zeros(32000, dtype=np.float32))
+
+        self.assertEqual(out.text, "Hello")
+        self.assertEqual([segment["text"] for segment in out.segments], ["", "Hello"])
+        self.assertEqual(
+            [segment["language"] for segment in out.segments], ["", "English"]
+        )
+        self.assertEqual(
+            [
+                call.kwargs["language"]
+                for call in model._generate_single_chunk.call_args_list
+            ],
+            [None, None],
+        )
+
+    def test_batched_chunks_parse_each_detected_language(self):
+        model = _make_minimal_model()
+        model._generate_chunks_batched = Mock(
+            return_value=(
+                ["language None<asr_text>", "language English<asr_text>Hello"],
+                [1, 1],
+                [1, 1],
+                [True, True],
+            )
+        )
+
+        with patch(
+            "mlx_audio.stt.models.qwen3_asr.qwen3_asr.split_audio_into_chunks",
+            return_value=self.chunks,
+        ):
+            out = model.generate(
+                np.zeros(32000, dtype=np.float32),
+                batch_size=2,
+            )
+
+        self.assertEqual(out.text, "Hello")
+        self.assertEqual([segment["text"] for segment in out.segments], ["", "Hello"])
+        self.assertEqual(
+            [segment["language"] for segment in out.segments], ["", "English"]
+        )
+        self.assertIsNone(model._generate_chunks_batched.call_args.kwargs["language"])
+
+    def test_streaming_chunks_reset_language_detection(self):
+        model = _make_minimal_model()
+        token_text = {
+            1: "language ",
+            2: "None",
+            3: "<asr_text>",
+            4: "English",
+            5: "Hello",
+        }
+        model._tokenizer.decode = lambda token_ids: token_text[token_ids[0]]
+        token_state = mx.zeros((1,))
+        model.stream_generate = Mock(
+            side_effect=[
+                iter(
+                    [
+                        (mx.array(1), token_state),
+                        (mx.array(2), token_state),
+                        (mx.array(3), token_state),
+                    ]
+                ),
+                iter(
+                    [
+                        (mx.array(1), token_state),
+                        (mx.array(4), token_state),
+                        (mx.array(3), token_state),
+                        (mx.array(5), token_state),
+                    ]
+                ),
+            ]
+        )
+
+        with patch(
+            "mlx_audio.stt.models.qwen3_asr.qwen3_asr.split_audio_into_chunks",
+            return_value=self.chunks,
+        ):
+            results = list(model.stream_transcribe(np.zeros(32000, dtype=np.float32)))
+
+        self.assertEqual([result.text for result in results if result.text], ["Hello"])
+        boundaries = [result for result in results if not result.text]
+        self.assertEqual([result.language for result in boundaries], ["", "English"])
+        self.assertEqual(
+            [call.kwargs["language"] for call in model.stream_generate.call_args_list],
+            [None, None],
         )
 
 


### PR DESCRIPTION
## Summary

Closes #928.

Qwen3-ASR accepts invalid audio, reports mlx-audio's minimum-length padding as valid clip duration, and mishandles the model's `language None<asr_text>` no-speech output. This change validates Qwen3-ASR input before inference, preserves the real duration of short clips, and parses language metadata independently for every chunk.

## Changes

- Reject empty, NaN, and infinite Qwen3-ASR audio before inference.
- Keep validation in Qwen3-ASR entry points so the shared Fun-ASR chunker retains its existing behavior.
- Measure duration before `min_chunk_duration` padding.
- Use the real duration for ordinary, batched, and streaming segment ends.
- Parse `language None<asr_text>` as empty language while preserving any returned text.
- Accept case and surrounding-whitespace variants of the language marker.
- Keep requested language immutable and parse auto-detected language per chunk in sequential, batched, and streaming paths.
- Omit empty no-speech chunks when joining the final transcript.

## Scope

This does not add an RMS silence threshold because that could reject quiet speech. Silence detection remains the responsibility of the model or VAD.

## Validation

- Focused Qwen3-ASR and shared-model tests: 62 passed, 1 skipped, 7 subtests passed.
- Full STT suite: 288 passed, 9 skipped, 25 subtests passed.
- Black, isort, and `git diff --check` passed.
- Real-model checks rejected empty and NaN input before inference.
- A valid 10 ms clip remained padded for inference but reported a `0.01`-second segment end.
