### PR TITLE
Breeze tts segment support

### DIFF
--- a/mlx_audio/tts/models/breeze_tts/README.md
+++ b/mlx_audio/tts/models/breeze_tts/README.md
@@ -4,8 +4,8 @@ MLX implementation of [BreezeBlue/Breeze-TTS-2](https://huggingface.co/BreezeBlu
 The original checkpoint bundles the text encoder and Qwen3-TTS codec used by
 this implementation, so loading it does not require the upstream PyTorch
 runtime. Its PyTorch safetensors do not load in MLX directly; the examples
-use an [unofficial MLX 4-bit
-conversion](https://huggingface.co/LunaFox/Breeze-TTS-2-mlx-4bit).
+use the [mlx-community MLX
+conversion](https://huggingface.co/mlx-community/Breeze-TTS-2-mlx).
 
 ## Voice design
 
@@ -14,7 +14,7 @@ model repository:
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --text "Welcome aboard. Your journey begins now." \
   --instruction "A warm, thoughtful young woman with a clear voice." \
   --cfg-scale 4
@@ -30,7 +30,7 @@ such as `(sigh)` are kept in the generated text.
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --ref-audio reference.wav \
   --ref-text "This is the exact transcript of the reference audio." \
   --text "(sigh) It is good to hear your voice again." \
@@ -49,7 +49,7 @@ while directing tone, emotion, pace, or delivery:
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --ref-audio reference.wav \
   --ref-text "This is the exact transcript of the reference audio." \
   --text "(clears throat) We need to discuss what happened." \
@@ -69,7 +69,7 @@ English events use parentheses, for example `(laugh)`, `(cough)`, and
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --text "[笑] 欢迎来到今晚的故事时间，让我们一起开始吧。" \
   --instruction "一位温柔自信的年轻女性，声音清晰，语气亲切。" \
   --cfg-scale 4
@@ -81,7 +81,7 @@ cadence:
 
 ```bash
 mlx_audio.tts.generate \
-  --model LunaFox/Breeze-TTS-2-mlx-4bit \
+  --model mlx-community/Breeze-TTS-2-mlx \
   --ref-audio reference.wav \
   --ref-text "This is the exact transcript of the reference audio." \
   --text "(sigh) This response is streamed as it is generated." \
@@ -98,7 +98,7 @@ mono waveforms:
 ```python
 from mlx_audio.tts import load
 
-model = load("LunaFox/Breeze-TTS-2-mlx-4bit")
+model = load("mlx-community/Breeze-TTS-2-mlx")
 for chunk in model.generate(
     text="(laugh) Hello from MLX-Audio.",
     instruct="A bright, friendly voice.",
@@ -112,4 +112,4 @@ for chunk in model.generate(
 
 The model weights, derivatives, and generated outputs are governed by the
 upstream BreezeBlue Research and Non-Commercial License. Review the [original
-model card](https://huggingface.co/BreezeBlue/breeze-tts-2) before use.
+model card](https://huggingface.co/BreezeBlue/Breeze-TTS-2) before use.

--- a/mlx_audio/tts/models/breeze_tts/breeze_tts.py
+++ b/mlx_audio/tts/models/breeze_tts/breeze_tts.py
@@ -28,6 +28,50 @@ from mlx_audio.utils import load_audio
 from .config import ModelConfig
 
 
+def _split_long_segment(text: str, max_chars: int = 600) -> list[str]:
+    """Split text into non-empty chunks no longer than ``max_chars``."""
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive.")
+    if len(text) <= max_chars:
+        return [text]
+
+    # Keep sentence-ending punctuation attached to the preceding sentence.
+    # Full-width terminators cover Chinese and Japanese text, where sentence
+    # boundaries are commonly not followed by whitespace.
+    sentences = [s for s in re.split(r"(?<=[.!?。！？])", text) if s]
+    chunks: list[str] = []
+    current = ""
+
+    for sentence in sentences:
+        while sentence:
+            if current and len(current) + len(sentence) > max_chars:
+                chunks.append(current.strip())
+                current = ""
+                sentence = sentence.lstrip()
+                continue
+
+            available = max_chars - len(current)
+            if len(sentence) <= available:
+                current += sentence
+                break
+
+            # A sentence can itself exceed the limit. Prefer a nearby word
+            # boundary, then fall back to a hard split for unspaced/CJK text.
+            split_at = available
+            whitespace = list(re.finditer(r"\s+", sentence[: available + 1]))
+            if whitespace and whitespace[-1].start() >= available // 2:
+                split_at = whitespace[-1].start()
+            chunk = (current + sentence[:split_at]).strip()
+            if chunk:
+                chunks.append(chunk)
+            current = ""
+            sentence = sentence[split_at:].lstrip()
+
+    if current.strip():
+        chunks.append(current.strip())
+    return chunks
+
+
 class _AudioEmbedding(nn.Module):
     """Sum wrapper-level audio codebook embeddings.
 
@@ -956,7 +1000,6 @@ class Model(nn.Module):
         ref_audio: Optional[Union[str, Path, mx.array]] = None,
         ref_text: Optional[str] = None,
         cfg_scale: Optional[float] = None,
-        split_pattern: Optional[str] = "\n",
         max_tokens: int = 750,
         temperature: float = 0.9,
         top_p: float = 1.0,
@@ -965,6 +1008,7 @@ class Model(nn.Module):
         seed: Optional[int] = None,
         stream: bool = False,
         streaming_interval: float = 2.0,
+        split_pattern: Optional[str] = "\n",
         **_: object,
     ) -> Generator[GenerationResult, None, None]:
         """Generate Breeze audio for voice design, cloning, or direction."""
@@ -996,15 +1040,7 @@ class Model(nn.Module):
                 ]
             segments: list[str] = []
             for segment in raw_segments:
-                if len(segment) > 600:
-                    sentences = [
-                        s.strip()
-                        for s in re.split(r"(?<=[.!?])\s+", segment)
-                        if s.strip()
-                    ]
-                    segments.extend(sentences if sentences else [segment])
-                else:
-                    segments.append(segment)
+                segments.extend(_split_long_segment(segment))
         else:
             segments = [text.strip()] if text.strip() else []
         if not segments:
@@ -1041,9 +1077,9 @@ class Model(nn.Module):
                 )
 
             cond_cache = self.backbone_model.make_cache()
-            cond_hidden = self.backbone_model(
-                input_embeddings=cond, cache=cond_cache
-            )[:, -1, :]
+            cond_hidden = self.backbone_model(input_embeddings=cond, cache=cond_cache)[
+                :, -1, :
+            ]
             if use_cfg:
                 uncond_cache = self.backbone_model.make_cache()
                 uncond_hidden = self.backbone_model(
@@ -1170,7 +1206,9 @@ class Model(nn.Module):
                     )
                     self.audio_tokenizer.decoder.reset_streaming_state()
                     yield stream_result(
-                        self._audio_vector(stream_audio), len(pending_frames), final=True
+                        self._audio_vector(stream_audio),
+                        len(pending_frames),
+                        final=True,
                     )
                 else:
                     self.audio_tokenizer.decoder.reset_streaming_state()

--- a/mlx_audio/tts/models/breeze_tts/breeze_tts.py
+++ b/mlx_audio/tts/models/breeze_tts/breeze_tts.py
@@ -8,6 +8,7 @@ no PyTorch or upstream Breeze runtime is required at inference time.
 
 import json
 import math
+import re
 import time
 from pathlib import Path
 from typing import Any, Dict, Generator, Optional, Union
@@ -955,6 +956,7 @@ class Model(nn.Module):
         ref_audio: Optional[Union[str, Path, mx.array]] = None,
         ref_text: Optional[str] = None,
         cfg_scale: Optional[float] = None,
+        split_pattern: Optional[str] = "\n",
         max_tokens: int = 750,
         temperature: float = 0.9,
         top_p: float = 1.0,
@@ -983,29 +985,31 @@ class Model(nn.Module):
         if streaming_interval <= 0:
             raise ValueError("streaming_interval must be positive.")
 
-        started = time.perf_counter()
-        cond = self._prompt_embeddings(
-            text, voice=voice, instruct=instruct, ref_audio=ref_audio, ref_text=ref_text
-        )
-        use_cfg = bool(instruct) and cfg_scale not in (None, 1.0)
-        scale = 1.0 if cfg_scale is None else cfg_scale
-        if use_cfg:
-            uncond = self._prompt_embeddings(
-                text, voice=voice, instruct=None, ref_audio=ref_audio, ref_text=ref_text
-            )
+        if split_pattern:
+            try:
+                raw_segments = [
+                    s.strip() for s in re.split(split_pattern, text) if s.strip()
+                ]
+            except Exception:
+                raw_segments = [
+                    s.strip() for s in text.split(split_pattern) if s.strip()
+                ]
+            segments: list[str] = []
+            for segment in raw_segments:
+                if len(segment) > 600:
+                    sentences = [
+                        s.strip()
+                        for s in re.split(r"(?<=[.!?])\s+", segment)
+                        if s.strip()
+                    ]
+                    segments.extend(sentences if sentences else [segment])
+                else:
+                    segments.append(segment)
+        else:
+            segments = [text.strip()] if text.strip() else []
+        if not segments:
+            segments = [text]
 
-        cond_cache = self.backbone_model.make_cache()
-        cond_hidden = self.backbone_model(input_embeddings=cond, cache=cond_cache)[
-            :, -1, :
-        ]
-        if use_cfg:
-            uncond_cache = self.backbone_model.make_cache()
-            uncond_hidden = self.backbone_model(
-                input_embeddings=uncond, cache=uncond_cache
-            )[:, -1, :]
-
-        frames: list[list[int]] = []
-        pending_frames: list[list[int]] = []
         decode_rate = getattr(self.audio_tokenizer, "decode_upsample_rate", None)
         if decode_rate is None:
             decoder = getattr(self.audio_tokenizer, "decoder", None)
@@ -1013,20 +1017,177 @@ class Model(nn.Module):
         if decode_rate is None or decode_rate <= 0:
             raise ValueError("Breeze audio tokenizer has no valid decode rate")
         chunk_frames = max(1, int(streaming_interval * self.sample_rate / decode_rate))
-        if stream:
-            self.audio_tokenizer.decoder.reset_streaming_state()
 
-        def stream_result(audio: mx.array, token_count: int, final: bool):
-            mx.eval(audio)
+        total_segments = len(segments)
+        for segment_idx, segment_text in enumerate(segments):
+            is_last_segment = segment_idx == total_segments - 1
+            started = time.perf_counter()
+            cond = self._prompt_embeddings(
+                segment_text,
+                voice=voice,
+                instruct=instruct,
+                ref_audio=ref_audio,
+                ref_text=ref_text,
+            )
+            use_cfg = bool(instruct) and cfg_scale not in (None, 1.0)
+            scale = 1.0 if cfg_scale is None else cfg_scale
+            if use_cfg:
+                uncond = self._prompt_embeddings(
+                    segment_text,
+                    voice=voice,
+                    instruct=None,
+                    ref_audio=ref_audio,
+                    ref_text=ref_text,
+                )
+
+            cond_cache = self.backbone_model.make_cache()
+            cond_hidden = self.backbone_model(
+                input_embeddings=cond, cache=cond_cache
+            )[:, -1, :]
+            if use_cfg:
+                uncond_cache = self.backbone_model.make_cache()
+                uncond_hidden = self.backbone_model(
+                    input_embeddings=uncond, cache=uncond_cache
+                )[:, -1, :]
+
+            frames: list[list[int]] = []
+            pending_frames: list[list[int]] = []
+            if stream:
+                self.audio_tokenizer.decoder.reset_streaming_state()
+
+            def stream_result(
+                audio: mx.array, token_count: int, final: bool, s_idx: int = segment_idx
+            ):
+                mx.eval(audio)
+                samples = audio.shape[0]
+                elapsed = time.perf_counter() - started
+                tokens_per_sec = token_count / elapsed if elapsed > 0 else 0.0
+                samples_per_sec = samples / elapsed if elapsed > 0 else 0.0
+                return GenerationResult(
+                    audio=audio,
+                    samples=samples,
+                    sample_rate=self.sample_rate,
+                    segment_idx=s_idx,
+                    token_count=token_count,
+                    audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
+                    real_time_factor=elapsed / max(samples / self.sample_rate, 1e-6),
+                    prompt={
+                        "tokens": token_count,
+                        "tokens-per-sec": tokens_per_sec,
+                    },
+                    audio_samples={
+                        "samples": samples,
+                        "samples-per-sec": samples_per_sec,
+                    },
+                    processing_time_seconds=elapsed,
+                    peak_memory_usage=mx.get_peak_memory() / 1e9,
+                    is_streaming_chunk=True,
+                    is_final_chunk=final and is_last_segment,
+                )
+
+            for _ in range(max_tokens):
+                cond_logits = self.lm_head(cond_hidden)
+                if use_cfg:
+                    uncond_logits = self.lm_head(uncond_hidden)
+                    logits = uncond_logits + scale * (cond_logits - uncond_logits)
+                else:
+                    logits = cond_logits
+                logits = self._apply_repetition_penalty(
+                    logits, [frame[0] for frame in frames], repetition_penalty
+                )
+                logits = self._mask_reserved_codec_logits(logits)
+                first = self._sample(
+                    logits,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    allow_eos=True,
+                )
+                if first == self.vocab_size:
+                    break
+                frame = self._depth_tokens(
+                    first,
+                    cond_hidden,
+                    unconditional_hidden=uncond_hidden if use_cfg else None,
+                    cfg_scale=scale,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                )
+                frames.append(frame)
+                pending_frames.append(frame)
+                if stream and len(pending_frames) >= chunk_frames:
+                    chunk = pending_frames[:chunk_frames]
+                    del pending_frames[:chunk_frames]
+                    pending_codes = mx.array(chunk, dtype=mx.int32)[None, :, :]
+                    stream_audio = self.audio_tokenizer.decoder.streaming_step(
+                        mx.transpose(pending_codes, (0, 2, 1))
+                    )
+                    yield stream_result(
+                        self._audio_vector(stream_audio), len(chunk), final=False
+                    )
+                codebooks = mx.array(frame, dtype=mx.int32)[None, None, :]
+                cond_hidden = self.backbone_model(
+                    input_ids=codebooks, cache=cond_cache
+                )[:, -1, :]
+                if use_cfg:
+                    uncond_hidden = self.backbone_model(
+                        input_ids=codebooks, cache=uncond_cache
+                    )[:, -1, :]
+
+            if not frames:
+                empty_audio = self._empty_audio()
+                if stream:
+                    self.audio_tokenizer.decoder.reset_streaming_state()
+                mx.eval(empty_audio)
+                elapsed = time.perf_counter() - started
+                samples = empty_audio.shape[0]
+                samples_per_sec = samples / elapsed if elapsed > 0 else 0.0
+                yield GenerationResult(
+                    audio=empty_audio,
+                    samples=samples,
+                    sample_rate=self.sample_rate,
+                    segment_idx=segment_idx,
+                    token_count=0,
+                    audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
+                    real_time_factor=0.0,
+                    prompt={"tokens": 0, "tokens-per-sec": 0.0},
+                    audio_samples={
+                        "samples": samples,
+                        "samples-per-sec": samples_per_sec,
+                    },
+                    processing_time_seconds=elapsed,
+                    peak_memory_usage=mx.get_peak_memory() / 1e9,
+                    is_streaming_chunk=stream,
+                    is_final_chunk=is_last_segment,
+                )
+                continue
+            if stream:
+                if pending_frames:
+                    pending_codes = mx.array(pending_frames, dtype=mx.int32)[None, :, :]
+                    stream_audio = self.audio_tokenizer.decoder.streaming_step(
+                        mx.transpose(pending_codes, (0, 2, 1))
+                    )
+                    self.audio_tokenizer.decoder.reset_streaming_state()
+                    yield stream_result(
+                        self._audio_vector(stream_audio), len(pending_frames), final=True
+                    )
+                else:
+                    self.audio_tokenizer.decoder.reset_streaming_state()
+                continue
+            codes = mx.array(frames, dtype=mx.int32)[None, :, :]
+            audio = self._decode_codes(codes)
             samples = audio.shape[0]
+            mx.eval(audio)
             elapsed = time.perf_counter() - started
+            token_count = len(frames)
             tokens_per_sec = token_count / elapsed if elapsed > 0 else 0.0
             samples_per_sec = samples / elapsed if elapsed > 0 else 0.0
-            return GenerationResult(
+            yield GenerationResult(
                 audio=audio,
                 samples=samples,
                 sample_rate=self.sample_rate,
-                segment_idx=0,
+                segment_idx=segment_idx,
                 token_count=token_count,
                 audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
                 real_time_factor=elapsed / max(samples / self.sample_rate, 1e-6),
@@ -1040,125 +1201,5 @@ class Model(nn.Module):
                 },
                 processing_time_seconds=elapsed,
                 peak_memory_usage=mx.get_peak_memory() / 1e9,
-                is_streaming_chunk=True,
-                is_final_chunk=final,
+                is_final_chunk=is_last_segment,
             )
-
-        for _ in range(max_tokens):
-            cond_logits = self.lm_head(cond_hidden)
-            if use_cfg:
-                uncond_logits = self.lm_head(uncond_hidden)
-                logits = uncond_logits + scale * (cond_logits - uncond_logits)
-            else:
-                logits = cond_logits
-            logits = self._apply_repetition_penalty(
-                logits, [frame[0] for frame in frames], repetition_penalty
-            )
-            logits = self._mask_reserved_codec_logits(logits)
-            first = self._sample(
-                logits,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                allow_eos=True,
-            )
-            if first == self.vocab_size:
-                break
-            frame = self._depth_tokens(
-                first,
-                cond_hidden,
-                unconditional_hidden=uncond_hidden if use_cfg else None,
-                cfg_scale=scale,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-            )
-            frames.append(frame)
-            pending_frames.append(frame)
-            if stream and len(pending_frames) >= chunk_frames:
-                chunk = pending_frames[:chunk_frames]
-                del pending_frames[:chunk_frames]
-                pending_codes = mx.array(chunk, dtype=mx.int32)[None, :, :]
-                stream_audio = self.audio_tokenizer.decoder.streaming_step(
-                    mx.transpose(pending_codes, (0, 2, 1))
-                )
-                yield stream_result(
-                    self._audio_vector(stream_audio), len(chunk), final=False
-                )
-            codebooks = mx.array(frame, dtype=mx.int32)[None, None, :]
-            cond_hidden = self.backbone_model(input_ids=codebooks, cache=cond_cache)[
-                :, -1, :
-            ]
-            if use_cfg:
-                uncond_hidden = self.backbone_model(
-                    input_ids=codebooks, cache=uncond_cache
-                )[:, -1, :]
-
-        if not frames:
-            empty_audio = self._empty_audio()
-            if stream:
-                self.audio_tokenizer.decoder.reset_streaming_state()
-            mx.eval(empty_audio)
-            elapsed = time.perf_counter() - started
-            samples = empty_audio.shape[0]
-            samples_per_sec = samples / elapsed if elapsed > 0 else 0.0
-            yield GenerationResult(
-                audio=empty_audio,
-                samples=samples,
-                sample_rate=self.sample_rate,
-                segment_idx=0,
-                token_count=0,
-                audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
-                real_time_factor=0.0,
-                prompt={"tokens": 0, "tokens-per-sec": 0.0},
-                audio_samples={
-                    "samples": samples,
-                    "samples-per-sec": samples_per_sec,
-                },
-                processing_time_seconds=elapsed,
-                peak_memory_usage=mx.get_peak_memory() / 1e9,
-                is_streaming_chunk=stream,
-                is_final_chunk=True,
-            )
-            return
-        if stream:
-            if pending_frames:
-                pending_codes = mx.array(pending_frames, dtype=mx.int32)[None, :, :]
-                stream_audio = self.audio_tokenizer.decoder.streaming_step(
-                    mx.transpose(pending_codes, (0, 2, 1))
-                )
-                self.audio_tokenizer.decoder.reset_streaming_state()
-                yield stream_result(
-                    self._audio_vector(stream_audio), len(pending_frames), final=True
-                )
-            else:
-                self.audio_tokenizer.decoder.reset_streaming_state()
-            return
-        codes = mx.array(frames, dtype=mx.int32)[None, :, :]
-        audio = self._decode_codes(codes)
-        samples = audio.shape[0]
-        mx.eval(audio)
-        elapsed = time.perf_counter() - started
-        token_count = len(frames)
-        tokens_per_sec = token_count / elapsed if elapsed > 0 else 0.0
-        samples_per_sec = samples / elapsed if elapsed > 0 else 0.0
-        yield GenerationResult(
-            audio=audio,
-            samples=samples,
-            sample_rate=self.sample_rate,
-            segment_idx=0,
-            token_count=token_count,
-            audio_duration=f"00:00:{samples / self.sample_rate:06.3f}",
-            real_time_factor=elapsed / max(samples / self.sample_rate, 1e-6),
-            prompt={
-                "tokens": token_count,
-                "tokens-per-sec": tokens_per_sec,
-            },
-            audio_samples={
-                "samples": samples,
-                "samples-per-sec": samples_per_sec,
-            },
-            processing_time_seconds=elapsed,
-            peak_memory_usage=mx.get_peak_memory() / 1e9,
-            is_final_chunk=True,
-        )

--- a/mlx_audio/tts/tests/test_breeze_tts.py
+++ b/mlx_audio/tts/tests/test_breeze_tts.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pytest
 
 try:
@@ -5,7 +7,11 @@ try:
 except (ImportError, RuntimeError) as exc:  # pragma: no cover - no Metal host
     pytest.skip(f"MLX device unavailable: {exc}", allow_module_level=True)
 
-from mlx_audio.tts.models.breeze_tts.breeze_tts import Model, _t5gemma2_attention_mask
+from mlx_audio.tts.models.breeze_tts.breeze_tts import (
+    Model,
+    _split_long_segment,
+    _t5gemma2_attention_mask,
+)
 from mlx_audio.tts.models.breeze_tts.config import ModelConfig
 from mlx_audio.tts.utils import get_model_and_args
 from mlx_audio.utils import get_model_name_parts
@@ -434,3 +440,45 @@ def test_breeze_generate_splits_segments(monkeypatch):
     assert not results[0].is_final_chunk
     assert results[1].segment_idx == 1
     assert results[1].is_final_chunk
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "a" * 1201,
+        "word " * 300,
+        "这是第一句。这是第二句！这是第三句？" * 50,
+    ],
+)
+def test_breeze_long_segments_are_bounded(text):
+    chunks = _split_long_segment(text)
+
+    assert len(chunks) > 1
+    assert all(chunk for chunk in chunks)
+    assert all(len(chunk) <= 600 for chunk in chunks)
+
+
+def test_breeze_generate_preserves_existing_positional_arguments():
+    signature = inspect.signature(Model.generate)
+    bound = signature.bind(
+        None,
+        "text",
+        "voice",
+        "instruction",
+        "reference.wav",
+        "reference text",
+        2.0,
+        321,
+        0.4,
+        0.8,
+        7,
+        1.2,
+        123,
+        True,
+        0.5,
+    )
+
+    assert bound.arguments["max_tokens"] == 321
+    assert bound.arguments["temperature"] == 0.4
+    assert bound.arguments["streaming_interval"] == 0.5
+    assert "split_pattern" not in bound.arguments

--- a/mlx_audio/tts/tests/test_breeze_tts.py
+++ b/mlx_audio/tts/tests/test_breeze_tts.py
@@ -380,3 +380,57 @@ def test_breeze_registry_loads_model_module():
     )
     assert model_type == "breeze_tts"
     assert module.Model is Model
+
+
+def test_breeze_generate_splits_segments(monkeypatch):
+    model = Model(tiny_config())
+
+    class Decoder:
+        decode_upsample_rate = 24000
+
+        def reset_streaming_state(self):
+            pass
+
+    class AudioTokenizer:
+        decode_upsample_rate = 24000
+        decoder = Decoder()
+
+        def decode(self, codes):
+            return mx.zeros((1, 4)), mx.array([4], dtype=mx.int32)
+
+    class Backbone:
+        def make_cache(self):
+            return []
+
+        def __call__(self, input_embeddings=None, input_ids=None, cache=None):
+            del cache
+            length = (
+                input_embeddings.shape[1]
+                if input_embeddings is not None
+                else input_ids.shape[1]
+            )
+            return mx.zeros((1, length, 16))
+
+    class Head:
+        def __call__(self, _hidden):
+            logits = mx.full((1, 9), -100.0)
+            logits[..., 8] = 100.0
+            return logits
+
+    model.audio_tokenizer = AudioTokenizer()
+    model.backbone_model = Backbone()
+    model.lm_head = Head()
+    prompt_calls = []
+    monkeypatch.setattr(
+        model,
+        "_prompt_embeddings",
+        lambda text, *args, **kwargs: prompt_calls.append(text) or mx.zeros((1, 1, 16)),
+    )
+
+    results = list(model.generate("Segment 1\n\nSegment 2", temperature=0, top_k=0))
+    assert len(results) == 2
+    assert prompt_calls == ["Segment 1", "Segment 2"]
+    assert results[0].segment_idx == 0
+    assert not results[0].is_final_chunk
+    assert results[1].segment_idx == 1
+    assert results[1].is_final_chunk


### PR DESCRIPTION
## Context
This is a followup to PR #911 with docs corrections I missed and proper segment splitting and `join_audio` functionality for long generations.

## Description
**There is no text segmentation in Breeze-TTS:**  
Unlike models like [qwen3_tts.py:1268-1277](https://github.com/SharkyRawr/mlx-audio/blob/main/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py#L1268-L1277) or Kokoro, which split input text on `\n` into separate segments and then concatenate the audio (`join_audio=True`), Breeze-TTS feeds the entire prompt text into the model at once and generates everything in a single pass. This manifested as truncated audio in my own project, as I was using a low `max_tokens=512` limit.

## Changes in the codebase
  - Long segments are now guaranteed ≤600 characters, with sentence-aware grouping, CJK punctuation support, and hard fallback splitting.
  - Added regression coverage for punctuation-free, whitespace-delimited, and Chinese text, plus signature binding.
  - `mlx_audio/tts/models/breeze_tts/README.md` now uses the mlx-community namespaced models rather than my own personal upload.

## Changes outside the codebase
None

## Additional information
AI was used in an assistive manner and all code was reviewed and tested by me. My sleep deprived brain might make more mistakes than AI at this point tbh.