### PR TITLE
feat: Expose model capabilities via /v1/models/{id}/metadata

### DIFF
--- a/docs/guides/web-ui-api-server.md
+++ b/docs/guides/web-ui-api-server.md
@@ -158,6 +158,15 @@ curl -X POST "http://localhost:8000/v1/models?model_name=mlx-community/Kokoro-82
 
 # Unload a model
 curl -X DELETE "http://localhost:8000/v1/models?model_name=mlx-community/Kokoro-82M-bf16"
+
+# Inspect machine-readable metadata (capabilities/limits/parameters/runtime)
+# for a loaded model; unknown capabilities are reported as null, never guessed.
+curl http://localhost:8000/v1/models/mlx-community/Kokoro-82M-bf16/metadata
+
+# Models with preset voices/languages annotate them on the parameters schema
+# as `enum` constraints, so clients never have to guess a valid `voice` (e.g.
+# CustomVoice rejects unknown speaker names).
+curl http://localhost:8000/v1/models/mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit/metadata
 ```
 
 ### Real-Time WebSocket Transcription

--- a/mlx_audio/model_metadata.py
+++ b/mlx_audio/model_metadata.py
@@ -1,0 +1,555 @@
+"""Standardized, machine-readable model metadata for OpenAI-compatible clients.
+
+Model metadata is defined by the model/provider implementation, never by the
+HTTP API layer. The serving runtime builds a grounded *inferred* baseline and
+then lets each model correct or extend it.
+
+The baseline is never guessed: it comes from structural facts about the loaded
+model itself --
+
+* the model's *kind* (``tts`` / ``stt`` / ``sts`` / ``lid`` / ``vad``), read
+  from the concrete class's module path (``mlx_audio.<kind>.models...``),
+  determines the audio I/O shape (a TTS model emits audio, an STT model
+  consumes audio, …);
+* the model's own inference entry point (``generate()`` / ``predict()`` /
+  ``detect()`` / …) determines streaming support (a ``stream`` parameter) and
+  reference-audio input (a ``ref_audio`` parameter); and
+* that same entry point's signature is introspected into the ``parameters``
+  JSON Schema (type hints drive ``type``, defaults are serialized, parameters
+  without defaults become ``required``) -- no hand-written JSON Schema.
+
+Capabilities that are not entailed by those facts (tool calling, vision,
+structured output) are reported as ``None`` = unknown.
+
+A model may correct or extend this baseline by exposing a duck-typed
+``get_metadata()`` method returning a :class:`ModelMetadata`; any non-``None``
+field it declares overrides the inferred value, and the ``id`` / runtime
+section are normalized to the serving runtime. This matches the codebase's
+existing capability hooks such as ``supports_tts_batch`` / ``batch_generate`` /
+``create_streaming_session``.
+
+    class Model(nn.Module):
+        def get_metadata(self) -> ModelMetadata:
+            return ModelMetadata(
+                limits=ModelLimits(context_window=32768),
+                # Annotate valid values directly on the parameters schema:
+                # each entry is merged into the matching introspected property
+                # (type/default stay introspected, the annotation adds enum).
+                parameters={"voice": {"enum": [...]}, "lang_code": {"enum": [...]}},
+            )
+
+The inferred audio capabilities and introspected parameters are still applied;
+only ``context_window`` and the parameter annotations are declared here.
+Models that have no extra facts to declare need no hook at all.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+import types
+from dataclasses import dataclass, field, replace
+from typing import (
+    Literal,
+    Optional,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+
+@dataclass
+class ModelCapabilities:
+    """Reported model capabilities.
+
+    Each field is tri-state:
+
+    * ``True`` -- the model/runtime supports the capability;
+    * ``False`` -- the model/runtime does not support it;
+    * ``None`` -- unknown; the implementation did not report it.
+    """
+
+    tools: Optional[bool] = None
+    streaming: Optional[bool] = None
+    vision: Optional[bool] = None
+    audio_input: Optional[bool] = None
+    audio_output: Optional[bool] = None
+    structured_output: Optional[bool] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "tools": self.tools,
+            "streaming": self.streaming,
+            "vision": self.vision,
+            "audio_input": self.audio_input,
+            "audio_output": self.audio_output,
+            "structured_output": self.structured_output,
+        }
+
+
+@dataclass
+class ModelLimits:
+    context_window: Optional[int] = None
+    max_output_tokens: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "context_window": self.context_window,
+            "max_output_tokens": self.max_output_tokens,
+        }
+
+
+@dataclass
+class ModelRuntime:
+    name: str = "mlx-audio"
+    version: Optional[str] = None
+    protocol: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "protocol": self.protocol,
+        }
+
+
+@dataclass
+class ModelMetadata:
+    #: Normalized to the requested model id by ``metadata_for_model``; models
+    #: that only declare limits/parameters may leave it unset.
+    id: Optional[str] = None
+    capabilities: ModelCapabilities = field(default_factory=ModelCapabilities)
+    limits: ModelLimits = field(default_factory=ModelLimits)
+    #: JSON Schema for the model's request parameters. When a ``get_metadata``
+    #: hook declares this, it is treated as *property annotations* (a dict of
+    #: parameter name -> schema fragment, e.g. ``{"voice": {"enum": [...]}}``)
+    #: and deep-merged into the introspected signature schema, so ``enum``
+    #: constraints etc. live here -- the single source of truth for requests.
+    parameters: Optional[dict] = None
+    runtime: ModelRuntime = field(default_factory=ModelRuntime)
+
+    def to_dict(self) -> dict:
+        # Guard against partially constructed metadata: a ``None`` section is
+        # serialized as unknown rather than raising.
+        capabilities = self.capabilities or ModelCapabilities()
+        limits = self.limits or ModelLimits()
+        runtime = self.runtime or default_runtime()
+        return {
+            "id": self.id,
+            "capabilities": capabilities.to_dict(),
+            "limits": limits.to_dict(),
+            "parameters": self.parameters,
+            "runtime": runtime.to_dict(),
+        }
+
+
+#: Audio I/O shape entailed by each model kind. A TTS model always emits audio
+#: but only *consumes* it when it clones voices (left unknown here, derived from
+#: the entry-point signature); STT / LID / VAD consume audio and never emit
+#: it; STS does both. Tool calling / vision / structured output are never
+#: entailed by a kind and stay unknown unless a model declares them.
+_KIND_CAPABILITIES = {
+    "tts": {"audio_output": True},
+    "stt": {"audio_input": True, "audio_output": False},
+    "sts": {"audio_input": True, "audio_output": True},
+    "lid": {"audio_input": True, "audio_output": False},
+    "vad": {"audio_input": True, "audio_output": False},
+}
+
+_CAPABILITY_FIELDS = (
+    "tools",
+    "streaming",
+    "vision",
+    "audio_input",
+    "audio_output",
+    "structured_output",
+)
+
+#: Candidate entry points, in priority order, used to introspect a model's
+#: parameters and to derive streaming / reference-audio capabilities. The STS
+#: ``generate_*`` methods cover STS families (e.g. LFM2Audio) that have no
+#: single ``generate`` method.
+_PRIMARY_METHODS = (
+    "generate",
+    "generate_interleaved",
+    "generate_sequential",
+    "generate_from_chat_state",
+    "predict",
+    "detect",
+    "detect_language",
+    "transcribe",
+    "classify",
+    "process",
+)
+
+_JSON_PRIMITIVES = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    list: "array",
+    tuple: "array",
+    set: "array",
+    frozenset: "array",
+    dict: "object",
+}
+
+_UNSET = object()
+
+
+def default_runtime() -> ModelRuntime:
+    """Runtime info describing the mlx-audio serving runtime."""
+    try:
+        from mlx_audio.version import __version__
+    except ImportError:  # pragma: no cover - the version module always ships
+        __version__ = None
+    return ModelRuntime(name="mlx-audio", version=__version__, protocol="openai")
+
+
+def metadata_for_model(model, model_id: str) -> ModelMetadata:
+    """Return metadata for ``model`` as identified by ``model_id``.
+
+    Capabilities are inferred from the model's kind (its module path) and its
+    entry-point signature, and parameters are introspected from that signature.
+    A duck-typed ``get_metadata()`` hook -- when present and returning a
+    :class:`ModelMetadata` -- overlays any non-``None`` field it declares
+    (limits, parameters, capability corrections). The ``id`` is always
+    normalized to ``model_id`` and the runtime section filled with the serving
+    runtime's identity.
+    """
+    inferred = _inferred_metadata(model, model_id)
+    get_metadata = getattr(model, "get_metadata", None)
+    if callable(get_metadata):
+        declared = get_metadata()
+        if isinstance(declared, ModelMetadata):
+            inferred = _finalize(_overlay(inferred, declared), model_id)
+    return inferred
+
+
+def schema_for_callable(func) -> Optional[dict]:
+    """Build a JSON Schema for a callable's parameters from its signature.
+
+    Type hints drive each property's ``type`` (``str`` → ``"string"``, ``int``
+    → ``"integer"``, ``Optional[X]`` → X, unions become a type list, ``Literal``
+    becomes ``enum``); serializable defaults are emitted as ``default`` and
+    parameters without defaults are listed under ``required``. ``*args`` /
+    ``**kwargs`` / ``self`` are skipped. Returns ``None`` when nothing can be
+    introspected.
+    """
+    if not callable(func):
+        return None
+    func = getattr(func, "__func__", func)  # unwrap bound methods for hints
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return None
+    try:
+        hints = get_type_hints(func)
+    except Exception:  # pragma: no cover - unresolvable forward refs degrade
+        hints = {}
+
+    properties = {}
+    required = []
+    for name, param in signature.parameters.items():
+        if name in ("self", "cls"):
+            continue
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        prop = _property_schema(hints.get(name, param.annotation))
+        if param.default is inspect.Parameter.empty:
+            required.append(name)
+        else:
+            default = _json_default(param.default)
+            if default is not _UNSET:
+                prop["default"] = default
+        properties[name] = prop
+
+    if not properties:
+        return None
+    schema = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _property_schema(annotation) -> dict:
+    """A JSON Schema fragment for a single parameter's type annotation."""
+    if annotation is not None and annotation is not inspect.Parameter.empty:
+        origin = get_origin(annotation)
+        if origin is Literal:
+            return {"enum": list(get_args(annotation))}
+    type_name = _type_name(annotation)
+    if isinstance(type_name, list):
+        return {"type": type_name}
+    if type_name:
+        return {"type": type_name}
+    return {}
+
+
+def _type_name(annotation):
+    """Best-effort JSON Schema type name(s) for a resolved annotation.
+
+    Returns a single type name (``"string"``), a list of names for unions, or
+    ``None`` when the type is unknown.
+    """
+    if annotation is None or annotation is inspect.Parameter.empty:
+        return None
+    if annotation in _JSON_PRIMITIVES:
+        return _JSON_PRIMITIVES[annotation]
+    if isinstance(annotation, str):
+        return _type_name_for_string(annotation)
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    # Optional[X] / Union[A, B, None] / ``X | Y``
+    if origin in (Union, types.UnionType):
+        names = []
+        for arg in args:
+            if arg is type(None):
+                continue
+            resolved = _type_name(arg)
+            if isinstance(resolved, list):
+                names.extend(resolved)
+            elif resolved:
+                names.append(resolved)
+        unique = []
+        for name in names:
+            if name not in unique:
+                unique.append(name)
+        if len(unique) == 1:
+            return unique[0]
+        return unique or None
+
+    if origin in (list, tuple, set, frozenset):
+        return "array"
+    if origin is dict:
+        return "object"
+
+    name = getattr(annotation, "__name__", "") or ""
+    lowered = name.lower()
+    if lowered in ("path", "posixpath", "windowspath", "purepath"):
+        return "string"
+    if lowered in ("ndarray", "array"):
+        return "array"
+    return None
+
+
+def _type_name_for_string(annotation: str):
+    """Resolve a raw (string) forward-ref annotation without evaluating it."""
+    annotation = annotation.strip()
+    if annotation.startswith("Optional[") and annotation.endswith("]"):
+        return _type_name_for_string(annotation[len("Optional[") : -1])
+    if annotation.startswith("Union[") and annotation.endswith("]"):
+        return _union_names(annotation[len("Union[") : -1])
+    if "|" in annotation:
+        return _union_names(annotation)
+    return {
+        "str": "string",
+        "int": "integer",
+        "float": "number",
+        "bool": "boolean",
+        "list": "array",
+        "tuple": "array",
+        "set": "array",
+        "dict": "object",
+        "Path": "string",
+        "None": None,
+        "NoneType": None,
+    }.get(annotation)
+
+
+def _union_names(inner: str):
+    names = []
+    for part in inner.split(",") if "," in inner else inner.split("|"):
+        resolved = _type_name_for_string(part.strip())
+        if isinstance(resolved, list):
+            names.extend(resolved)
+        elif resolved:
+            names.append(resolved)
+    unique = []
+    for name in names:
+        if name not in unique:
+            unique.append(name)
+    if len(unique) == 1:
+        return unique[0]
+    return unique or None
+
+
+def _json_default(value):
+    """Convert a default value to a JSON-serializable form, or ``_UNSET``."""
+    if value is None or isinstance(value, (str, bool)):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return _UNSET
+        return value
+    if isinstance(value, (list, tuple)):
+        items = []
+        for item in value:
+            converted = _json_default(item)
+            if converted is _UNSET:
+                return _UNSET
+            items.append(converted)
+        return items
+    if isinstance(value, dict):
+        result = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                return _UNSET
+            converted = _json_default(item)
+            if converted is _UNSET:
+                return _UNSET
+            result[key] = converted
+        return result
+    return _UNSET
+
+
+def _inferred_metadata(model, model_id: str) -> ModelMetadata:
+    entry = _primary_callable(model)
+    return ModelMetadata(
+        id=model_id,
+        capabilities=_inferred_capabilities(model, model_id, entry),
+        parameters=schema_for_callable(entry),
+        runtime=default_runtime(),
+    )
+
+
+def _inferred_capabilities(model, model_id: str, entry=None) -> ModelCapabilities:
+    """Grounded baseline capabilities: kind shape + entry-point signature."""
+    capabilities = ModelCapabilities()
+    kind = _model_kind(model, model_id)
+    for name, value in _KIND_CAPABILITIES.get(kind, {}).items():
+        setattr(capabilities, name, value)
+
+    if entry is None:
+        entry = _primary_callable(model)
+    if callable(entry):
+        try:
+            params = inspect.signature(entry).parameters
+        except (TypeError, ValueError):
+            params = {}
+        if capabilities.streaming is None and "stream" in params:
+            capabilities.streaming = True
+        if capabilities.audio_input is None and "ref_audio" in params:
+            capabilities.audio_input = True
+    return capabilities
+
+
+def _primary_callable(model):
+    """The model's user-facing inference method, or ``None``."""
+    for name in _PRIMARY_METHODS:
+        method = getattr(model, name, None)
+        if callable(method):
+            return method
+    return None
+
+
+def _model_kind(model, model_id: str) -> Optional[str]:
+    """The audio kind of a loaded model, from its concrete class module path.
+
+    Every model architecture lives under ``mlx_audio/<kind>/models/<family>``,
+    so the second module segment of the concrete class is the kind. Falls back
+    to the import-free registry classification when the module path does not
+    follow that layout (e.g. test doubles or dynamically built models).
+    """
+    module = type(model).__module__.split(".")
+    if len(module) >= 2 and module[0] == "mlx_audio" and module[1] in _KIND_CAPABILITIES:
+        return module[1]
+    from mlx_audio.registry import classify_model
+
+    try:
+        model_type = getattr(model, "model_type", "") or ""
+    except Exception:  # pragma: no cover - defensive; model_type is trivial
+        model_type = ""
+    if not isinstance(model_type, str):
+        model_type = ""
+    return classify_model(model_type, model_id)
+
+
+def _overlay(inferred: ModelMetadata, declared: ModelMetadata) -> ModelMetadata:
+    """Overlay declared metadata onto the inferred baseline.
+
+    A declared ``None`` never overrides an inferred value (a model that only
+    declares limits still inherits its kind's audio shape and introspected
+    parameters); only explicit ``True``/``False``/values win.
+    """
+    capabilities = ModelCapabilities()
+    for name in _CAPABILITY_FIELDS:
+        declared_value = (
+            getattr(declared.capabilities, name) if declared.capabilities else None
+        )
+        inferred_value = getattr(inferred.capabilities, name)
+        setattr(
+            capabilities,
+            name,
+            declared_value if declared_value is not None else inferred_value,
+        )
+    return ModelMetadata(
+        id=declared.id,
+        capabilities=capabilities,
+        limits=declared.limits if declared.limits is not None else inferred.limits,
+        parameters=_merge_parameters(inferred.parameters, declared.parameters),
+        runtime=declared.runtime,
+    )
+
+
+def _finalize(metadata: ModelMetadata, model_id: str) -> ModelMetadata:
+    """Normalize ``id`` and fill the serving runtime identity into metadata."""
+    metadata = _with_serving_runtime(metadata)
+    if metadata.id != model_id:
+        return replace(metadata, id=model_id)
+    return metadata
+
+
+def _merge_parameters(base: Optional[dict], annotations: Optional[dict]) -> Optional[dict]:
+    """Merge declared property annotations into the introspected parameters
+    schema.
+
+    ``annotations`` is a dict of parameter name -> JSON Schema fragment (e.g.
+    ``{"voice": {"enum": [...]}}``). Each fragment is merged into the matching
+    introspected property (declared keys win, introspected ``type``/``default``
+    survive), so the base schema stays the single source of truth and models
+    only annotate valid values. Unknown properties are added as-is; nothing is
+    mutated.
+    """
+    if not annotations:
+        return base
+    if base is None or not isinstance(base.get("properties"), dict):
+        return {"type": "object", "properties": dict(annotations)}
+    properties = dict(base["properties"])
+    for name, fragment in annotations.items():
+        if not isinstance(fragment, dict):
+            continue
+        existing = properties.get(name)
+        if isinstance(existing, dict):
+            properties[name] = {**existing, **fragment}
+        else:
+            properties[name] = fragment
+    return {**base, "properties": properties}
+
+
+def _with_serving_runtime(metadata: ModelMetadata) -> ModelMetadata:
+    """Fill the serving runtime's identity (version / protocol) into metadata.
+
+    The runtime section describes who is serving the model; the model only
+    overrides fields it actually knows about (e.g. a custom runtime name).
+    """
+    defaults = default_runtime()
+    runtime = metadata.runtime
+    if runtime is None:
+        return replace(metadata, runtime=defaults)
+    return replace(
+        metadata,
+        runtime=ModelRuntime(
+            name=runtime.name or defaults.name,
+            version=runtime.version or defaults.version,
+            protocol=runtime.protocol or defaults.protocol,
+        ),
+    )

--- a/mlx_audio/server.py
+++ b/mlx_audio/server.py
@@ -44,6 +44,7 @@ from pydantic import BaseModel
 
 from mlx_audio.audio_io import read as audio_read
 from mlx_audio.audio_io import write as audio_write
+from mlx_audio.model_metadata import ModelMetadata, metadata_for_model
 from mlx_audio.realtime_vad import (
     VAD_SAMPLE_RATE,
     ServerVadConfig,
@@ -110,6 +111,20 @@ class ModelProvider:
     async def get_available_models(self):
         async with self.lock:
             return list(self.models.keys())
+
+    async def get_metadata(self, model_name: str) -> Optional[ModelMetadata]:
+        """Return machine-readable metadata for a loaded model.
+
+        Audio capabilities are inferred from the model's kind and
+        ``generate()`` signature; a model may correct or extend that baseline
+        through its ``get_metadata()`` hook. Returns ``None`` when the model
+        is not currently loaded.
+        """
+        async with self.lock:
+            model = self.models.get(model_name)
+        if model is None:
+            return None
+        return metadata_for_model(model, model_id=model_name)
 
 
 app = FastAPI()
@@ -917,6 +932,29 @@ async def list_models():
             }
         )
     return {"object": "list", "data": models_data}
+
+
+@app.get("/v1/models/{model_id:path}/metadata")
+async def get_model_metadata(model_id: str):
+    """Return machine-readable metadata for a loaded model.
+
+    The response describes what the loaded model/runtime actually supports: a
+    grounded baseline inferred from the model's kind and ``generate()``
+    signature, corrected or extended by the model's ``get_metadata()`` hook.
+    Nothing is hardcoded by this endpoint. The ``:path`` converter accepts
+    HuggingFace repo ids such as ``mlx-community/whisper-large-v3``. Models
+    must be loaded first (``POST /v1/models``).
+    """
+    metadata = await model_provider.get_metadata(model_id)
+    if metadata is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Model '{model_id}' is not loaded. Load it with "
+                f"POST /v1/models?model_name={model_id}"
+            ),
+        )
+    return metadata.to_dict()
 
 
 @app.post("/v1/models")

--- a/mlx_audio/sts/models/lfm_audio/model.py
+++ b/mlx_audio/sts/models/lfm_audio/model.py
@@ -15,6 +15,7 @@ from huggingface_hub import snapshot_download
 
 from mlx_audio.lm.models.cache import ArraysCache, KVCache
 from mlx_audio.lm.models.lfm2 import Lfm2Model
+from mlx_audio.model_metadata import ModelLimits, ModelMetadata
 
 from ....base import check_array_shape
 from .config import DepthformerConfig, LFM2AudioConfig
@@ -216,6 +217,15 @@ class AudioHead(nn.Module):
 
 
 class LFM2AudioModel(nn.Module):
+
+    def get_metadata(self) -> ModelMetadata:
+        # Context window is the LFM2 backbone's positional embedding limit.
+        lfm_config = getattr(self.config, "lfm", None)
+        return ModelMetadata(
+            limits=ModelLimits(
+                context_window=getattr(lfm_config, "max_position_embeddings", None)
+            )
+        )
 
     def __init__(self, config: LFM2AudioConfig):
         super().__init__()

--- a/mlx_audio/sts/models/moshi/moshi.py
+++ b/mlx_audio/sts/models/moshi/moshi.py
@@ -8,6 +8,7 @@ import sentencepiece
 from huggingface_hub import snapshot_download
 
 from mlx_audio.codec.models.mimi.mimi import Mimi, mimi_202407
+from mlx_audio.model_metadata import ModelLimits, ModelMetadata
 
 from . import generate as moshi_models
 from . import lm as moshi_lm
@@ -26,6 +27,15 @@ class MoshiConfig:
 
 
 class MoshiSTSModel:
+    def get_metadata(self) -> ModelMetadata:
+        # Context window is the LM transformer's max sequence length.
+        transformer = getattr(getattr(self, "lm_config", None), "transformer", None)
+        return ModelMetadata(
+            limits=ModelLimits(
+                context_window=getattr(transformer, "max_seq_len", None)
+            )
+        )
+
     def __init__(self, config: MoshiConfig):
         self.config = config
         self.lm_config = moshi_lm.config_v0_1()

--- a/mlx_audio/tests/test_model_metadata.py
+++ b/mlx_audio/tests/test_model_metadata.py
@@ -1,0 +1,658 @@
+"""Tests for the machine-readable model metadata endpoint and provider hook.
+
+The endpoint ``GET /v1/models/{model_id}/metadata`` must only serialize what
+the model/provider implementation reports; nothing about a model's capabilities
+may be hardcoded in the HTTP layer.
+"""
+
+import pytest
+
+pytest.importorskip("multipart", reason="python-multipart is required for server tests")
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from mlx_audio.model_metadata import (
+    ModelCapabilities,
+    ModelLimits,
+    ModelMetadata,
+    ModelRuntime,
+    metadata_for_model,
+    schema_for_callable,
+)
+from mlx_audio.server import ModelProvider, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def mock_model_provider():
+    with patch(
+        "mlx_audio.server.model_provider", new_callable=AsyncMock
+    ) as mock_provider:
+        yield mock_provider
+
+
+def _full_metadata(model_id="test-model"):
+    return ModelMetadata(
+        id=model_id,
+        capabilities=ModelCapabilities(
+            tools=True,
+            streaming=True,
+            vision=False,
+            audio_input=True,
+            audio_output=False,
+            structured_output=True,
+        ),
+        limits=ModelLimits(context_window=32768, max_output_tokens=4096),
+        parameters={
+            "type": "object",
+            "properties": {
+                "temperature": {"type": "number"},
+                "top_p": {"type": "number"},
+            },
+        },
+        runtime=ModelRuntime(name="mlx-audio", version="0.5.0", protocol="openai"),
+    )
+
+
+def _provider_with(models):
+    """A real ModelProvider pre-loaded with the given model objects."""
+    provider = ModelProvider()
+    provider.models = dict(models)
+    return provider
+
+
+class _BareModel:
+    """A loaded model that does not implement ``get_metadata()``."""
+
+
+# ---------------------------------------------------------------------------
+# Endpoint behavior
+# ---------------------------------------------------------------------------
+
+
+def test_model_metadata_valid_response(client, mock_model_provider):
+    mock_model_provider.get_metadata = AsyncMock(return_value=_full_metadata())
+    response = client.get("/v1/models/test-model/metadata")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert body["id"] == "test-model"
+    assert body["capabilities"] == {
+        "tools": True,
+        "streaming": True,
+        "vision": False,
+        "audio_input": True,
+        "audio_output": False,
+        "structured_output": True,
+    }
+    assert body["limits"] == {"context_window": 32768, "max_output_tokens": 4096}
+    assert body["parameters"] == {
+        "type": "object",
+        "properties": {
+            "temperature": {"type": "number"},
+            "top_p": {"type": "number"},
+        },
+    }
+    assert body["runtime"] == {
+        "name": "mlx-audio",
+        "version": "0.5.0",
+        "protocol": "openai",
+    }
+
+
+def test_model_metadata_unknown_model_returns_404(client, mock_model_provider):
+    mock_model_provider.get_metadata = AsyncMock(return_value=None)
+    response = client.get("/v1/models/not-loaded/metadata")
+    assert response.status_code == 404
+    assert "not-loaded" in response.json()["detail"]
+
+
+def test_model_metadata_accepts_hf_repo_ids(client, mock_model_provider):
+    """Model ids containing slashes (HuggingFace repo ids) must work, both raw
+    and percent-encoded."""
+    seen = {}
+
+    async def get_metadata(model_name):
+        seen["model"] = model_name
+        return ModelMetadata(id=model_name)
+
+    mock_model_provider.get_metadata = AsyncMock(side_effect=get_metadata)
+    for path in (
+        "/v1/models/mlx-community/whisper-large-v3/metadata",
+        "/v1/models/mlx-community%2Fwhisper-large-v3/metadata",
+    ):
+        response = client.get(path)
+        assert response.status_code == 200
+        assert response.json()["id"] == "mlx-community/whisper-large-v3"
+    assert seen["model"] == "mlx-community/whisper-large-v3"
+
+
+def test_model_without_metadata_returns_conservative_defaults(client, monkeypatch):
+    """A model that does not implement get_metadata() still yields a valid
+    response, but capabilities are unknown (null) rather than guessed."""
+    monkeypatch.setattr(
+        "mlx_audio.server.model_provider", _provider_with({"bare": _BareModel()})
+    )
+    response = client.get("/v1/models/bare/metadata")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "bare"
+    assert body["capabilities"] == {
+        "tools": None,
+        "streaming": None,
+        "vision": None,
+        "audio_input": None,
+        "audio_output": None,
+        "structured_output": None,
+    }
+    assert body["limits"] == {"context_window": None, "max_output_tokens": None}
+    assert body["parameters"] is None
+    assert body["runtime"]["name"] == "mlx-audio"
+    assert body["runtime"]["version"] is not None
+    assert body["runtime"]["protocol"] == "openai"
+
+
+def test_model_metadata_serializes_partial_capabilities_and_limits(
+    client, mock_model_provider
+):
+    """Unreported capabilities serialize as null, never as false."""
+    mock_model_provider.get_metadata = AsyncMock(
+        return_value=ModelMetadata(
+            id="m",
+            capabilities=ModelCapabilities(tools=False, streaming=True),
+            limits=ModelLimits(context_window=8192),
+        )
+    )
+    body = client.get("/v1/models/m/metadata").json()
+    assert body["capabilities"] == {
+        "tools": False,
+        "streaming": True,
+        "vision": None,
+        "audio_input": None,
+        "audio_output": None,
+        "structured_output": None,
+    }
+    assert body["limits"] == {"context_window": 8192, "max_output_tokens": None}
+
+
+def test_model_metadata_parameters_json_schema(client, mock_model_provider):
+    schema = {
+        "type": "object",
+        "properties": {
+            "temperature": {"type": "number", "minimum": 0.0, "maximum": 2.0},
+            "voice": {"type": "string"},
+            "stream": {"type": "boolean"},
+        },
+        "required": ["input"],
+    }
+    mock_model_provider.get_metadata = AsyncMock(
+        return_value=ModelMetadata(id="m", parameters=schema)
+    )
+    body = client.get("/v1/models/m/metadata").json()
+    assert body["parameters"] == schema
+
+
+def test_model_metadata_multiple_models(client, mock_model_provider):
+    async def get_metadata(model_name):
+        if model_name == "tts-model":
+            return ModelMetadata(
+                id=model_name,
+                capabilities=ModelCapabilities(audio_output=True, streaming=True),
+            )
+        if model_name == "stt-model":
+            return ModelMetadata(
+                id=model_name,
+                capabilities=ModelCapabilities(audio_input=True, streaming=False),
+            )
+        return None
+
+    mock_model_provider.get_metadata = AsyncMock(side_effect=get_metadata)
+    tts_body = client.get("/v1/models/tts-model/metadata").json()
+    stt_body = client.get("/v1/models/stt-model/metadata").json()
+    assert tts_body["capabilities"]["audio_output"] is True
+    assert tts_body["capabilities"]["audio_input"] is None
+    assert stt_body["capabilities"]["audio_input"] is True
+    assert stt_body["capabilities"]["audio_output"] is None
+
+
+def test_partially_constructed_metadata_serializes_unknowns(
+    client, mock_model_provider
+):
+    """None sections (capabilities/limits/runtime) serialize as unknown rather
+    than raising a 500 from the endpoint."""
+    mock_model_provider.get_metadata = AsyncMock(
+        return_value=ModelMetadata(id="m", capabilities=None, limits=None, runtime=None)
+    )
+    response = client.get("/v1/models/m/metadata")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == "m"
+    assert body["capabilities"]["tools"] is None
+    assert body["limits"]["context_window"] is None
+    assert body["runtime"]["name"] == "mlx-audio"
+
+
+def test_metadata_endpoint_echoes_provider_without_hardcoding(
+    client, mock_model_provider
+):
+    """The endpoint is a pure serializer: it must echo exactly what the
+    provider reports, including capabilities the endpoint has no knowledge of."""
+    exotic = ModelMetadata(
+        id="weird",
+        capabilities=ModelCapabilities(vision=True),
+        limits=ModelLimits(),
+        parameters=None,
+        runtime=ModelRuntime(name="custom-runtime", version="9.9", protocol="custom"),
+    )
+    mock_model_provider.get_metadata = AsyncMock(return_value=exotic)
+    body = client.get("/v1/models/weird/metadata").json()
+    assert body == exotic.to_dict()
+    assert body["capabilities"]["vision"] is True
+    assert body["capabilities"]["tools"] is None
+
+
+def test_new_model_only_needs_metadata_implementation(client, monkeypatch):
+    """Adding a model with different capabilities requires only implementing
+    ``get_metadata()`` on the model -- the metadata endpoint is untouched and no
+    model-specific conditional is added anywhere."""
+
+    class TtsModel:
+        def get_metadata(self):
+            return ModelMetadata(
+                id="internal-name",  # normalized to the requested id by the provider
+                capabilities=ModelCapabilities(
+                    tools=True, streaming=True, audio_output=True
+                ),
+                limits=ModelLimits(context_window=32768, max_output_tokens=4096),
+                # Property annotations are merged into the parameters schema.
+                parameters={
+                    "voice": {"type": "string", "enum": ["serena", "vivian"]}
+                },
+                runtime=ModelRuntime(name="my-tts-runtime", version="1.2.3"),
+            )
+
+    class SttModel:
+        def get_metadata(self):
+            return ModelMetadata(
+                id="internal-name",
+                capabilities=ModelCapabilities(streaming=False, audio_input=True),
+                limits=ModelLimits(context_window=8192),
+            )
+
+    monkeypatch.setattr(
+        "mlx_audio.server.model_provider",
+        _provider_with({"my-tts": TtsModel(), "my-stt": SttModel()}),
+    )
+
+    tts_body = client.get("/v1/models/my-tts/metadata").json()
+    assert tts_body["id"] == "my-tts"
+    assert tts_body["capabilities"]["tools"] is True
+    assert tts_body["capabilities"]["audio_output"] is True
+    assert tts_body["capabilities"]["audio_input"] is None  # not claimed
+    assert tts_body["limits"] == {
+        "context_window": 32768,
+        "max_output_tokens": 4096,
+    }
+    assert tts_body["parameters"] == {
+        "type": "object",
+        "properties": {"voice": {"type": "string", "enum": ["serena", "vivian"]}},
+    }
+    assert tts_body["runtime"] == {
+        "name": "my-tts-runtime",
+        "version": "1.2.3",
+        "protocol": "openai",  # serving runtime's protocol fills the gap
+    }
+
+    stt_body = client.get("/v1/models/my-stt/metadata").json()
+    assert stt_body["id"] == "my-stt"
+    assert stt_body["capabilities"]["audio_input"] is True
+    assert stt_body["capabilities"]["audio_output"] is None
+    assert stt_body["capabilities"]["streaming"] is False
+
+
+# ---------------------------------------------------------------------------
+# metadata_for_model dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_for_model_uses_duck_typed_hook():
+    class Model:
+        def get_metadata(self):
+            return ModelMetadata(
+                id="internal-name",
+                capabilities=ModelCapabilities(streaming=True),
+            )
+
+    metadata = metadata_for_model(Model(), model_id="requested-name")
+    assert isinstance(metadata, ModelMetadata)
+    assert metadata.id == "requested-name"
+    assert metadata.capabilities.streaming is True
+
+
+def test_metadata_for_model_falls_back_when_hook_missing_or_invalid():
+    class NoHook:
+        pass
+
+    class NonCallableHook:
+        get_metadata = "not a callable"
+
+    class InvalidHook:
+        def get_metadata(self):
+            return {"tools": True}  # not a ModelMetadata
+
+    for model in (NoHook(), NonCallableHook(), InvalidHook()):
+        metadata = metadata_for_model(model, model_id="m")
+        assert isinstance(metadata, ModelMetadata)
+        assert metadata.id == "m"
+        assert metadata.capabilities.tools is None
+        assert metadata.limits.context_window is None
+        assert metadata.runtime.name == "mlx-audio"
+
+
+def test_metadata_for_model_id_is_normalized_to_requested_id():
+    class Model:
+        def get_metadata(self):
+            return ModelMetadata(
+                id="internal-name",
+                capabilities=ModelCapabilities(audio_input=True),
+            )
+
+    metadata = metadata_for_model(Model(), model_id="hf-repo/model-name")
+    assert metadata.id == "hf-repo/model-name"
+
+
+def test_metadata_for_model_merges_serving_runtime():
+    """Model-provided metadata with an empty runtime gets the serving runtime's
+    version/protocol; an explicitly overridden runtime is preserved."""
+
+    class DefaultRuntimeModel:
+        def get_metadata(self):
+            return ModelMetadata(id="m", capabilities=ModelCapabilities(streaming=True))
+
+    merged = metadata_for_model(DefaultRuntimeModel(), model_id="m")
+    assert merged.runtime.name == "mlx-audio"
+    assert merged.runtime.version is not None
+    assert merged.runtime.protocol == "openai"
+
+    class CustomRuntimeModel:
+        def get_metadata(self):
+            return ModelMetadata(
+                id="m",
+                runtime=ModelRuntime(name="my-runtime", version="9.9"),
+            )
+
+    custom = metadata_for_model(CustomRuntimeModel(), model_id="m")
+    assert custom.runtime.name == "my-runtime"
+    assert custom.runtime.version == "9.9"
+    assert custom.runtime.protocol == "openai"  # still filled from serving runtime
+
+
+def _model_with_module(module: str, namespace=None):
+    """A minimal loaded model whose concrete class lives under ``module``."""
+    cls = type("Model", (), namespace or {})
+    cls.__module__ = module
+    return cls()
+
+
+def test_metadata_for_model_infers_audio_shape_from_kind():
+    """Audio I/O is inferred from the model's kind (its module path) -- no
+    per-model declaration or hardcoded table in the HTTP layer."""
+    tts = metadata_for_model(
+        _model_with_module("mlx_audio.tts.models.kokoro.kokoro"), model_id="kokoro"
+    )
+    assert tts.capabilities.audio_output is True
+    assert tts.capabilities.audio_input is None  # TTS kind: may or may not clone
+    assert tts.capabilities.tools is None  # never guessed from a kind
+
+    stt = metadata_for_model(
+        _model_with_module("mlx_audio.stt.models.whisper.whisper"), model_id="whisper"
+    )
+    assert stt.capabilities.audio_input is True
+    assert stt.capabilities.audio_output is False
+
+    sts = metadata_for_model(
+        _model_with_module("mlx_audio.sts.models.moshi.moshi"), model_id="moshi"
+    )
+    assert sts.capabilities.audio_input is True
+    assert sts.capabilities.audio_output is True
+
+    lid = metadata_for_model(
+        _model_with_module("mlx_audio.lid.models.ecapa_tdnn.ecapa_tdnn"),
+        model_id="lid",
+    )
+    assert lid.capabilities.audio_input is True
+    assert lid.capabilities.audio_output is False
+
+
+def test_metadata_for_model_derives_streaming_and_ref_audio_from_signature():
+    """Streaming / reference-audio support come from the model's own generate()
+    signature; absent parameters stay unknown."""
+
+    def streaming_with_ref(text, *, stream=False, ref_audio=None):
+        ...
+
+    def plain(text):
+        ...
+
+    streamed = metadata_for_model(
+        _model_with_module("mlx_audio.tts.models.fake.fake", {"generate": streaming_with_ref}),
+        model_id="m",
+    )
+    assert streamed.capabilities.streaming is True
+    assert streamed.capabilities.audio_input is True  # ref_audio param
+
+    plain_model = metadata_for_model(
+        _model_with_module("mlx_audio.tts.models.fake.fake", {"generate": plain}),
+        model_id="m",
+    )
+    assert plain_model.capabilities.streaming is None
+    assert plain_model.capabilities.audio_input is None
+
+
+def test_metadata_for_model_declared_fields_override_inferred():
+    """Non-None declared fields win; everything else falls back to inference."""
+
+    class Model:
+        def get_metadata(self):
+            return ModelMetadata(
+                capabilities=ModelCapabilities(audio_input=False, tools=False),
+                limits=ModelLimits(context_window=32768),
+            )
+
+    Model.__module__ = "mlx_audio.tts.models.fake.fake"
+
+    meta = metadata_for_model(Model(), model_id="m")
+    assert meta.capabilities.audio_output is True  # inferred from TTS kind
+    assert meta.capabilities.audio_input is False  # declared override
+    assert meta.capabilities.tools is False
+    assert meta.limits.context_window == 32768
+    assert meta.id == "m"
+
+
+def test_metadata_for_model_limits_only_hook_keeps_inferred_capabilities():
+    """A model that only declares limits still inherits its kind's audio shape."""
+
+    class Model:
+        def get_metadata(self):
+            return ModelMetadata(limits=ModelLimits(context_window=4096))
+
+    Model.__module__ = "mlx_audio.sts.models.moshi.moshi"
+
+    meta = metadata_for_model(Model(), model_id="moshi")
+    assert meta.capabilities.audio_input is True
+    assert meta.capabilities.audio_output is True
+    assert meta.limits.context_window == 4096
+
+
+def test_schema_for_callable_introspects_types_defaults_and_required():
+    """Type hints become JSON Schema types, defaults are serialized, and
+    parameters without defaults become ``required``."""
+
+    def generate(text: str, speed: float = 1.0, max_tokens: int = 4096, verbose: bool = False):
+        ...
+
+    schema = schema_for_callable(generate)
+    assert schema["type"] == "object"
+    assert schema["required"] == ["text"]
+    assert schema["properties"]["text"] == {"type": "string"}
+    assert schema["properties"]["speed"] == {"type": "number", "default": 1.0}
+    assert schema["properties"]["max_tokens"] == {"type": "integer", "default": 4096}
+    assert schema["properties"]["verbose"] == {"type": "boolean", "default": False}
+
+
+def test_schema_for_callable_handles_optional_union_and_literal():
+    from typing import Literal, Optional, Union
+
+    def generate(
+        text: str,
+        voice: Optional[str] = None,
+        task: Literal["transcribe", "translate"] = "transcribe",
+        audio: Union[str, list[int]] = None,
+    ):
+        ...
+
+    schema = schema_for_callable(generate)
+    props = schema["properties"]
+    assert props["voice"] == {"type": "string", "default": None}
+    assert props["task"] == {"enum": ["transcribe", "translate"], "default": "transcribe"}
+    assert props["audio"] == {"type": ["string", "array"], "default": None}
+    assert schema["required"] == ["text"]
+
+
+def test_metadata_for_model_attaches_introspected_parameters():
+    """A model's entry-point signature yields a parameters schema automatically,
+    with no get_metadata() hook needed."""
+
+    class Model:
+        def generate(self, text: str, speed: float = 1.0):
+            ...
+
+    Model.__module__ = "mlx_audio.tts.models.fake.fake"
+
+    meta = metadata_for_model(Model(), model_id="fake")
+    assert meta.parameters == {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string"},
+            "speed": {"type": "number", "default": 1.0},
+        },
+        "required": ["text"],
+    }
+
+
+
+def test_qwen3_tts_hook_declares_variant_dependent_audio_input():
+    """The qwen3_tts hook reports audio_input only for the base variant;
+    CustomVoice/VoiceDesign ignore ref_audio. Skipped where the model module
+    cannot be imported (no real mlx available)."""
+    try:
+        from mlx_audio.tts.models.qwen3_tts.config import (
+            ModelConfig,
+            Qwen3TTSTalkerConfig,
+        )
+        from mlx_audio.tts.models.qwen3_tts.qwen3_tts import Model
+    except (ImportError, AttributeError) as exc:
+        pytest.skip(f"qwen3_tts model module unavailable: {exc}")
+
+    model = Model.__new__(Model)  # bypass heavy __init__; only config is needed
+    model.config = ModelConfig(
+        tts_model_type="custom_voice",
+        talker_config=Qwen3TTSTalkerConfig(
+            spk_id={"serena": [0], "vivian": [1], "ryan": [2]},
+            codec_language_id={"English": [0], "Chinese": [1], "English-dialect": [2]},
+        ),
+    )
+    metadata = model.get_metadata()
+    assert isinstance(metadata, ModelMetadata)
+    assert metadata.capabilities.audio_output is True
+    assert metadata.capabilities.streaming is True
+    assert metadata.capabilities.tools is False
+    assert metadata.capabilities.audio_input is False  # custom_voice: no ref audio
+    assert metadata.parameters == {
+        "voice": {"enum": ["serena", "vivian", "ryan"]},
+        "lang_code": {"enum": ["auto", "English", "Chinese"]},  # dialect excluded
+    }
+
+    model.config = ModelConfig(tts_model_type="voice_design")
+    assert model.get_metadata().capabilities.audio_input is False
+
+    model.config = ModelConfig(tts_model_type="base")
+    assert model.get_metadata().capabilities.audio_input is True
+
+def test_sts_entry_point_discovered_without_generate():
+    """STS families (e.g. LFM2Audio) expose generate_interleaved instead of
+    generate; parameters must still be introspected."""
+
+    class Model:
+        def generate_interleaved(self, max_new_tokens: int = 512, temperature: float = 1.0):
+            ...
+
+    Model.__module__ = "mlx_audio.sts.models.lfm_audio.model"
+
+    meta = metadata_for_model(Model(), model_id="lfm")
+    assert meta.capabilities.audio_input is True
+    assert meta.capabilities.audio_output is True
+    assert meta.parameters == {
+        "type": "object",
+        "properties": {
+            "max_new_tokens": {"type": "integer", "default": 512},
+            "temperature": {"type": "number", "default": 1.0},
+        },
+    }
+
+def test_declared_parameters_merge_as_property_annotations():
+    """A hook's parameters dict is treated as property annotations and merged
+    into the introspected schema: declared fragments win per-property, while
+    introspected type/default survive and untouched properties stay as-is."""
+
+    class Model:
+        def generate(self, text: str, voice: str = None, lang_code: str = "auto"):
+            ...
+
+        def get_metadata(self):
+            return ModelMetadata(
+                parameters={
+                    "voice": {"enum": ["serena", "vivian"]},
+                    "lang_code": {"enum": ["auto", "English"]},
+                }
+            )
+
+    Model.__module__ = "mlx_audio.tts.models.fake.fake"
+
+    meta = metadata_for_model(Model(), model_id="m")
+    props = meta.parameters["properties"]
+    assert props["voice"] == {
+        "type": "string",
+        "default": None,
+        "enum": ["serena", "vivian"],
+    }
+    assert props["lang_code"] == {
+        "type": "string",
+        "default": "auto",
+        "enum": ["auto", "English"],
+    }
+    assert props["text"] == {"type": "string"}  # untouched
+    assert meta.parameters["required"] == ["text"]
+
+
+def test_declared_parameters_annotations_without_introspected_schema():
+    """When there is no introspected schema, declared property annotations are
+    wrapped into a minimal object schema."""
+
+    class Model:
+        def get_metadata(self):
+            return ModelMetadata(parameters={"task": {"enum": ["a", "b"]}})
+
+    Model.__module__ = "mlx_audio.tts.models.fake.fake"
+
+    meta = metadata_for_model(Model(), model_id="m")
+    assert meta.parameters == {
+        "type": "object",
+        "properties": {"task": {"enum": ["a", "b"]}},
+    }

--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -17,6 +17,7 @@ from mlx_audio.lm.sample_utils import (
     apply_top_p,
     categorical_sampling,
 )
+from mlx_audio.model_metadata import ModelCapabilities, ModelLimits, ModelMetadata
 from mlx_audio.tts.continuous import TTSBatchItem, TTSBatchOptions
 from mlx_audio.tts.models.base import BatchGenerationResult, GenerationResult
 from mlx_audio.utils import load_audio
@@ -30,6 +31,34 @@ from .config import (
 from .speaker_encoder import Qwen3TTSSpeakerEncoder
 from .speech_tokenizer import Qwen3TTSSpeechTokenizer
 from .talker import Qwen3TTSTalkerForConditionalGeneration
+
+
+def _parameter_annotations(config) -> Optional[Dict[str, dict]]:
+    """Property annotations for the parameters schema: valid ``voice`` /
+    ``lang_code`` values as ``enum`` fragments.
+
+    ``voice`` comes from the talker config's preset speakers (omitted when the
+    variant has no preset voices -- base clones from reference audio instead);
+    ``lang_code`` lists the supported codes, "auto" first, excluding dialect
+    entries (e.g. "English-dialect"), matching the model.
+    """
+    talker = getattr(config, "talker_config", None)
+    spk_id = getattr(talker, "spk_id", None) if talker is not None else None
+    voices = list(spk_id.keys()) if spk_id else None
+
+    codec_lang = (
+        getattr(talker, "codec_language_id", None) if talker is not None else None
+    )
+    languages = ["auto"]
+    if codec_lang:
+        languages.extend(lang for lang in codec_lang if "dialect" not in lang)
+
+    annotations = {}
+    if voices:
+        annotations["voice"] = {"enum": voices}
+    if languages:
+        annotations["lang_code"] = {"enum": languages}
+    return annotations or None
 
 
 @dataclass
@@ -211,6 +240,41 @@ class Model(nn.Module):
     @property
     def model_type(self) -> str:
         return "qwen3_tts"
+
+    def get_metadata(self) -> ModelMetadata:
+        """Declare what this model supports for the metadata endpoint.
+
+        Grounded in the implementation: ``generate()`` streams on all three
+        model variants (base / custom_voice / voice_design); only base models
+        accept reference audio for voice cloning (CustomVoice and VoiceDesign
+        generate from text + instructions and ignore ``ref_audio``); the
+        context window is the talker's max position embeddings. Parameters are
+        introspected from ``generate()``'s signature, not declared here.
+        """
+        talker = getattr(self.config, "talker_config", None)
+        return ModelMetadata(
+            id=self.model_type,
+            capabilities=ModelCapabilities(
+                tools=False,
+                streaming=True,
+                vision=False,
+                # Base models clone voices from reference audio; VoiceDesign and
+                # CustomVoice variants generate from text + instructions only.
+                audio_input=getattr(self.config, "tts_model_type", "base") == "base",
+                audio_output=True,
+                structured_output=False,
+            ),
+            limits=ModelLimits(
+                context_window=getattr(talker, "max_position_embeddings", None),
+                max_output_tokens=4096,
+            ),
+            # Annotate valid ``voice`` / ``lang_code`` values directly on the
+            # parameters schema; the server merges these into the introspected
+            # ``generate()`` schema as ``enum`` constraints, so clients never
+            # have to guess a ``voice`` (CustomVoice rejects unknown or missing
+            # speaker names with a ValueError).
+            parameters=_parameter_annotations(self.config),
+        )
 
     def supports_tts_batch(
         self,


### PR DESCRIPTION
## Context
OpenAI-compatible clients can discover available models via `/v1/models`, but not what those models actually support (tools, streaming, structured output, request parameters, limits, etc.). This often leads client frameworks to maintain provider-specific compatibility logic.

## Description
This PR adds an optional `GET /v1/models/{id}/metadata` endpoint that exposes machine-readable model metadata while keeping the existing OpenAI-compatible API unchanged.

The metadata is provided by the provider/runtime abstraction rather than a hardcoded model registry, making it easy to extend for future providers.

## Changes in the codebase
Adds a dynamic GET /v1/models/{model_id}/metadata endpoint exposing model capabilities, limits, request parameters, and runtime info.
Metadata is derived from the loaded model at runtime, with optional model-level hooks for overrides. No hardcoded model registry. Includes tests and docs.

## Changes outside the codebase
None.

## Additional information
This is a fully backward-compatible, additive change; existing endpoints and clients continue to work unchanged.

I originally implemented this for my MLX-Audio fork to make model capabilities and parameters discoverable without hardcoding them. This is especially useful for enum parameters such as predefined voices or supported languages.

If the maintainers are interested, I can also update the MLX-Audio UI to build parameter forms dynamically from this metadata. If this isn't aligned with the project's direction, that's completely fine - I'll continue maintaining it in my fork.



<!-- Optional: Add a checklist for contributors -->
## Checklist
- [x] Tests added/updated
- [x] Documentation updated
