### PR TITLE
fix(tts): prevent cold-start distortion in Qwen voice cloning

### DIFF
--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -2271,7 +2271,8 @@ class Model(nn.Module):
             decoded_tokens = 0
             chunk_start_time = time.time()
             self.speech_tokenizer.decoder.reset_streaming_state()
-            # Match non-streaming decode's reference context without emitting its audio.
+            # Prime the decoder's conv buffers and KV cache with the reference so
+            # generated codes continue the reference utterance. Its audio is discarded.
             mx.eval(self.speech_tokenizer.decoder.streaming_step(ref_codes))
 
         for step in range(effective_max_tokens):

--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -2271,6 +2271,8 @@ class Model(nn.Module):
             decoded_tokens = 0
             chunk_start_time = time.time()
             self.speech_tokenizer.decoder.reset_streaming_state()
+            # Match non-streaming decode's reference context without emitting its audio.
+            mx.eval(self.speech_tokenizer.decoder.streaming_step(ref_codes))
 
         for step in range(effective_max_tokens):
             # Forward pass through talker

--- a/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
+++ b/mlx_audio/tts/models/qwen3_tts/qwen3_tts.py
@@ -2270,10 +2270,9 @@ class Model(nn.Module):
             streaming_chunk_size = max(1, int(streaming_interval * 12.5))
             decoded_tokens = 0
             chunk_start_time = time.time()
-            self.speech_tokenizer.decoder.reset_streaming_state()
-            # Prime the decoder's conv buffers and KV cache with the reference so
-            # generated codes continue the reference utterance. Its audio is discarded.
-            mx.eval(self.speech_tokenizer.decoder.streaming_step(ref_codes))
+            # Generated codes continue the reference utterance, so the decoder
+            # starts with the reference's context rather than empty state.
+            self.speech_tokenizer.decoder.prime_streaming_state(ref_codes)
 
         for step in range(effective_max_tokens):
             # Forward pass through talker

--- a/mlx_audio/tts/models/qwen3_tts/speech_tokenizer.py
+++ b/mlx_audio/tts/models/qwen3_tts/speech_tokenizer.py
@@ -886,6 +886,20 @@ class Qwen3TTSSpeechTokenizerDecoder(nn.Module):
             if hasattr(m, "reset_state"):
                 m.reset_state()
 
