### PR TITLE
arktts: support Audio8-TTS-Preview-0.1b (Falcon-H1 slow backbone)

### DIFF
--- a/mlx_audio/lm/models/cache.py
+++ b/mlx_audio/lm/models/cache.py
@@ -718,3 +718,92 @@ class BatchKVCache(_BaseCache):
         if self.keys is None:
             return 0
         return self.keys.nbytes + self.values.nbytes
+
+
+class CacheList(_BaseCache):
+    def __init__(self, *caches):
+        self.caches = caches
+
+    def __getitem__(self, idx):
+        return self.caches[idx]
+
+    def is_trimmable(self):
+        return all(c.is_trimmable() for c in self.caches)
+
+    def trim(self, n):
+        for c in self.caches:
+            m = c.trim(n)
+        return m
+
+    @property
+    def state(self):
+        return [c.state for c in self.caches]
+
+    @state.setter
+    def state(self, v):
+        for c, s in zip(self.caches, v):
+            c.state = s
+
+    @property
+    def meta_state(self):
+        return (
+            [type(c).__name__ for c in self.caches],
+            [c.meta_state for c in self.caches],
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        for c, m in zip(self.caches, v[1]):
+            c.meta_state = m
+
+    def filter(self, batch_indices):
+        """
+        In-place filter to keep just the given indices in the cache.
+        """
+        for c in self.caches:
+            c.filter(batch_indices)
+
+    def extend(self, other):
+        """
+        In-place extend this cache with the other cache.
+        """
+        for c, o in zip(self.caches, other.caches):
+            c.extend(o)
+
+    @classmethod
+    def merge(cls, caches):
+        cache = cls()
+        cache.caches = tuple(
+            caches[0].caches[i].merge([c.caches[i] for c in caches])
+            for i in range(len(caches[0].caches))
+        )
+        return cache
+
+    def extract(self, idx):
+        return CacheList(*(c.extract(idx) for c in self.caches))
+
+    def prepare(self, **kwargs):
+        for c in self.caches:
+            c.prepare(**kwargs)
+
+    def finalize(self):
+        for c in self.caches:
+            c.finalize()
+
+    def size(self):
+        return max(c.size() for c in self.caches)
+
+    def empty(self):
+        return self.caches[0].empty()
+
+    @property
+    def nbytes(self):
+        return sum(c.nbytes for c in self.caches)
+
+    @classmethod
+    def from_state(cls, state, meta_state):
+        obj = cls.__new__(cls)
+        obj.caches = [
+            globals()[c].from_state(s, m) for s, c, m in zip(state, *meta_state)
+        ]
+        return obj

--- a/mlx_audio/lm/models/falcon_h1.py
+++ b/mlx_audio/lm/models/falcon_h1.py
@@ -1,0 +1,505 @@
+# Copyright © 2025 Apple Inc.
+# Vendored from mlx-lm 0.31.3.
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .activations import swiglu
+from .base import (
+    BaseModelArgs,
+    create_attention_mask,
+    create_ssm_mask,
+    scaled_dot_product_attention,
+)
+from .cache import ArraysCache, CacheList, KVCache
+from .rope_utils import initialize_rope
+from .ssm import ssm_update
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    attention_bias: bool = False
+    attention_in_multiplier: float = 1.0
+    attention_out_multiplier: float = 0.9375
+    embedding_multiplier: float = 5.656854249492381
+    head_dim: int = 64
+    hidden_size: int = 1024
+    initializer_range: float = 0.02
+    intermediate_size: int = 2048
+    key_multiplier: float = 0.390625
+    lm_head_multiplier: float = 0.0390625
+    mamba_chunk_size: int = 128
+    mamba_conv_bias: bool = True
+    mamba_d_conv: int = 4
+    mamba_d_head: int = 64
+    mamba_d_ssm: int = 1536
+    mamba_d_state: int = 128
+    mamba_expand: int = 2
+    mamba_n_groups: int = 1
+    mamba_n_heads: int = 24
+    mamba_norm_before_gate: bool = False
+    mamba_proj_bias: bool = False
+    mamba_rms_norm: bool = False
+    mamba_use_mlp: bool = True
+    max_position_embeddings: int = 131072
+    mlp_bias: bool = False
+    mlp_expansion_factor: int = 8
+    mlp_multipliers: List[float] = field(
+        default_factory=lambda: [0.8838834764831844, 0.5859375]
+    )
+    model_type: str = "falcon_h1"
+    num_attention_heads: int = 8
+    num_hidden_layers: int = 36
+    num_key_value_heads: int = 2
+    projectors_bias: bool = False
+    rms_norm_eps: float = 1e-05
+    rope_traditional: bool = False
+    rope_scaling: Optional[float] = None
+    rope_theta: float = 100000000000.0
+    ssm_in_multiplier: float = 1.25
+    ssm_multipliers: List[float] = field(
+        default_factory=lambda: [
+            0.3535533905932738,
+            0.25,
+            0.3535533905932738,
+            0.5,
+            0.3535533905932738,
+        ]
+    )
+    ssm_out_multiplier: float = 0.23570226039551587
+    vocab_size: int = 32784
+    tie_word_embeddings: bool = True
+
+
+class FalconH1RMSNormGated(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6, n_groups=1, norm_before_gate=True):
+        super().__init__()
+        self.weight = mx.ones((hidden_size,))
+        self.variance_epsilon = eps
+        self.n_groups = n_groups
+        self.norm_before_gate = norm_before_gate
+
+    def __call__(self, hidden_states, gate=None):
+        if not self.norm_before_gate and gate is not None:
+            hidden_states = swiglu(gate, hidden_states)
+
+        hidden_states = mx.fast.rms_norm(
+            hidden_states, self.weight, self.variance_epsilon
+        )
+
+        if self.norm_before_gate and gate is not None:
+            hidden_states = swiglu(gate, hidden_states)
+        return hidden_states
+
+
+def compute_mup_vector(args):
+    intermediate_size = args.mamba_d_ssm
+    groups_time_state_size = args.mamba_n_groups * args.mamba_d_state
+    num_heads = args.mamba_n_heads
+    sizes = [
+        intermediate_size,
+        intermediate_size,
+        groups_time_state_size,
+        groups_time_state_size,
+        num_heads,
+    ]
+    return mx.concatenate(
+        [
+            mx.broadcast_to(mx.array(m), (s,))
+            for s, m in zip(sizes, args.ssm_multipliers)
+        ]
+    )
+
+
+class FalconH1Attention(nn.Module):
+
+    def __init__(self, args):
+        super().__init__()
+
+        self.hidden_size = args.hidden_size
+        self.num_heads = args.num_attention_heads
+        self.num_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            self.hidden_size, self.num_heads * self.head_dim, bias=args.attention_bias
+        )
+        self.k_proj = nn.Linear(
+            self.hidden_size,
+            self.num_kv_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size,
+            self.num_kv_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim, self.hidden_size, bias=args.attention_bias
+        )
+
+        self.rope = initialize_rope(
+            self.head_dim,
+            args.rope_theta,
+            args.rope_traditional,
+            args.rope_scaling,
+            args.max_position_embeddings,
+        )
+
+    def __call__(self, x, mask=None, cache=None):
+        B, L, _ = x.shape
+
+        queries = self.q_proj(x)
+        keys = self.k_proj(x)
+        values = self.v_proj(x)
+
+        queries = queries.reshape(B, L, self.num_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(B, L, self.num_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(B, L, self.num_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, mask=mask, scale=self.scale, cache=cache
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+
+        return self.o_proj(output)
+
+
+class FalconH1Mixer(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.num_heads = args.mamba_n_heads
+        self.hidden_size = args.hidden_size
+        self.ssm_state_size = args.mamba_d_state
+        self.conv_kernel_size = args.mamba_d_conv
+        self.intermediate_size = args.mamba_d_ssm
+        self.use_conv_bias = args.mamba_conv_bias
+
+        self.layer_norm_epsilon = args.rms_norm_eps
+        self.groups_time_state_size = args.mamba_n_groups * self.ssm_state_size
+
+        self.n_groups = args.mamba_n_groups
+        self.head_dim = args.mamba_d_head
+        self.chunk_size = args.mamba_chunk_size
+
+        self.time_step_limit = (0.0, float("inf"))
+        self.time_step_min = 0.001
+        self.time_step_max = 0.1
+
+        self.conv_dim = self.intermediate_size + 2 * self.n_groups * self.ssm_state_size
+        self.conv1d = nn.Conv1d(
+            in_channels=self.conv_dim,
+            out_channels=self.conv_dim,
+            bias=self.use_conv_bias,
+            kernel_size=self.conv_kernel_size,
+            groups=self.conv_dim,
+        )
+
+        projection_size = self.intermediate_size + self.conv_dim + self.num_heads
+        self.in_proj = nn.Linear(
+            self.hidden_size,
+            projection_size,
+            bias=args.mamba_proj_bias,
+        )
+
+        self.dt_bias = mx.ones(self.num_heads)
+
+        A = mx.arange(1, self.num_heads + 1)
+        self.A_log = mx.log(A)
+
+        self.mamba_rms_norm = args.mamba_rms_norm
+        if self.mamba_rms_norm:
+            self.norm = FalconH1RMSNormGated(
+                self.intermediate_size,
+                eps=self.layer_norm_epsilon,
+                n_groups=self.n_groups,
+                norm_before_gate=args.mamba_norm_before_gate,
+            )
+
+        self.D = mx.ones(self.num_heads)
+
+        self.out_proj = nn.Linear(
+            self.intermediate_size, self.hidden_size, bias=args.projectors_bias
+        )
+
+    def _conv(
+        self,
+        conv_input: mx.array,
+        cache: Optional[ArraysCache],
+        mask: Optional[mx.array],
+    ) -> mx.array:
+        if mask is not None:
+            conv_input = mx.where(mask[..., None], conv_input, 0)
+
+        if cache is not None:
+            if cache[0] is None:
+                conv_state = mx.zeros(
+                    (conv_input.shape[0], self.conv_kernel_size - 1, self.conv_dim),
+                    dtype=conv_input.dtype,
+                )
+            else:
+                conv_state = cache[0]
+            padded_input = mx.concatenate([conv_state, conv_input], axis=1)
+            n_keep = self.conv_kernel_size - 1
+            if cache.lengths is not None:
+                t = padded_input.shape[1]
+                ends = mx.clip(cache.lengths, 0, t - n_keep)
+                positions = (ends[:, None] + mx.arange(n_keep))[..., None]
+                cache[0] = mx.take_along_axis(padded_input, positions, axis=1)
+            else:
+                cache[0] = padded_input[:, -n_keep:, :]
+        else:
+            padded_input = mx.pad(
+                conv_input, [(0, 0), (self.conv_kernel_size - 1, 0), (0, 0)]
+            )
+
+        conv_output = self.conv1d(padded_input)
+        return nn.silu(conv_output)
+
+    def _ssm(
+        self,
+        hidden_states: mx.array,
+        B: mx.array,
+        C: mx.array,
+        dt: mx.array,
+        cache: Optional[ArraysCache],
+        mask: Optional[mx.array],
+    ) -> mx.array:
+        batch_size, seq_len, _ = hidden_states.shape
+        hidden_states = hidden_states.reshape(
+            batch_size, seq_len, self.num_heads, self.head_dim
+        )
+        B = B.reshape(batch_size, seq_len, self.n_groups, self.ssm_state_size)
+        C = C.reshape(batch_size, seq_len, self.n_groups, self.ssm_state_size)
+        if cache:
+            state = cache[1]
+            lengths = cache.lengths
+        else:
+            state, lengths = None, None
+        y, state = ssm_update(
+            hidden_states,
+            self.A_log,
+            B,
+            C,
+            self.D,
+            dt,
+            self.dt_bias,
+            state,
+            self.time_step_limit,
+            mask,
+            lengths,
+        )
+        if cache:
+            cache[1] = state
+        return y.reshape(batch_size, seq_len, self.intermediate_size)
+
+    def __call__(self, input_states, cache=None, mask: Optional[mx.array] = None):
+        projected_states = self.in_proj(input_states)
+
+        gate, conv_input, dt = mx.split(
+            projected_states,
+            [self.intermediate_size, self.intermediate_size + self.conv_dim],
+            axis=-1,
+        )
+
+        conv_output = self._conv(conv_input, cache, mask)
+
+        hidden_states, B, C = mx.split(
+            conv_output,
+            [
+                self.intermediate_size,
+                self.intermediate_size + self.n_groups * self.ssm_state_size,
+            ],
+            axis=-1,
+        )
+
+        y = self._ssm(hidden_states, B, C, dt, cache, mask=mask)
+        if cache:
+            cache.advance(y.shape[1])
+
+        if self.mamba_rms_norm:
+            y = self.norm(y, gate)
+        else:
+            y = swiglu(gate, y)
+
+        return self.out_proj(y)
+
+
+class FalconH1MLP(nn.Module):
+
+    def __init__(self, args):
+        super().__init__()
+
+        hidden_size = args.hidden_size
+        intermediate_size = args.intermediate_size
+
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=args.mlp_bias)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=args.mlp_bias)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=args.mlp_bias)
+
+    def __call__(self, x):
+        y = swiglu(self.gate_proj(x), self.up_proj(x))
+        y = self.down_proj(y)
+        return y
+
+
+class FalconH1DecoderLayer(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.feed_forward = FalconH1MLP(args)
+
+        head_dim = args.head_dim
+        self.channels_attn = (
+            args.num_attention_heads * head_dim
+            + 2 * args.num_key_value_heads * head_dim
+        )
+
+        self.mamba = FalconH1Mixer(args=args)
+
+        self.self_attn = FalconH1Attention(args)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.pre_ff_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        h: mx.array,
+        cache,
+        attn_mask: Optional[mx.array],
+        mamba_mask: Optional[mx.array],
+    ) -> mx.array:
+
+        residual = h
+        h = self.input_layernorm(h)
+
+        mamba_h = self.mamba(input_states=h, cache=cache[0], mask=mamba_mask)
+
+        attn_h = self.self_attn(
+            h,
+            mask=attn_mask,
+            cache=cache[1],
+        )
+
+        h = residual + mamba_h + attn_h
+
+        residual = h
+        h = self.pre_ff_layernorm(h)
+        h = self.feed_forward(h)
+        return residual + h
+
+
+class FalconH1Model(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.hidden_size = args.hidden_size
+
+        self.embed_tokens = nn.Embedding(self.vocab_size, self.hidden_size)
+
+        self._mup_vector = compute_mup_vector(args)
+        self.layers = [
+            FalconH1DecoderLayer(args) for _ in range(args.num_hidden_layers)
+        ]
+        self.final_layernorm = nn.RMSNorm(self.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs, cache=None):
+
+        h = self.embed_tokens(inputs)
+
+        h = h
+
+        if cache is None:
+            cache = [(None, None) * len(self.layers)]
+
+        mamba_mask = create_ssm_mask(h, cache[0][0])
+        attn_mask = create_attention_mask(h, cache[0][1])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(
+                h,
+                cache=c,
+                attn_mask=attn_mask,
+                mamba_mask=mamba_mask,
+            )
+
+        return self.final_layernorm(h)
+
+
+class Model(nn.Module):
+
+    def __init__(self, args):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = FalconH1Model(args=args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(self, inputs, cache=None):
+        hidden_states = self.model(inputs, cache=cache)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(hidden_states)
+            return out * (self.args.lm_head_multiplier / self.args.embedding_multiplier)
+        else:
+            return self.lm_head(hidden_states)
+
+    def sanitize(self, weights):
+        # Check if needs sanitization
+        c1d = weights["model.layers.0.mamba.conv1d.weight"]
+        if c1d.shape[-1] <= c1d.shape[1]:
+            return weights
+
+        sanitized_weights = {}
+        args = self.args
+
+        for name, param in weights.items():
+            # Fold-in multipliers
+            if name.endswith("embed_tokens.weight"):
+                param *= args.embedding_multiplier
+            elif name.endswith("lm_head.weight"):
+                param *= args.lm_head_multiplier
+            elif name.endswith("q_proj.weight") or name.endswith("k_proj.weight"):
+                param *= args.attention_in_multiplier
+            elif name.endswith("key_proj.weight"):
+                param *= args.attention_in_multiplier * args.key_multiplier
+            elif name.endswith("o_proj.weight"):
+                param *= args.attention_out_multiplier
+            elif name.endswith("out_proj.weight"):
+                param *= args.ssm_out_multiplier
+            elif name.endswith("gate_proj.weight"):
+                param *= args.mlp_multipliers[0]
+            elif name.endswith("down_proj.weight"):
+                param *= args.mlp_multipliers[1]
+            elif name.endswith("in_proj.weight"):
+                param *= (
+                    args.ssm_in_multiplier
+                    * self.model._mup_vector.astype(param.dtype)[:, None]
+                )
+            elif "conv1d.weight" in name:
+                param = param.transpose(0, 2, 1)
+            sanitized_weights[name] = param
+        return sanitized_weights
+
+    def make_cache(self):
+        return [
+            CacheList(ArraysCache(size=2), KVCache())
+            for _ in range(self.args.num_hidden_layers)
+        ]
+
+    @property
+    def layers(self):
+        return self.model.layers

--- a/mlx_audio/lm/models/ssm.py
+++ b/mlx_audio/lm/models/ssm.py
@@ -1,0 +1,263 @@
+# Copyright © 2025 Apple Inc.
+# Vendored from mlx-lm 0.31.3.
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@mx.compile
+def compute_dt(dt, dt_bias, time_step_limit):
+    dt = dt.astype(mx.float32)
+    dt = nn.softplus(dt + dt_bias)
+    return mx.clip(dt, time_step_limit[0], time_step_limit[1])
+
+
+def make_ssm_kernel():
+    if not mx.metal.is_available():
+        return None
+    source = """
+        auto n = thread_position_in_grid.z;
+        auto h_idx = n % H;
+        auto g_idx = n / G;
+        constexpr int n_per_t = Ds / 32;
+
+        auto x = X + n * Dh;
+        out += n * Dh;
+        auto i_state = state_in + n * Dh * Ds;
+        auto o_state = state_out + n * Dh * Ds;
+
+        // C and B have shape [batch, group, state_dim]
+        // C and B need to be offset by group size
+        auto C_ = C + g_idx * Ds;
+        auto B_ = B + g_idx * Ds;
+
+        auto ds_idx = thread_position_in_threadgroup.x;
+        auto d_idx = thread_position_in_grid.y;
+
+        auto dt_ = static_cast<float>(dt[n]);
+        auto A = -fast::exp(static_cast<float>(A_log[h_idx]));
+        auto dA = fast::exp(A * dt_);
+
+        float acc = 0.0;
+        auto x_ = static_cast<float>(x[d_idx]);
+
+        for (int i = 0; i < n_per_t; ++i) {
+            auto s_idx = n_per_t * ds_idx + i;
+            auto idx = d_idx * Ds + s_idx;
+            auto dB_by_x = x_ * dt_ * static_cast<float>(B_[s_idx]);
+            auto state = dA * i_state[idx] + dB_by_x;
+            o_state[idx] = static_cast<U>(state);
+            acc += state * C_[s_idx];
+        }
+        acc = simd_sum(acc);
+        if (thread_index_in_simdgroup == 0) {
+            out[d_idx] = static_cast<T>(acc + x_ * D[h_idx]);
+        }
+    """
+    return mx.fast.metal_kernel(
+        name="ssm_kernel",
+        input_names=["X", "A_log", "B", "C", "D", "dt", "state_in"],
+        output_names=["out", "state_out"],
+        source=source,
+    )
+
+
+_ssm_kernel = make_ssm_kernel()
+
+
+def ssm_update_kernel(
+    hidden_states: mx.array,
+    A_log: mx.array,
+    B: mx.array,
+    C: mx.array,
+    D: mx.array,
+    dt: mx.array,
+    dt_bias: mx.array,
+    state: mx.array,
+    time_step_limit: Tuple[float, float],
+):
+    n, _, h, d = hidden_states.shape
+    input_type = hidden_states.dtype
+    state_type = state.dtype
+    hb, ds = B.shape[-2:]
+    dt = compute_dt(dt, dt_bias, time_step_limit)
+    return _ssm_kernel(
+        inputs=[hidden_states, A_log, B, C, D, dt, state],
+        template=[
+            ("T", input_type),
+            ("U", state_type),
+            ("Dh", d),
+            ("Ds", ds),
+            ("H", h),
+            ("G", h // hb),
+        ],
+        grid=(32, d, h * n),
+        threadgroup=(32, 8, 1),
+        output_shapes=[(n, 1, h, d), state.shape],
+        output_dtypes=[input_type, state_type],
+    )
+
+
+def segsum(x, mask=None):
+    l = x.shape[-1]
+    if mask is not None:
+        mask = mx.expand_dims(mask, 1)
+        x = x * mask
+    x = mx.repeat(x[..., None], l, axis=-1)
+    x = mx.tril(x, -1)
+    x_segsum = mx.cumsum(x, axis=-2)
+    if mask is not None:
+        x_segsum = mx.where(
+            mask[..., None, :] * mask[..., None], x_segsum, -float("inf")
+        )
+    return x_segsum
+
+
+def ssm_attn(
+    x: mx.array,
+    A_log: mx.array,
+    B: mx.array,
+    C: mx.array,
+    D: mx.array,
+    dt: mx.array,
+    dt_bias: mx.array,
+    state: Optional[mx.array] = None,
+    time_step_limit: Tuple[float, float] = (0.001, 100.0),
+    mask: Optional[mx.array] = None,
+    lengths: Optional[mx.array] = None,
+    step: int = 256,
+) -> Tuple[mx.array, mx.array]:
+    """SSD-SSM forward pass.
+
+    Args:
+        x: Input of shape (batch_size, seq_len, num_heads, head_dim).
+        dt: Time deltas of shape (seq_len, num_heads,).
+        A_log: State transition of shape (num_heads,).
+        B: Input mixing of shape (batch_size, seq_len, num_groups, n).
+        C: Output mixing of shape (batch_size, seq_len, num_groups, n).
+        D: Residual connection.
+        dt_bias: Bias for time deltas of shape (num_heads,).
+        time_step_limit: Minimum and maximum value for time deltas.
+        mask: Optional multiplicative mask.
+        lengths: Optional lenghts of sequences, assumed to be the full length if unspecified.
+        step: Step size for processing x.
+
+    Code modified from
+    https://github.com/cartesia-ai/edge/blob/main/cartesia-mlx/cartesia_mlx/layers/ssd/ops.py
+
+    """
+    b, l, h, dh = x.shape
+    _, _, g, d = B.shape
+
+    dt = compute_dt(dt, dt_bias, time_step_limit)
+    repeats = h // g
+    A = -mx.exp(A_log).astype(dt.dtype)
+    dtA = dt * A.reshape(1, 1, -1)
+    dtx = dt.reshape(b, l, h, 1) * x
+
+    def _step(dtx, dtA, B, C, state, mask):
+        s = dtx.shape[1]
+        B = mx.transpose(B, (0, 2, 3, 1))
+
+        CB = mx.swapaxes(C, 1, 2) @ B
+        CB = mx.repeat(CB, repeats, axis=1)
+
+        decay = mx.exp(segsum(dtA.swapaxes(1, 2), mask=mask))
+
+        surrogate_attention_matrix = mx.tril(CB * decay, 0)
+
+        y = surrogate_attention_matrix @ dtx.swapaxes(1, 2)
+        y = mx.swapaxes(y, 1, 2)
+
+        if lengths is not None:
+            pos = mx.maximum(mx.minimum(lengths, step) - 1, 0)
+            pos = mx.expand_dims(pos, (1, 2, 3))
+            decay = mx.take_along_axis(decay, pos, axis=2)
+        else:
+            decay = decay[:, :, -1:, :]
+
+        decay = decay.transpose(0, 3, 1, 2)
+        B = mx.repeat(B, h // g, axis=1).swapaxes(2, 3)
+        dtxdecay = dtx * decay
+        dtxdecay = dtxdecay.swapaxes(1, 2).swapaxes(2, 3)
+
+        next_state = dtxdecay @ B
+
+        if state is not None:
+            exp_dtA_cumsum = mx.exp(mx.cumsum(dtA, axis=-2))
+            next_state += exp_dtA_cumsum[:, -1, :, None, None] * state
+            C = C.reshape(b, s, g, 1, d, 1)
+            y_prev = (
+                (state.reshape((b, 1, g, repeats, dh, d)) @ C).squeeze(-1).flatten(2, 3)
+            )
+            y += exp_dtA_cumsum[..., None] * y_prev
+        if lengths is not None and state is not None:
+            next_state = mx.where(
+                mx.expand_dims(lengths < 0, (1, 2, 3)), state, next_state
+            )
+
+        return y.astype(x.dtype), next_state
+
+    ys = []
+    for i in range(0, l, step):
+        y, state = _step(
+            dtx[:, i : i + step],
+            dtA[:, i : i + step],
+            B[:, i : i + step],
+            C[:, i : i + step],
+            state,
+            None if mask is None else mask[..., i : i + step],
+        )
+        if lengths is not None:
+            lengths = lengths - step
+        ys.append(y)
+    y = mx.concatenate(ys, axis=1) + x * D.reshape(1, 1, h, 1)
+    return y, state
+
+
+def ssm_update(
+    hidden_states: mx.array,
+    A_log: mx.array,
+    B: mx.array,
+    C: mx.array,
+    D: mx.array,
+    dt: mx.array,
+    dt_bias: mx.array,
+    state: Optional[mx.array] = None,
+    time_step_limit: Tuple[float, float] = (0.001, 100.0),
+    mask: Optional[mx.array] = None,
+    lengths: Optional[mx.array] = None,
+):
+    seq_len = hidden_states.shape[1]
+    if (
+        seq_len > 1
+        or state is None
+        or mx.default_device() != mx.gpu
+        or not mx.metal.is_available()
+    ):
+        return ssm_attn(
+            hidden_states,
+            A_log,
+            B,
+            C,
+            D,
+            dt,
+            dt_bias,
+            state,
+            time_step_limit,
+            mask=mask,
+            lengths=lengths,
+        )
+    else:
+        return ssm_update_kernel(
+            hidden_states,
+            A_log,
+            B,
+            C,
+            D,
+            dt,
+            dt_bias,
+            state,
+            time_step_limit,
+        )

--- a/mlx_audio/tts/models/arktts/README.md
+++ b/mlx_audio/tts/models/arktts/README.md
@@ -1,11 +1,22 @@
 # Audio8 TTS (arktts)
 
-Multilingual zero-shot voice cloning across 11 languages, with a bundled 44.1 kHz neural codec.
-Based on [Audio8/Audio8-TTS-Preview-0.6b](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.6b).
+Multilingual zero-shot voice cloning with a bundled 44.1 kHz neural codec.
 
 ## Supported Models
 
-- `mlx-community/Audio8-TTS-Preview-0.6b-bf16`
+| | slow backbone | LM params | languages |
+|---|---|---|---|
+| `mlx-community/Audio8-TTS-Preview-0.6b-bf16` | pure attention | 601M | 11 |
+| `mlx-community/Audio8-TTS-Preview-0.1b-bf16` | Falcon-H1 hybrid | 170M | 8 |
+
+Both are selected automatically from `slow_backbone` in `config.json`; there is one model
+class. Based on [Audio8/Audio8-TTS-Preview-0.6b](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.6b)
+and [Audio8/Audio8-TTS-Preview-0.1b](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.1b).
+
+**Licences differ.** The 0.6b is Apache-2.0. The 0.1b is the Audio8 Community License v1.0
+(revenue-capped: free non-commercial, free commercial under US$2M annual revenue, written
+licence at or above that). The bundled codec is byte-identical between the two upstream
+repos, so the converted codec tensors are shared and carry the 0.6b's Apache-2.0 terms.
 
 ## Usage
 
@@ -60,10 +71,23 @@ are used here.
 
 ## Architecture
 
-DualAR, in the style of Fish Audio S2 Pro:
+DualAR, in the style of Fish Audio S2 Pro. The 0.1b (`slow_backbone: falcon_h1`) swaps the
+slow stack for a Falcon-H1 hybrid — every layer carries a Mamba-2 mixer, attention, and an
+MLP — consumed from `mlx_lm.models.falcon_h1`, and adds a dedicated `semantic_output` head
+emitting COMPACT logits of width `codebook_size + 1` (index `i` = semantic token
+`semantic_begin_id + i`; index `codebook_size` = EOS) instead of full-vocabulary logits tied
+to the input embedding. Its fast AR, prompt layout, sampling, and codec are unchanged.
 
-- **Slow AR** — 24 layers, width 896, 14 heads / 2 KV heads. Emits one semantic token per audio
-  frame.
+One trap is worth knowing before touching the falcon path: `embedding_multiplier` is applied
+to the COMPOSITE embedding (text + the ten codebook embeddings), not to the token lookup.
+`sanitize()` therefore deliberately does NOT fold it into `embed_tokens.weight` the way
+`mlx_lm`'s own FalconH1 sanitize does. Folding it scales the text half and leaves the
+codebook half at 1.0 — measured against the PyTorch reference that is 77% relative error on
+the embedding and 38% on the final hidden state, while still producing plausible audio of
+the right length.
+
+- **Slow AR** (0.6b) — 24 layers, width 896, 14 heads / 2 KV heads. Emits one semantic token
+  per audio frame.
 - **Fast AR** — 4 layers, same width. Emits that frame's 10 residual codec codebooks, conditioned
   on the slow hidden state and the preceding codebooks.
 - **Codec** — 44.1 kHz, 2048 samples per frame (~21.5 frames/s). DAC-style encoder/decoder with a
@@ -83,11 +107,23 @@ unchanged. It stays able to consume a raw upstream checkpoint as well.
 
 ## Parity
 
-Verified against the PyTorch reference on CPU in fp32:
+Verified against the PyTorch reference on CPU in fp32, for both checkpoints:
 
-| | |
-|---|---|
-| unit / block outputs | max-abs 1e-6 … 1e-4 |
-| reference-audio codec encode | **100% code-exact** |
-| greedy generation | **100% token-exact** over a 102-frame utterance |
-| decoded waveform | max-abs 7.5e-6 |
+| | 0.6b | 0.1b |
+|---|---|---|
+| unit / block outputs | max-abs 1e-6 … 1e-4 | max-abs 1e-6 … 3e-5 |
+| prefill final hidden | max-abs 6.1e-5 | max-abs 2.1e-5 |
+| reference-audio codec encode | **100% code-exact** | **100% code-exact** |
+| greedy generation | **100% token-exact** (102 frames) | **100% token-exact** (107 frames) |
+| decoded waveform | max-abs 7.5e-6 | max-abs 1.2e-5 |
+
+Steady-state throughput, same text and reference clip, deterministic decoding, first run
+discarded as warm-up:
+
+| | 0.6b | 0.1b |
+|---|---|---|
+| RTF | 0.33 | **0.28** |
+| peak memory | 8.17 GB | **7.59 GB** |
+
+The gains are modest relative to the 3.5x LM shrink because the codec — identical in both —
+dominates both throughput and peak activation.

--- a/mlx_audio/tts/models/arktts/arktts.py
+++ b/mlx_audio/tts/models/arktts/arktts.py
@@ -1,4 +1,4 @@
-"""MLX port of Audio8-TTS-Preview-0.6b (model_type: arktts).
+"""MLX port of the Audio8 TTS preview models (model_type: arktts).
 
 Mirrors the reference modeling_arktts.py structure: a DualAR transformer — a
 slow AR stack predicting one semantic token per audio frame, and a fast AR
@@ -6,6 +6,23 @@ stack predicting the frame's residual codec codebooks — plus the bundled
 44.1 kHz codec (codec.py). Sampling reproduces the reference exactly:
 semantic-range logit filtering, the legacy top-k/top-p order (filter before
 temperature), exponential-race sampling, and RAS repetition rescue.
+
+Two checkpoints share this ``model_type`` and are told apart by ``slow_backbone``:
+
+``arktts`` (default, Audio8-TTS-Preview-0.6b)
+    Pure-attention slow stack, full-vocabulary semantic logits tied to the input
+    embedding, EOS at ``eos_token_id``.
+
+``falcon_h1`` (Audio8-TTS-Preview-0.1b)
+    Falcon-H1 hybrid slow stack — every layer carries Mamba-2 + attention + MLP —
+    consumed from ``mlx_lm.models.falcon_h1``. Adds a dedicated
+    ``semantic_output`` head emitting COMPACT logits of width
+    ``codebook_size + 1``: index ``i`` means semantic token
+    ``semantic_begin_id + i`` and index ``codebook_size`` means EOS. The fast AR,
+    the prompt layout, and the codec are identical across both.
+
+Both share the codec byte-for-byte (same upstream ``codec.pth`` checksum), so a
+conversion of either can reuse the other's converted codec tensors.
 """
 
 from __future__ import annotations
@@ -20,6 +37,11 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+from mlx_lm.models.base import create_attention_mask, create_ssm_mask
+from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+from mlx_lm.models.falcon_h1 import FalconH1DecoderLayer
+from mlx_lm.models.falcon_h1 import ModelArgs as FalconH1Args
+from mlx_lm.models.falcon_h1 import compute_mup_vector
 
 from ..base import BaseModelArgs, GenerationResult
 from .codec import ArkttsCodec
@@ -70,6 +92,48 @@ class ModelConfig(BaseModelArgs):
     pad_token_id: int = 151643
     sample_rate: int = 44100
 
+    # -- slow-backbone selection --------------------------------------------
+    # "arktts" = the 0.6b pure-attention stack (fields above). "falcon_h1" = the
+    # 0.1b hybrid stack (fields below). Defaults keep 0.6b checkpoints, which
+    # carry none of these keys, loading exactly as before.
+    slow_backbone: str = "arktts"
+
+    # Falcon-H1 slow backbone. Names mirror the reference config verbatim so
+    # _falcon_args() is a rename-free pass-through; do not "tidy" them.
+    hidden_act: str = "silu"
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    attention_in_multiplier: float = 1.0
+    attention_out_multiplier: float = 1.0
+    key_multiplier: float = 1.0
+    embedding_multiplier: float = 1.0
+    lm_head_multiplier: float = 1.0
+    expansion_factor: float = 2.0
+    mlp_bias: bool = False
+    mlp_multipliers: tuple = (1.0, 1.0)
+    projectors_bias: bool = False
+    ssm_in_multiplier: float = 1.0
+    ssm_multipliers: tuple = (1.0, 1.0, 1.0, 1.0, 1.0)
+    ssm_out_multiplier: float = 1.0
+    mamba_chunk_size: int = 128
+    mamba_conv_bias: bool = True
+    mamba_d_conv: int = 4
+    mamba_d_head: int = 32
+    mamba_d_ssm: int = 768
+    mamba_d_state: int = 64
+    mamba_expand: int = 2
+    mamba_n_groups: int = 1
+    mamba_n_heads: int = 24
+    mamba_norm_before_gate: bool = False
+    mamba_proj_bias: bool = False
+    mamba_rms_norm: bool = False
+    mamba_use_mlp: bool = True
+    initializer_range: float = 0.02
+
+    @property
+    def uses_falcon_slow(self) -> bool:
+        return self.slow_backbone == "falcon_h1"
+
 
 def _precompute_rope(length: int, head_dim: int, base: float) -> mx.array:
     frequencies = 1.0 / (
@@ -99,6 +163,100 @@ def _apply_rope(x: mx.array, rope: mx.array) -> mx.array:
         axis=-1,
     )
     return output.flatten(3).astype(x.dtype)
+
+
+def _falcon_args(config: ModelConfig) -> FalconH1Args:
+    """Mirror of ArkttsModel._build_falcon_config in the reference remote code."""
+    return FalconH1Args(
+        model_type="falcon_h1",
+        vocab_size=config.vocab_size,
+        hidden_size=config.dim,
+        intermediate_size=config.intermediate_size,
+        num_hidden_layers=config.n_layer,
+        num_attention_heads=config.n_head,
+        num_key_value_heads=config.n_local_heads,
+        head_dim=config.head_dim,
+        rms_norm_eps=config.norm_eps,
+        rope_theta=config.rope_base,
+        max_position_embeddings=config.max_seq_len,
+        attention_bias=config.attention_bias,
+        attention_in_multiplier=config.attention_in_multiplier,
+        attention_out_multiplier=config.attention_out_multiplier,
+        key_multiplier=config.key_multiplier,
+        embedding_multiplier=config.embedding_multiplier,
+        lm_head_multiplier=config.lm_head_multiplier,
+        mlp_bias=config.mlp_bias,
+        mlp_multipliers=list(config.mlp_multipliers),
+        mamba_chunk_size=config.mamba_chunk_size,
+        mamba_conv_bias=config.mamba_conv_bias,
+        mamba_d_conv=config.mamba_d_conv,
+        mamba_d_head=config.mamba_d_head,
+        mamba_d_ssm=config.mamba_d_ssm,
+        mamba_d_state=config.mamba_d_state,
+        mamba_expand=config.mamba_expand,
+        mamba_n_groups=config.mamba_n_groups,
+        mamba_n_heads=config.mamba_n_heads,
+        mamba_norm_before_gate=config.mamba_norm_before_gate,
+        mamba_proj_bias=config.mamba_proj_bias,
+        mamba_rms_norm=config.mamba_rms_norm,
+        mamba_use_mlp=config.mamba_use_mlp,
+        projectors_bias=config.projectors_bias,
+        ssm_in_multiplier=config.ssm_in_multiplier,
+        ssm_multipliers=list(config.ssm_multipliers),
+        ssm_out_multiplier=config.ssm_out_multiplier,
+        tie_word_embeddings=config.tie_word_embeddings,
+    )
+
+
+class FalconSlowStack(nn.Module):
+    """The 0.1b slow backbone: Falcon-H1 decoder layers driven by an INJECTED embedding.
+
+    ``mlx_lm.models.falcon_h1.FalconH1Model`` embeds its own token ids and offers no
+    ``inputs_embeds`` seam, which arktts needs — its slow input is
+
+        (text_embed + sum_of_ten_codebook_embeds) * embedding_multiplier
+
+    So this holds the same submodules under the same names (weights map straight
+    across) and reimplements only the ten-line forward, entering at the embedding.
+
+    THE MULTIPLIER IS APPLIED HERE, to the composite, and must NOT be folded into
+    ``embed_tokens.weight`` the way ``FalconH1Model.sanitize`` does — folding scales
+    the text half and silently leaves the codebook half at 1.0. Measured against the
+    PyTorch oracle that is a 77% relative error on the embedding and 38% on the final
+    hidden state, while still producing plausible audio of the right length. See
+    ``Model.sanitize`` below, which deliberately omits the embedding fold.
+    """
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        args = _falcon_args(config)
+        self.args = args
+        self.embedding_multiplier = config.embedding_multiplier
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.dim)
+        self.layers = [
+            FalconH1DecoderLayer(args) for _ in range(args.num_hidden_layers)
+        ]
+        self.final_layernorm = nn.RMSNorm(config.dim, eps=args.rms_norm_eps)
+        self._mup_vector = compute_mup_vector(args)
+        mx.eval(self._mup_vector)
+
+    def make_cache(self):
+        return [
+            CacheList(ArraysCache(size=2), KVCache())
+            for _ in range(self.args.num_hidden_layers)
+        ]
+
+    def __call__(self, hidden: mx.array, cache=None) -> mx.array:
+        """`hidden` is the UNSCALED composite embedding; the multiplier is applied here."""
+        hidden = hidden * self.embedding_multiplier
+        cache = cache if cache is not None else [(None, None)] * len(self.layers)
+        mamba_mask = create_ssm_mask(hidden, cache[0][0])
+        attn_mask = create_attention_mask(hidden, cache[0][1])
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden = layer(
+                hidden, cache=layer_cache, attn_mask=attn_mask, mamba_mask=mamba_mask
+            )
+        return self.final_layernorm(hidden)
 
 
 class ArkttsRMSNorm(nn.Module):
@@ -239,25 +397,34 @@ class ArkttsModel(nn.Module):
     def __init__(self, config: ModelConfig):
         super().__init__()
         self.config = config
-        self.embeddings = nn.Embedding(config.vocab_size, config.dim)
         self.codebook_embeddings = nn.Embedding(
             config.codebook_size * config.num_codebooks, config.dim
         )
-        self.layers = [
-            ArkttsTransformerBlock(
-                config.dim,
-                config.intermediate_size,
-                config.n_head,
-                config.n_local_heads,
-                config.head_dim,
-                config.attention_qkv_bias,
-                config.attention_o_bias,
-                config.attention_qk_norm,
-                config.norm_eps,
+        if config.uses_falcon_slow:
+            # 0.1b: hybrid Mamba+attention slow stack with its own text embedding,
+            # plus a dedicated compact semantic head (codebook_size + 1 wide).
+            self.slow = FalconSlowStack(config)
+            self.semantic_output = nn.Linear(
+                config.dim, config.codebook_size + 1, bias=False
             )
-            for _ in range(config.n_layer)
-        ]
-        self.norm = ArkttsRMSNorm(config.dim, config.norm_eps)
+        else:
+            # 0.6b: pure-attention slow stack, semantic logits tied to the embedding.
+            self.embeddings = nn.Embedding(config.vocab_size, config.dim)
+            self.layers = [
+                ArkttsTransformerBlock(
+                    config.dim,
+                    config.intermediate_size,
+                    config.n_head,
+                    config.n_local_heads,
+                    config.head_dim,
+                    config.attention_qkv_bias,
+                    config.attention_o_bias,
+                    config.attention_qk_norm,
+                    config.norm_eps,
+                )
+                for _ in range(config.n_layer)
+            ]
+            self.norm = ArkttsRMSNorm(config.dim, config.norm_eps)
         self.fast_project_in = (
             nn.Linear(config.dim, config.fast_dim)
             if config.fast_dim != config.dim
@@ -280,8 +447,12 @@ class ArkttsModel(nn.Module):
         ]
         self.fast_norm = ArkttsRMSNorm(config.fast_dim, config.norm_eps)
         self.fast_output = nn.Linear(config.fast_dim, config.codebook_size, bias=False)
-        self._freqs_cis = _precompute_rope(
-            config.max_seq_len, config.head_dim, config.rope_base
+        # The Falcon slow stack builds its own rope internally, so the slow table is
+        # only needed by the pure-attention path. The fast table is shared.
+        self._freqs_cis = (
+            None
+            if config.uses_falcon_slow
+            else _precompute_rope(config.max_seq_len, config.head_dim, config.rope_base)
         )
         self._fast_freqs_cis = _precompute_rope(
             config.num_codebooks, config.fast_head_dim, config.rope_base
@@ -290,9 +461,21 @@ class ArkttsModel(nn.Module):
         # parameters, so nothing else forces them; left lazy, their graph would first be
         # evaluated inside whichever stream/thread happens to run the first forward, which
         # crashes when the model is moved across streams.
-        mx.eval((self._freqs_cis, self._fast_freqs_cis))
+        mx.eval(
+            (self._fast_freqs_cis,)
+            if self._freqs_cis is None
+            else (self._freqs_cis, self._fast_freqs_cis)
+        )
+        self._slow_cache = None
 
     # -- embedding -----------------------------------------------------------
+    @property
+    def text_embeddings(self) -> nn.Embedding:
+        """The text-token embedding table, wherever this variant keeps it."""
+        return (
+            self.slow.embed_tokens if self.config.uses_falcon_slow else self.embeddings
+        )
+
     def _embed(self, input_ids: mx.array) -> mx.array:
         config = self.config
         codebook_embeds = []
@@ -308,7 +491,9 @@ class ArkttsModel(nn.Module):
             input_ids[:, 0] <= config.semantic_end_id,
         )
         codebook_sum = mx.where(semantic[..., None], codebook_sum, 0.0)
-        return self.embeddings(input_ids[:, 0]) + codebook_sum
+        # Returned UNSCALED. On the falcon path FalconSlowStack applies
+        # embedding_multiplier to this composite; see its docstring.
+        return self.text_embeddings(input_ids[:, 0]) + codebook_sum
 
     @staticmethod
     def _causal_mask(
@@ -335,12 +520,15 @@ class ArkttsModel(nn.Module):
         batch, _, length = input_ids.shape
         if attention_mask is None:
             attention_mask = mx.ones((batch, length), dtype=mx.int64)
+        hidden = self._embed(input_ids)
+        if config.uses_falcon_slow:
+            normalized = self.slow(hidden)
+            return self.semantic_output(normalized), normalized
         position_ids = mx.maximum(
             mx.cumsum(attention_mask.astype(mx.int64), axis=-1) - 1, 0
         )
         rope = self._freqs_cis[position_ids]
         mask = self._causal_mask(attention_mask, mx.arange(length), length)
-        hidden = self._embed(input_ids)
         for layer in self.layers:
             hidden = layer(hidden, rope, mask)
         normalized = self.norm(hidden)
@@ -350,14 +538,21 @@ class ArkttsModel(nn.Module):
     # -- cached decode steps -------------------------------------------------
     def _setup_generation_caches(self, batch_size: int, dtype):
         config = self.config
-        for layer in self.layers:
-            layer.attention.kv_cache = ArkttsKVCache(
-                batch_size,
-                config.max_seq_len,
-                config.n_local_heads,
-                config.head_dim,
-                dtype,
-            )
+        if config.uses_falcon_slow:
+            # Hybrid cache: per layer an ArraysCache(2) for the Mamba conv+ssm state
+            # and a KVCache for the attention half. Unlike the pure-attention path's
+            # static full-buffer cache, this one tracks its own offset, so the slow
+            # step feeds only the new column and passes no explicit mask.
+            self._slow_cache = self.slow.make_cache()
+        else:
+            for layer in self.layers:
+                layer.attention.kv_cache = ArkttsKVCache(
+                    batch_size,
+                    config.max_seq_len,
+                    config.n_local_heads,
+                    config.head_dim,
+                    dtype,
+                )
         for layer in self.fast_layers:
             layer.attention.kv_cache = ArkttsKVCache(
                 batch_size,
@@ -368,7 +563,9 @@ class ArkttsModel(nn.Module):
             )
 
     def _clear_generation_caches(self):
-        for layer in list(self.layers) + list(self.fast_layers):
+        self._slow_cache = None
+        slow_layers = [] if self.config.uses_falcon_slow else list(self.layers)
+        for layer in slow_layers + list(self.fast_layers):
             layer.attention.kv_cache = None
 
     def _slow_step(
@@ -381,6 +578,13 @@ class ArkttsModel(nn.Module):
     ):
         config = self.config
         hidden = self._embed(input_ids)
+        if config.uses_falcon_slow:
+            # The hybrid cache carries its own offset and mask construction, so the
+            # explicit position/mask arguments are unused here. The reference returns
+            # the normalized hidden for BOTH the logits and the fast-AR input
+            # (norm_fastlayer_input is not consulted on this path).
+            normalized = self.slow(hidden, cache=self._slow_cache)[:, -1:]
+            return self.semantic_output(normalized)[:, -1], normalized
         rope = self._freqs_cis[position_ids]
         mask = self._causal_mask(attention_mask, cache_positions, config.max_seq_len)
         for layer in self.layers:
@@ -415,6 +619,12 @@ class ArkttsModel(nn.Module):
 
     def _semantic_filter(self, scores: mx.array) -> mx.array:
         config = self.config
+        if config.uses_falcon_slow:
+            # Compact head: the reference builds this filter with
+            # (begin, end, eos) = (0, codebook_size - 1, codebook_size), which spans
+            # all codebook_size + 1 columns. Provably a no-op, so skip the full-width
+            # scatter rather than pay for it every frame.
+            return scores
         filtered = mx.full(scores.shape, -mx.inf, dtype=scores.dtype)
         filtered[:, config.semantic_begin_id : config.semantic_end_id + 1] = scores[
             :, config.semantic_begin_id : config.semantic_end_id + 1
@@ -450,9 +660,13 @@ class ArkttsModel(nn.Module):
         if previous is None:
             return normal
         repeated = mx.any(previous == normal[:, None], axis=1)
-        semantic = mx.logical_and(
-            normal >= config.semantic_begin_id, normal <= config.semantic_end_id
-        )
+        if config.uses_falcon_slow:
+            # Compact space: semantic ids are 0..codebook_size-1, EOS is codebook_size.
+            semantic = normal < config.codebook_size
+        else:
+            semantic = mx.logical_and(
+                normal >= config.semantic_begin_id, normal <= config.semantic_end_id
+            )
         return mx.where(mx.logical_and(repeated, semantic), high, normal)
 
     def _generate_codebooks(
@@ -461,9 +675,12 @@ class ArkttsModel(nn.Module):
         config = self.config
         hidden = self.fast_project_in(slow_hidden)
         self._fast_step(hidden, 0)
-        current = mx.clip(
-            semantic - config.semantic_begin_id, 0, config.codebook_size - 1
+        # Codebook 0 IS the semantic token, expressed in codebook space. The compact
+        # head already emits that space; the full-vocab head needs the offset removed.
+        raw = (
+            semantic if config.uses_falcon_slow else semantic - config.semantic_begin_id
         )
+        current = mx.clip(raw, 0, config.codebook_size - 1)
         codebooks = [current]
         hidden = self.fast_embeddings(current)[:, None]
         for position in range(1, config.num_codebooks):
@@ -549,7 +766,12 @@ class ArkttsModel(nn.Module):
                 f"Prompt length {prompt_width} must be smaller than {config.max_seq_len}"
             )
         max_new_tokens = min(max_new_tokens, config.max_seq_len - prompt_width)
-        dtype = self.embeddings.weight.dtype
+        dtype = self.text_embeddings.weight.dtype
+        # In the compact semantic space EOS is the last column of the head, not the
+        # tokenizer's eos_token_id.
+        eos_index = (
+            config.codebook_size if config.uses_falcon_slow else config.eos_token_id
+        )
         self._setup_generation_caches(batch_size, dtype)
         rng_key = mx.random.key(
             seed if seed is not None else int(time.time_ns() % (2**63))
@@ -582,7 +804,7 @@ class ArkttsModel(nn.Module):
             codebooks = self._generate_codebooks(
                 slow_hidden, semantic, top_k, top_p, temperature, do_sample, keys[2]
             )
-            emitted = mx.logical_and(active_before, semantic != config.eos_token_id)
+            emitted = mx.logical_and(active_before, semantic != eos_index)
             frame = mx.where(emitted[:, None], codebooks, -1)
             generated_frames.append(frame)
             code_lengths = code_lengths + emitted.astype(mx.int64)
@@ -593,12 +815,22 @@ class ArkttsModel(nn.Module):
                 )
             else:
                 previous = mx.concatenate((previous[:, 1:], semantic[:, None]), axis=1)
-            finished = mx.logical_or(finished, semantic == config.eos_token_id)
+            finished = mx.logical_or(finished, semantic == eos_index)
             mx.eval(finished, frame, code_lengths)
             if bool(mx.all(finished)):
                 break
 
-            next_column = mx.concatenate((semantic[:, None], codebooks), axis=1)[
+            # The slow stack is always fed FULL-vocabulary ids, even when the head
+            # emits the compact space, because the prompt rows are full-vocabulary.
+            if config.uses_falcon_slow:
+                semantic_in = mx.where(
+                    semantic == eos_index,
+                    mx.full(semantic.shape, config.eos_token_id, dtype=semantic.dtype),
+                    semantic + config.semantic_begin_id,
+                )
+            else:
+                semantic_in = semantic
+            next_column = mx.concatenate((semantic_in[:, None], codebooks), axis=1)[
                 ..., None
             ]
             new_valid = active_before.astype(mx.int64)[:, None]
@@ -861,8 +1093,39 @@ class Model(nn.Module):
         for base, pair in pending.items():
             out[base] = fold_weight_norm(pair["g"], pair["v"])
 
+        falcon = self.config.uses_falcon_slow
+        args = _falcon_args(self.config) if falcon else None
+        mup = self.model.slow._mup_vector if falcon else None
+
         remapped = {}
         for key, value in out.items():
+            if falcon and key.startswith("model.slow."):
+                # Falcon-H1 muP folding, mirroring mlx_lm's FalconH1 sanitize with ONE
+                # deliberate omission: embed_tokens is NOT scaled by embedding_multiplier.
+                # arktts applies that multiplier to the composite (text + codebooks)
+                # embedding instead — folding it here would scale the text half and leave
+                # the codebook half at 1.0. Measured cost of getting this wrong: 77% relative
+                # error on the embedding, 38% on the final hidden state, and audio that still
+                # sounds plausible. See FalconSlowStack's docstring.
+                if key.endswith(("q_proj.weight", "k_proj.weight", "v_proj.weight")):
+                    value = value * args.attention_in_multiplier
+                elif key.endswith("o_proj.weight"):
+                    value = value * args.attention_out_multiplier
+                elif key.endswith("out_proj.weight"):
+                    value = value * args.ssm_out_multiplier
+                elif key.endswith("gate_proj.weight"):
+                    value = value * args.mlp_multipliers[0]
+                elif key.endswith("down_proj.weight"):
+                    value = value * args.mlp_multipliers[1]
+                elif key.endswith("in_proj.weight"):
+                    value = value * (
+                        args.ssm_in_multiplier * mup.astype(value.dtype)[:, None]
+                    )
+                elif key.endswith("conv1d.weight"):
+                    # torch (C, 1, K) -> mlx (C, K, 1)
+                    value = value.transpose(0, 2, 1)
+                remapped[key] = value
+                continue
             if key.startswith("codec."):
                 if key.endswith("alpha"):
                     # Snake (1, C, 1) -> (1, 1, C)

--- a/mlx_audio/tts/models/arktts/arktts.py
+++ b/mlx_audio/tts/models/arktts/arktts.py
@@ -15,7 +15,7 @@ Two checkpoints share this ``model_type`` and are told apart by ``slow_backbone`
 
 ``falcon_h1`` (Audio8-TTS-Preview-0.1b)
     Falcon-H1 hybrid slow stack — every layer carries Mamba-2 + attention + MLP —
-    consumed from ``mlx_lm.models.falcon_h1``. Adds a dedicated
+    consumed from the vendored ``mlx_audio.lm.models.falcon_h1``. Adds a dedicated
     ``semantic_output`` head emitting COMPACT logits of width
     ``codebook_size + 1``: index ``i`` means semantic token
     ``semantic_begin_id + i`` and index ``codebook_size`` means EOS. The fast AR,
@@ -37,11 +37,12 @@ from typing import Optional
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
-from mlx_lm.models.base import create_attention_mask, create_ssm_mask
-from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
-from mlx_lm.models.falcon_h1 import FalconH1DecoderLayer
-from mlx_lm.models.falcon_h1 import ModelArgs as FalconH1Args
-from mlx_lm.models.falcon_h1 import compute_mup_vector
+
+from mlx_audio.lm.models.base import create_attention_mask, create_ssm_mask
+from mlx_audio.lm.models.cache import ArraysCache, CacheList, KVCache
+from mlx_audio.lm.models.falcon_h1 import FalconH1DecoderLayer
+from mlx_audio.lm.models.falcon_h1 import ModelArgs as FalconH1Args
+from mlx_audio.lm.models.falcon_h1 import compute_mup_vector
 
 from ..base import BaseModelArgs, GenerationResult
 from .codec import ArkttsCodec
@@ -211,7 +212,7 @@ def _falcon_args(config: ModelConfig) -> FalconH1Args:
 class FalconSlowStack(nn.Module):
     """The 0.1b slow backbone: Falcon-H1 decoder layers driven by an INJECTED embedding.
 
-    ``mlx_lm.models.falcon_h1.FalconH1Model`` embeds its own token ids and offers no
+    ``mlx_audio.lm.models.falcon_h1.FalconH1Model`` embeds its own token ids and offers no
     ``inputs_embeds`` seam, which arktts needs — its slow input is
 
         (text_embed + sum_of_ten_codebook_embeds) * embedding_multiplier
@@ -227,8 +228,40 @@ class FalconSlowStack(nn.Module):
     ``Model.sanitize`` below, which deliberately omits the embedding fold.
     """
 
+    #: muP multipliers that the upstream FalconH1 folds into weights during `sanitize`.
+    #: This port does not fold them (see `Model.sanitize`), so it only supports checkpoints
+    #: that carry them at unity — which every published arktts checkpoint does.
+    _MUST_BE_UNITY = (
+        "attention_in_multiplier",
+        "attention_out_multiplier",
+        "key_multiplier",
+        "ssm_in_multiplier",
+        "ssm_out_multiplier",
+    )
+    _MUST_BE_UNITY_SEQUENCES = ("mlp_multipliers", "ssm_multipliers")
+
     def __init__(self, config: ModelConfig):
         super().__init__()
+        # Fail loudly rather than load silently-unscaled weights. `embedding_multiplier` is
+        # deliberately absent from this check: it is applied at runtime to the COMPOSITE
+        # embedding (see this class's docstring), and `lm_head_multiplier` is unused because
+        # arktts brings its own semantic head.
+        offenders = [
+            name for name in self._MUST_BE_UNITY if float(getattr(config, name)) != 1.0
+        ]
+        offenders += [
+            name
+            for name in self._MUST_BE_UNITY_SEQUENCES
+            if set(float(v) for v in getattr(config, name)) != {1.0}
+        ]
+        if offenders:
+            raise ValueError(
+                "arktts's falcon_h1 backbone supports unity muP multipliers only, but this "
+                f"config sets {', '.join(offenders)} away from 1.0. Folding them belongs in "
+                "sanitize(), which is contractually self-contained here and cannot read the "
+                "config — so this checkpoint needs that seam reworked rather than silently "
+                "loading unscaled weights."
+            )
         args = _falcon_args(config)
         self.args = args
         self.embedding_multiplier = config.embedding_multiplier
@@ -1093,36 +1126,25 @@ class Model(nn.Module):
         for base, pair in pending.items():
             out[base] = fold_weight_norm(pair["g"], pair["v"])
 
-        falcon = self.config.uses_falcon_slow
-        args = _falcon_args(self.config) if falcon else None
-        mup = self.model.slow._mup_vector if falcon else None
-
+        # SANITIZE IS SELF-CONTAINED, by contract: the test suite calls it on a
+        # `Model.__new__(Model)` with no __init__, so it must not read instance state.
+        # The falcon variant is therefore detected from the KEYS, and the only work its
+        # weights need here is a layout transpose, which is decidable from shapes.
+        #
+        # The muP multipliers the upstream FalconH1 sanitize folds are NOT folded here.
+        # Every published arktts checkpoint carries them at unity, and `FalconSlowStack`
+        # ASSERTS that at construction — a loud failure on a future checkpoint that
+        # changes them, rather than dead code here that has to read a config it cannot see.
         remapped = {}
         for key, value in out.items():
-            if falcon and key.startswith("model.slow."):
-                # Falcon-H1 muP folding, mirroring mlx_lm's FalconH1 sanitize with ONE
-                # deliberate omission: embed_tokens is NOT scaled by embedding_multiplier.
-                # arktts applies that multiplier to the composite (text + codebooks)
-                # embedding instead — folding it here would scale the text half and leave
-                # the codebook half at 1.0. Measured cost of getting this wrong: 77% relative
-                # error on the embedding, 38% on the final hidden state, and audio that still
-                # sounds plausible. See FalconSlowStack's docstring.
-                if key.endswith(("q_proj.weight", "k_proj.weight", "v_proj.weight")):
-                    value = value * args.attention_in_multiplier
-                elif key.endswith("o_proj.weight"):
-                    value = value * args.attention_out_multiplier
-                elif key.endswith("out_proj.weight"):
-                    value = value * args.ssm_out_multiplier
-                elif key.endswith("gate_proj.weight"):
-                    value = value * args.mlp_multipliers[0]
-                elif key.endswith("down_proj.weight"):
-                    value = value * args.mlp_multipliers[1]
-                elif key.endswith("in_proj.weight"):
-                    value = value * (
-                        args.ssm_in_multiplier * mup.astype(value.dtype)[:, None]
-                    )
-                elif key.endswith("conv1d.weight"):
-                    # torch (C, 1, K) -> mlx (C, K, 1)
+            if key.startswith("model.slow."):
+                # torch Conv1d (C, 1, K) -> mlx (C, K, 1). `shape[1] == 1` identifies the
+                # torch layout (the kernel width is 4, never 1), so this cannot double-apply.
+                if (
+                    key.endswith("conv1d.weight")
+                    and value.ndim == 3
+                    and value.shape[1] == 1
+                ):
                     value = value.transpose(0, 2, 1)
                 remapped[key] = value
                 continue


### PR DESCRIPTION
Follow-up to #867. Audio8 published a second preview checkpoint, [Audio8-TTS-Preview-0.1b](https://huggingface.co/Audio8/Audio8-TTS-Preview-0.1b) (~170M params), carrying the same `model_type: arktts`.

It is routed to this model file by `model_type` alone, so it lands here whether or not the file understands it — today it fails at weight loading, and a third-party conversion declaring `library_name: mlx-audio` is [already on the Hub](https://huggingface.co/plaincompute/audio8-tts-preview-0.1b-mx).

### How the two are told apart

A new `slow_backbone` config key:

| value | checkpoint | slow stack | semantic logits |
|---|---|---|---|
| `arktts` *(default)* | 0.6b | pure attention | full vocabulary, tied to the input embedding, EOS at `eos_token_id` |
| `falcon_h1` | 0.1b | Falcon-H1 hybrid — every layer carries a Mamba-2 mixer, attention and an MLP | **compact**, width `codebook_size + 1` via a dedicated `semantic_output` head |

`arktts` is the default, so 0.6b configs — which carry none of the new keys — decode and run exactly as before.

The fast AR, prompt layout, sampling algorithm and codec are identical across the two. Only the five points where the compact semantic space differs are branched: the semantic filter, the RAS repeated-token test, the codebook-0 offset, the EOS index, and the compact→full-vocabulary mapping when feeding the next slow column.

Falcon-H1 was not vendored yet, so per `docs/contributing/adding-a-model.md` it is copied into `mlx_audio/lm/models/` verbatim with a provenance header — `falcon_h1.py`, plus `ssm.py` (for `ssm_update`) and `CacheList` in `cache.py`, which it needs and which were also missing. Everything else it imports was already vendored, so its import block is unchanged. `FalconSlowStack` then wraps `FalconH1DecoderLayer` rather than adding a second Mamba-2 implementation, reimplementing only the short forward — `FalconH1Model` embeds its own token ids and offers no `inputs_embeds` seam, which arktts needs.

### The trap, for whoever touches this next

`embedding_multiplier` applies to the **composite** slow input — text embedding plus the ten codebook embeddings — not to the token lookup. `sanitize()` therefore deliberately does **not** fold it into `embed_tokens.weight` the way the vendored FalconH1 sanitize does. `sanitize()` is also contractually self-contained here (`test_arktts` calls it on a `Model.__new__(Model)`), so it reads no instance state: the falcon variant is detected from the weight keys, and the only work those weights need is a shape-decidable Conv1d transpose. The muP multipliers upstream folds are unity on every published arktts checkpoint — `FalconSlowStack.__init__` asserts that and names any offender, rather than folding them in a function that cannot see the config.

Folding it scales the text half and leaves the codebook half at 1.0. Measured against the PyTorch reference that is **77% relative error on the embedding and 38% on the final hidden state**, while still producing plausible audio of the right length — listening does not catch it. Both the module docstring and `FalconSlowStack`'s docstring spell this out.

### Parity vs the PyTorch reference (fp32, CPU, transformers 4.57.6)

| | 0.6b (regression) | 0.1b (new) |
|---|---|---|
| composite embedding | — | max-abs **0.0** |
| prefill final hidden | 6.104e-05 | 2.098e-05 |
| semantic logits | 3.052e-05 | 3.147e-05 |
| fast AR units | 1e-6 … 1e-4 | 9.5e-07 … 1.4e-06 |
| reference codec encode | **100% code-exact** | **100% code-exact** |
| greedy generation | **100% token-exact** (102 frames) | **100% token-exact** (107 frames) |
| decoded waveform | 7.493e-06 | 1.231e-05 |

The 0.6b column is a regression run through this changed file and matches its pre-change values exactly.

`test_lazy_imports` and `test_no_mlx_lm` both pass — the model imports the vendored `mlx_audio.lm`, as in `zonos2`, `pocket_tts`, `bark` and `chatterbox_turbo`.

### Throughput

Steady-state, same text and reference clip, deterministic decoding, warm-up run discarded:

| | 0.6b | 0.1b |
|---|---|---|
| RTF | 0.33 | **0.28** |
| peak memory | 8.17 GB | **7.59 GB** |

Modest relative to the 3.5x smaller LM, because the shared codec dominates both axes.

### Weights

[`mlx-community/Audio8-TTS-Preview-0.1b-bf16`](https://huggingface.co/mlx-community/Audio8-TTS-Preview-0.1b-bf16).

**Licences differ.** The 0.6b is Apache-2.0; the 0.1b is the Audio8 Community License v1.0 (revenue-capped: free non-commercial, free commercial under US$2M revenue). The bundled codec is byte-identical between the two upstream repos — same checksum, and bit-identical outputs across encoder, quantizer decode and full decode — so the converted codec tensors are shared and carry the 0.6b's Apache-2.0 terms. The model README states this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
