### PR TITLE
fix(tests): enlarge test_clipping buffer past ffmpeg FLAC min block size

### DIFF
--- a/mlx_audio/tests/test_audio_io.py
+++ b/mlx_audio/tests/test_audio_io.py
@@ -330,7 +330,7 @@ class TestAudioIOEdgeCases:
         """Test that values outside [-1, 1] are clipped."""
         samplerate = 16000
         # Create data with values outside [-1, 1]
-        data = np.array([1.5, -1.5, 0.5, -0.5], dtype=np.float32)
+        data = np.tile([1.5, -1.5, 0.5, -0.5], 1024).astype(np.float32)
 
         output_file = tmp_path / "test_clipped.ogg"
         write(output_file, data, samplerate, format="ogg")


### PR DESCRIPTION
Tiles `test_clipping`'s 4-sample buffer up to ~4096 samples so ffmpeg 9's FLAC encoder no longer rejects it with "invalid block size: 4", unblocking the core CI job in #954