+    def prime_streaming_state(self, context_codes: mx.array) -> None:
+        """Start a stream that continues ``context_codes`` without emitting their audio.
+
+        Only the last ``sliding_window`` codes are decoded. That is the span the
+        pre-transformer attends over, and the conv buffers need far less, so a
+        longer context only adds latency before the first emitted chunk.
+
+        Args:
+            context_codes: [batch, num_quantizers, time] codes the stream continues
+        """
+        self.reset_streaming_state()
+        window = self.config.sliding_window
+        mx.eval(self.streaming_step(context_codes[:, :, -window:]))
+
     def streaming_step(self, codes: mx.array) -> mx.array:
         """Incrementally decode new codes using conv buffers and transformer KV cache.
 

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -3394,7 +3394,10 @@ class TestQwen3TTSGenerateICL(unittest.TestCase):
             )
 
         self.assertEqual(len(results), 51)
-        self.assertEqual(model.speech_tokenizer.decoder.streaming_step.call_count, 52)
+        # 51 emitted chunks plus one reference-priming call after reset.
+        self.assertEqual(
+            model.speech_tokenizer.decoder.streaming_step.call_count, 51 + 1
+        )
         mock_clear_cache.assert_called_once_with()
 
     def test_generate_icl_repetition_penalty_applied(self):

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -3394,7 +3394,7 @@ class TestQwen3TTSGenerateICL(unittest.TestCase):
             )
 
         self.assertEqual(len(results), 51)
-        self.assertEqual(model.speech_tokenizer.decoder.streaming_step.call_count, 51)
+        self.assertEqual(model.speech_tokenizer.decoder.streaming_step.call_count, 52)
         mock_clear_cache.assert_called_once_with()
 
     def test_generate_icl_repetition_penalty_applied(self):

--- a/mlx_audio/tts/tests/test_models.py
+++ b/mlx_audio/tts/tests/test_models.py
@@ -3394,10 +3394,7 @@ class TestQwen3TTSGenerateICL(unittest.TestCase):
             )
 
         self.assertEqual(len(results), 51)
-        # 51 emitted chunks plus one reference-priming call after reset.
-        self.assertEqual(
-            model.speech_tokenizer.decoder.streaming_step.call_count, 51 + 1
-        )
+        self.assertEqual(model.speech_tokenizer.decoder.streaming_step.call_count, 51)
         mock_clear_cache.assert_called_once_with()
 
     def test_generate_icl_repetition_penalty_applied(self):

--- a/mlx_audio/tts/tests/test_qwen3_tts.py
+++ b/mlx_audio/tts/tests/test_qwen3_tts.py
@@ -512,7 +512,11 @@ def _make_generation_test_model(text_token_count: int = 10):
 
 
 class _ContextStreamingDecoder:
-    """Decode each code with its predecessor to expose missing reference context."""
+    """Decode each code as ``code + previous code`` to expose missing reference context.
+
+    After a reset, ``previous`` is -10, a value no real code can produce, so the
+    first output is -9 if the reference was never fed through the decoder.
+    """
 
     def reset_streaming_state(self):
         self.previous = mx.array([[[-10]]], dtype=mx.int32)
@@ -529,6 +533,10 @@ class TestQwen3TTSICLStreamingContext(unittest.TestCase):
         model.speech_tokenizer.has_encoder = True
         model.speech_tokenizer.decoder = _ContextStreamingDecoder()
 
+        # The fake ICL inputs carry reference code 0 and the fake sampler returns
+        # code 1 every step, so primed decoding gives [1 + 0, 1 + 1, 1 + 1].
+        # Unprimed, the first sample would be 1 + (-10) = -9.
+        # streaming_interval=0.16 is int(0.16 * 12.5) = 2 codes per chunk.
         # Repeat on the same model to exercise reset between utterances.
         for _ in range(2):
             with self.subTest():

--- a/mlx_audio/tts/tests/test_qwen3_tts.py
+++ b/mlx_audio/tts/tests/test_qwen3_tts.py
@@ -511,6 +511,45 @@ def _make_generation_test_model(text_token_count: int = 10):
     return model
 
 
+class _ContextStreamingDecoder:
+    """Decode each code with its predecessor to expose missing reference context."""
+
+    def reset_streaming_state(self):
+        self.previous = mx.array([[[-10]]], dtype=mx.int32)
+
+    def streaming_step(self, codes):
+        previous = mx.concatenate([self.previous, codes[:, :, :-1]], axis=2)
+        self.previous = codes[:, :, -1:]
+        return (codes + previous).astype(mx.float32)
+
+
+class TestQwen3TTSICLStreamingContext(unittest.TestCase):
+    def test_reference_conditions_audio_without_being_emitted(self):
+        model = _make_generation_test_model()
+        model.speech_tokenizer.has_encoder = True
+        model.speech_tokenizer.decoder = _ContextStreamingDecoder()
+
+        # Repeat on the same model to exercise reset between utterances.
+        for _ in range(2):
+            with self.subTest():
+                results = list(
+                    model.generate(
+                        text="Hello",
+                        ref_audio=mx.zeros((2400,), dtype=mx.float32),
+                        ref_text="Reference",
+                        stream=True,
+                        streaming_interval=0.16,
+                        max_tokens=3,
+                    )
+                )
+
+                audio = np.concatenate([np.array(result.audio) for result in results])
+                np.testing.assert_array_equal(audio, [1.0, 2.0, 2.0])
+                self.assertEqual([result.token_count for result in results], [2, 1])
+                self.assertEqual([result.samples for result in results], [2, 1])
+                self.assertTrue(results[-1].is_final_chunk)
+
+
 class TestQwen3TTSSamplingFilters(unittest.TestCase):
     def test_sample_token_scales_before_top_p_filtering(self):
         logits = mx.array([[[3.0, 2.0, 1.0, 0.0]]], dtype=mx.float32)

--- a/mlx_audio/tts/tests/test_qwen3_tts.py
+++ b/mlx_audio/tts/tests/test_qwen3_tts.py
@@ -7,10 +7,14 @@ from unittest.mock import patch
 import mlx.core as mx
 import numpy as np
 
+from mlx_audio.tts.models.qwen3_tts.config import Qwen3TTSTokenizerDecoderConfig
 from mlx_audio.tts.models.qwen3_tts.qwen3_tts import Model, mel_spectrogram
 from mlx_audio.tts.models.qwen3_tts.speaker_encoder import (
     TimeDelayNetBlock,
     reflect_pad_1d,
+)
+from mlx_audio.tts.models.qwen3_tts.speech_tokenizer import (
+    Qwen3TTSSpeechTokenizerDecoder,
 )
 
 
@@ -521,6 +525,10 @@ class _ContextStreamingDecoder:
     def reset_streaming_state(self):
         self.previous = mx.array([[[-10]]], dtype=mx.int32)
 
+    def prime_streaming_state(self, context_codes):
+        self.reset_streaming_state()
+        self.streaming_step(context_codes)
+
     def streaming_step(self, codes):
         previous = mx.concatenate([self.previous, codes[:, :, :-1]], axis=2)
         self.previous = codes[:, :, -1:]
@@ -556,6 +564,36 @@ class TestQwen3TTSICLStreamingContext(unittest.TestCase):
                 self.assertEqual([result.token_count for result in results], [2, 1])
                 self.assertEqual([result.samples for result in results], [2, 1])
                 self.assertTrue(results[-1].is_final_chunk)
+
+
+class TestQwen3TTSDecoderPriming(unittest.TestCase):
+    def test_prime_decodes_only_the_sliding_window(self):
+        config = Qwen3TTSTokenizerDecoderConfig(
+            latent_dim=8,
+            codebook_dim=8,
+            codebook_size=4,
+            decoder_dim=64,
+            hidden_size=8,
+            intermediate_size=8,
+            head_dim=8,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            num_hidden_layers=1,
+            num_quantizers=2,
+            num_semantic_quantizers=1,
+            semantic_codebook_size=4,
+            sliding_window=3,
+            upsample_rates=[2, 2, 2, 2],
+        )
+        decoder = Qwen3TTSSpeechTokenizerDecoder(config)
+        codes = mx.zeros((1, config.num_quantizers, 10), dtype=mx.int32)
+
+        for _ in range(2):
+            decoder.prime_streaming_state(codes)
+            self.assertEqual(decoder._transformer_cache[0].offset, 3)
+
+        decoder.prime_streaming_state(codes[:, :, :2])
+        self.assertEqual(decoder._transformer_cache[0].offset, 2)
 
 
 class TestQwen3TTSSamplingFilters(unittest.TestCase):


### PR DESCRIPTION
## Context

Qwen3-TTS ICL streaming decode starts with empty convolution buffers and transformer KV cache, even though generated codes continue the reference utterance. This can distort the start of speech. Non-streaming decode already prepends the reference codes and removes their audio afterwards.

Related cold-start report: https://github.com/QwenLM/Qwen3-TTS/issues/219. That report concerns CustomVoice and silence-code padding; this change addresses ICL, where reference codes already exist.

A downstream byte-level comparison found that application output and raw mlx-audio streaming output were identical at the head and tail under the same seed, including with the application's audio cleanup disabled. Priming the streaming decoder with reference codes removed the observed onset burst without changing chunk sizes or durations. This is not a claim that streaming and non-streaming output are byte-identical.

## Description

Immediately after resetting the ICL streaming decoder, decode the tail of `ref_codes` and discard the audio, so the decoder starts with the reference's context. This lives in a new `Qwen3TTSSpeechTokenizerDecoder.prime_streaming_state`, which resets and then runs one `streaming_step` over the last `sliding_window` codes. The pre-transformer's attention is configured for that span and the conv buffers need far less, so a longer context only delays the first emitted chunk. Generated chunks keep their existing token and sample accounting.

## Changes in the codebase

- Add `prime_streaming_state` to the speech tokenizer decoder and call it from the ICL streaming branch.
- Add a `Model.generate` regression checking reference-conditioned output, exclusion of reference audio, chunk accounting, the final partial chunk, and repeated utterances.
- Add a small-decoder test that priming decodes only the last `sliding_window` codes and works when the context is shorter than the window.

## Changes outside the codebase

None.

## Additional information

- The new regression failed before the fix and passes after it.
- Latency, measured on the 0.6B model with a 7.6 s reference (95 codes) and `streaming_interval=2.0` at `temperature=0`, so token sampling was identical across runs and only the decoder state differed:

  | Priming | Time to first chunk | Correlation with full priming, first 2 s |
  | --- | --- | --- |
  | none (before this PR) | 791 ms | 0.87 |
  | last 25 codes | 935 ms | 0.93 |
  | last 72 codes (`sliding_window`, this PR) | 1243 ms | 0.98 |
  | whole reference | 1609 ms | 1.00 |

  The window bound keeps the priming cost constant for long references while staying within 2 % of full priming. The added latency is one vocoder pass over 72 codes.
- The batch session (`qwen3_tts.py`, the ICL streaming path that decodes the first chunk through `chunked_decode` with `context_tokens = 0`) has the analogous cold start. It uses stateless left-context re-decode rather than `streaming_step`, so it is a separate change and out of scope here.
- Focused Qwen3-TTS selection: **86 passed**.
- Black 26.3.1 and isort 5.13.2 checks pass for all four changed files. No static typechecker is configured upstream.
- Full suite at the first two commits: **1518 passed, 32 failed, 44 skipped, 13 errors**. All 32 failing cases and 13 error cases reproduce on unchanged upstream commit `41537ec5cf79bcf731a0dd6749cac12ab554a691` in the same local environment. Hugging Face offline mode was enabled. This is not a clean-room CI pass.
- After the priming bound, `mlx_audio/tts/tests` in a second environment: **673 passed, 15 failed, 10 skipped**, and the same 15 fail on that upstream commit there. That environment cannot collect the `sts` tests (no `sentencepiece`), so the full suite was not re-run after the bound.
- Independent local Standards and Spec reviews found no issues.

## Checklist
- [x] Tests added/updated
- [x] Behavior and validation documented above
- [x] Related issue referenced

Authored with OpenAI Codex (GPT-6); the priming bound and its measurements with Claude Code (Claude Fable 5.1).

