### PR TITLE
docs: add VoxCPM2 model guide

### DIFF
--- a/docs/models/tts/index.md
+++ b/docs/models/tts/index.md
@@ -27,7 +27,7 @@ MLX-Audio supports a wide range of TTS models optimized for Apple Silicon. Each 
 | [Echo TTS](https://github.com/Blaizzy/mlx-audio/tree/main/mlx_audio/tts/models/echo_tts/README.md) | -- | EN | Yes | -- | Diffusion-based, fast voice cloning |
 | [Irodori TTS](https://github.com/Blaizzy/mlx-audio/tree/main/mlx_audio/tts/models/irodori_tts/README.md) | 500M | JA | Yes | -- | Japanese-only, DiT + DACVAE |
 | [Fish Speech](https://github.com/Blaizzy/mlx-audio/tree/main/mlx_audio/tts/models/fish_qwen3_omni/README.md) | -- | EN | Yes | -- | Inline control tags, multi-speaker, long-form batching |
-| [VoxCPM2](https://github.com/Blaizzy/mlx-audio/tree/main/mlx_audio/tts/models/voxcpm2/README.md) | 2B | 30 languages | Yes | -- | 48kHz, voice design, voice cloning, continuation |
+| [**VoxCPM2**](voxcpm2.md) | 2B | 30 languages | Yes | -- | 48kHz, voice design, voice cloning, continuation |
 
 ## Quick Start
 
@@ -55,7 +55,7 @@ All TTS models share a common interface:
 
 !!! tip "Choosing a model"
     - **Fastest / smallest:** Kokoro (82M) -- great for quick generation with many voice presets.
-    - **Voice cloning:** CSM, Qwen3-TTS, Higgs Audio v3, or OmniVoice -- clone a voice from reference speech.
-    - **Multilingual:** Voxtral TTS (9 languages, 20 voices) or Chatterbox (23 languages).
+    - **Voice cloning:** CSM, Qwen3-TTS, Higgs Audio v3, OmniVoice, or VoxCPM2 -- clone a voice from reference speech.
+    - **Multilingual:** VoxCPM2 (30 languages), Voxtral TTS (9 languages, 20 voices), or Chatterbox (23 languages).
     - **Dialogue:** Dia -- built-in support for multi-speaker conversations.
-    - **Emotion / style control:** Qwen3-TTS CustomVoice or VoiceDesign variants.
+    - **Emotion / style control:** Qwen3-TTS CustomVoice and VoiceDesign variants, or VoxCPM2 voice design.

--- a/docs/models/tts/voxcpm2.md
+++ b/docs/models/tts/voxcpm2.md
@@ -1,0 +1,141 @@
+# VoxCPM2
+
+[VoxCPM2](https://huggingface.co/openbmb/VoxCPM2) is OpenBMB's 2B-parameter,
+multilingual tokenizer-free text-to-speech model. The MLX implementation produces
+48 kHz audio and supports standard synthesis, voice design from a text description,
+voice cloning from reference audio, and speech continuation.
+
+## Model Variants
+
+| Model | Format | Size | HuggingFace |
+|-------|--------|------|-------------|
+| `mlx-community/VoxCPM2-bf16` | bfloat16 | 4.96 GB | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/VoxCPM2-bf16) |
+| `mlx-community/VoxCPM2-8bit` | 8-bit | 3.23 GB | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/VoxCPM2-8bit) |
+| `mlx-community/VoxCPM2-4bit` | 4-bit | 2.30 GB | [:octicons-link-external-16: Model Card](https://huggingface.co/mlx-community/VoxCPM2-4bit) |
+
+## Quick Start
+
+=== "CLI"
+
+    ```bash
+    mlx_audio.tts.generate \
+        --model mlx-community/VoxCPM2-8bit \
+        --text "Hello, this is VoxCPM2 running on Apple Silicon." \
+        --output_path outputs
+    ```
+
+=== "Python"
+
+    ```python
+    from mlx_audio.tts import load
+
+    model = load("mlx-community/VoxCPM2-8bit")
+
+    result = next(
+        model.generate("Hello, this is VoxCPM2 running on Apple Silicon.")
+    )
+    audio = result.audio  # 48 kHz mono waveform as an MLX array
+    ```
+
+## Voice Design
+
+Describe the desired speaker and delivery with `instruct`; no reference audio is
+required.
+
+=== "CLI"
+
+    ```bash
+    mlx_audio.tts.generate \
+        --model mlx-community/VoxCPM2-8bit \
+        --text "Welcome. I hope you enjoy the presentation." \
+        --instruct "A warm, confident young woman speaking at a relaxed pace" \
+        --output_path outputs
+    ```
+
+=== "Python"
+
+    ```python
+    result = next(
+        model.generate(
+            text="Welcome. I hope you enjoy the presentation.",
+            instruct="A warm, confident young woman speaking at a relaxed pace",
+        )
+    )
+    ```
+
+## Voice Cloning
+
+Pass a clean reference recording to synthesize the target text in the reference
+speaker's voice.
+
+=== "CLI"
+
+    ```bash
+    mlx_audio.tts.generate \
+        --model mlx-community/VoxCPM2-8bit \
+        --text "This sentence uses the voice from the reference recording." \
+        --ref_audio speaker.wav \
+        --ref_text "The exact transcript of speaker.wav." \
+        --output_path outputs
+    ```
+
+=== "Python"
+
+    ```python
+    result = next(
+        model.generate(
+            text="This sentence uses the voice from the reference recording.",
+            ref_audio="speaker.wav",
+        )
+    )
+    ```
+
+`ref_text` is part of the common MLX-Audio CLI voice-cloning interface. Supplying
+it prevents the CLI from running automatic reference-audio transcription;
+VoxCPM2 conditions directly on the reference audio.
+
+## Speech Continuation
+
+For long-form generation, provide an earlier audio clip and its transcript. The
+new text should begin where `prompt_text` ends.
+
+```python
+result = next(
+    model.generate(
+        text=" The story continues from here.",
+        prompt_text="This is the opening of the story.",
+        prompt_audio="opening.wav",
+    )
+)
+```
+
+Continuation is currently available through the Python API. Reference voice
+cloning can be combined with continuation by also passing `ref_audio`.
+
+## Generation Settings
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `inference_timesteps` | `10` | Diffusion steps; higher values trade speed for quality |
+| `cfg_value` | `2.0` | Classifier-free guidance strength |
+| `instruct` | `None` | Natural-language voice description for voice design |
+| `ref_audio` | `None` | Reference audio path or waveform for voice cloning |
+| `prompt_text` | `None` | Transcript of `prompt_audio` for continuation |
+| `prompt_audio` | `None` | Previous audio clip used as continuation context |
+| `warmup_patches` | `0` | Extra conditioning patches excluded from the output |
+| `max_tokens` | `2000` | Maximum number of audio patches to generate |
+
+The CLI exposes `--ddpm_steps` as an alias for `inference_timesteps` and
+`--cfg_scale` as an alias for `cfg_value`. VoxCPM2 enforces a minimum guidance
+value of `2.0`.
+
+## License
+
+VoxCPM2 is released under the
+[Apache License 2.0](https://github.com/OpenBMB/VoxCPM/blob/main/LICENSE).
+
+## Links
+
+- [:octicons-mark-github-16: Source code](https://github.com/Blaizzy/mlx-audio/tree/main/mlx_audio/tts/models/voxcpm2)
+- [:octicons-mark-github-16: In-repo README](https://github.com/Blaizzy/mlx-audio/blob/main/mlx_audio/tts/models/voxcpm2/README.md)
+- [:octicons-link-external-16: Original model](https://huggingface.co/openbmb/VoxCPM2)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Higgs Audio v3: models/tts/higgs_audio_v3.md
       - MOSS-TTS: models/tts/moss-tts.md
       - Voxtral TTS: models/tts/voxtral-tts.md
+      - VoxCPM2: models/tts/voxcpm2.md
       - Svara TTS: models/tts/svara.md
       - KugelAudio: models/tts/kugelaudio.md
       - CSM: models/tts/csm.md


### PR DESCRIPTION
## Context
VoxCPM2 support was introduced in #641 and added to the top-level supported-model tables in #942. The documentation site still links to the implementation README instead of providing a first-class model guide.

## Description
Add a dedicated VoxCPM2 page to the documentation site with usage guidance for synthesis, voice design, voice cloning, and speech continuation.

## Changes in the codebase
- Add a VoxCPM2 model guide with checkpoint variants and CLI/Python examples.
- Document generation settings, output sample rate, and licensing.
- Link the TTS model catalog to the new internal page.
- Add VoxCPM2 to the MkDocs navigation.
- Include VoxCPM2 in the model-selection recommendations.

## Changes outside the codebase
None.

## Additional information
Validation:
- uv run --extra docs mkdocs build --strict
- git diff --check
- Confirmed every external link added by this change returns HTTP 200

## Checklist
- [x] Tests not required (documentation-only change)
- [x] Documentation updated
- [x] Related implementation referenced (#641)